### PR TITLE
Allow warning 68 to be controlled by attributes

### DIFF
--- a/testsuite/tests/warnings/w68.compilers.reference
+++ b/testsuite/tests/warnings/w68.compilers.reference
@@ -9,3 +9,8 @@ File "w68.ml", line 14, characters 10-13:
                ^^^
 Warning 68 [match-on-mutable-state-prevent-uncurry]: This pattern depends on mutable state.
 It prevents the remaining arguments from being uncurried, which will cause additional closure allocations.
+File "w68.ml", line 39, characters 25-28:
+39 | let do_warn_when_enabled {a} b = a + b
+                              ^^^
+Warning 68 [match-on-mutable-state-prevent-uncurry]: This pattern depends on mutable state.
+It prevents the remaining arguments from being uncurried, which will cause additional closure allocations.

--- a/testsuite/tests/warnings/w68.ml
+++ b/testsuite/tests/warnings/w68.ml
@@ -32,3 +32,10 @@ let () =
 
 
 let dont_warn_with_partial_match None x = x
+
+let dont_warn_when_disabled {a} b = a + b
+[@@warning "-68"]
+
+let do_warn_when_enabled {a} b = a + b
+[@@warning "+68"]
+

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -260,9 +260,9 @@ let expr sub x =
     | Texp_let (rec_flag, list, exp) ->
         let (rec_flag, list) = sub.value_bindings sub (rec_flag, list) in
         Texp_let (rec_flag, list, sub.expr sub exp)
-    | Texp_function { arg_label; param; cases; partial; region; } ->
+    | Texp_function { arg_label; param; cases; partial; region; warnings } ->
         let cases = List.map (sub.case sub) cases in
-        Texp_function { arg_label; param; cases; partial; region; }
+        Texp_function { arg_label; param; cases; partial; region; warnings }
     | Texp_apply (exp, list, pos) ->
         Texp_apply (
           sub.expr sub exp,
@@ -389,13 +389,14 @@ let expr sub x =
         Texp_object (sub.class_structure sub cl, sl)
     | Texp_pack mexpr ->
         Texp_pack (sub.module_expr sub mexpr)
-    | Texp_letop {let_; ands; param; body; partial} ->
+    | Texp_letop {let_; ands; param; body; partial; warnings} ->
         Texp_letop{
           let_ = sub.binding_op sub let_;
           ands = List.map (sub.binding_op sub) ands;
           param;
           body = sub.case sub body;
           partial;
+          warnings
         }
     | Texp_unreachable ->
         Texp_unreachable

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4585,8 +4585,9 @@ and type_expect_
           bop_exp = exp;
           bop_loc = slet.pbop_loc; }
       in
+      let warnings = Warnings.backup () in
       let desc =
-        Texp_letop{let_; ands; param; body; partial}
+        Texp_letop{let_; ands; param; body; partial; warnings}
       in
       rue { exp_desc = desc;
             exp_loc = sexp.pexp_loc;
@@ -4851,10 +4852,11 @@ and type_function ?in_function loc attrs env (expected_mode : expected_mode)
       Warnings.Unerasable_optional_argument;
   let param = name_cases "param" cases in
   let region = region_locked && not uncurried_function in
+  let warnings = Warnings.backup () in
   re {
     exp_desc =
       Texp_function
-        { arg_label = l; param; cases; partial; region };
+        { arg_label = l; param; cases; partial; region; warnings };
     exp_loc = loc; exp_extra = [];
     exp_type =
       instance (newgenty (Tarrow((l,arg_mode,ret_mode), ty_arg, ty_res, Cok)));
@@ -5291,7 +5293,8 @@ and type_argument ?explanation ?recarg env (mode : expected_mode) sarg
         let param = name_cases "param" cases in
         { texp with exp_type = ty_fun; exp_mode = mode.mode;
             exp_desc = Texp_function { arg_label = Nolabel; param; cases;
-                                       partial = Total; region = false } }
+                                       partial = Total; region = false;
+                                       warnings = Warnings.backup () } }
       in
       Location.prerr_warning texp.exp_loc
         (Warnings.Eliminated_optional_arguments

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -103,7 +103,8 @@ and expression_desc =
   | Texp_constant of constant
   | Texp_let of rec_flag * value_binding list * expression
   | Texp_function of { arg_label : arg_label; param : Ident.t;
-      cases : value case list; partial : partial; region : bool; }
+      cases : value case list; partial : partial;
+      region : bool; warnings : Warnings.state; }
   | Texp_apply of expression * (arg_label * apply_arg) list * apply_position
   | Texp_match of expression * computation case list * partial
   | Texp_try of expression * value case list
@@ -150,6 +151,7 @@ and expression_desc =
       param : Ident.t;
       body : value case;
       partial : partial;
+      warnings : Warnings.state;
     }
   | Texp_unreachable
   | Texp_extension_constructor of Longident.t loc * Path.t

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -181,7 +181,8 @@ and expression_desc =
             let rec P1 = E1 and ... and Pn = EN in E   (flag = Recursive)
          *)
   | Texp_function of { arg_label : arg_label; param : Ident.t;
-      cases : value case list; partial : partial; region : bool }
+      cases : value case list; partial : partial;
+      region : bool; warnings : Warnings.state; }
         (** [Pexp_fun] and [Pexp_function] both translate to [Texp_function].
             See {!Parsetree} for more details.
 
@@ -190,6 +191,8 @@ and expression_desc =
 
             partial =
               [Partial] if the pattern match is partial
+              [Total_w68_error] otherwise if warning 68 is enabled as an error
+              [Total_w68_active] otherwise if warning 68 is enabled
               [Total] otherwise.
          *)
   | Texp_apply of expression * (arg_label * apply_arg) list * apply_position
@@ -278,6 +281,7 @@ and expression_desc =
       param : Ident.t;
       body : value case;
       partial : partial;
+      warnings : Warnings.state;
     }
   | Texp_unreachable
   | Texp_extension_constructor of Longident.t loc * Path.t

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -191,8 +191,6 @@ and expression_desc =
 
             partial =
               [Partial] if the pattern match is partial
-              [Total_w68_error] otherwise if warning 68 is enabled as an error
-              [Total_w68_active] otherwise if warning 68 is enabled
               [Total] otherwise.
          *)
   | Texp_apply of expression * (arg_label * apply_arg) list * apply_position


### PR DESCRIPTION
Remembers whether warning 68 was enabled when we type a function so that the warning can be controlled by `[@warning]` attributes. I stored the information as part of the existing `partial` information, which is related, so keeping the data won't take any extra space in e.g. cmt files.