### PR TITLE
Optimise the allocation of optional arguments

### DIFF
--- a/testsuite/tests/typing-local/alloc.ml
+++ b/testsuite/tests/typing-local/alloc.ml
@@ -395,6 +395,14 @@ let makeverylong n =
   ignore_local (local_array 100_000 n);
   ()
 
+let fun_with_optional_arg ?(local_ foo = 5) () =
+  let _ = foo + 5 in
+  ()
+
+let optionalarg ((f : ?foo:local_ int -> unit -> unit), n) =
+  let () = f ~foo:n () in
+  ()
+
 let run name f x =
   let prebefore = Gc.allocated_bytes () in
   let before = Gc.allocated_bytes () in
@@ -446,7 +454,8 @@ let () =
   run "stringbint" readstringbint ();
   run "bigstringbint" readbigstringbint ();
   run "verylong" makeverylong 42;
-  run "manylong" makemanylong 100
+  run "manylong" makemanylong 100;
+  run "optionalarg" optionalarg (fun_with_optional_arg, 10)
 
 
 (* In debug mode, Gc.minor () checks for minor heap->local pointers *)

--- a/testsuite/tests/typing-local/alloc.reference
+++ b/testsuite/tests/typing-local/alloc.reference
@@ -31,3 +31,4 @@
   bigstringbint: OK
        verylong: OK
        manylong: OK
+    optionalarg: OK

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -362,9 +362,12 @@ let register_allocation_mode alloc_mode =
   | Amode _const -> ()
   | Amodevar _ -> allocations := alloc_mode :: !allocations
 
-let register_allocation (expected_mode : expected_mode) =
+let register_allocation_value_mode mode =
   register_allocation_mode
-    (Value_mode.regional_to_global_alloc expected_mode.mode)
+    (Value_mode.regional_to_global_alloc mode)
+
+let register_allocation (expected_mode : expected_mode) =
+  register_allocation_value_mode expected_mode.mode
 
 let optimise_allocations () =
   if Clflags.Extension.is_enabled Local then begin
@@ -433,6 +436,7 @@ let option_none env ty mode loc =
   mkexp (Texp_construct(mknoloc lid, cnone, [])) ty mode loc env
 
 let option_some env texp mode =
+  register_allocation_value_mode mode;
   let lid = Longident.Lident "Some" in
   let csome = Env.find_ident_constructor Predef.ident_some env in
   mkexp ( Texp_construct(mknoloc lid , csome, [texp]) )


### PR DESCRIPTION
A missing call to `register_allocation` meant that we were not optimising the allocation of optional arguments.