### PR TITLE
Enable the local keywords even when the local extension is off

### DIFF
--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -103,9 +103,6 @@ let keyword_table =
 
 let lookup_keyword name =
   match Hashtbl.find keyword_table name with
-  | LOCAL | NONLOCAL | GLOBAL
-       when not (Clflags.Extension.is_enabled Local) ->
-     LIDENT name
   | kw -> kw
   | exception Not_found ->
      LIDENT name

--- a/testsuite/tests/typing-local/nosyntax.ml
+++ b/testsuite/tests/typing-local/nosyntax.ml
@@ -7,11 +7,11 @@ type lfn' = local_ string -> int
 [%%expect{|
 type fn = string -> int
 type lfn = (string [@ocaml.local]) -> int
-Line 3, characters 12-25:
+Line 3, characters 19-25:
 3 | type lfn' = local_ string -> int
-                ^^^^^^^^^^^^^
-Error: The type constructor string expects 0 argument(s),
-       but is here applied to 1 argument(s)
+                       ^^^^^^
+Error: The local extension is disabled
+       To enable it, pass the '-extension local' flag
 |}]
 
 let cast (x : fn) = (x : lfn)


### PR DESCRIPTION
Avoid having different configurations of lexing and parsing by always enabling the local syntax. Using the syntax when the local extension is disabled will still get an error, but from the type-checker.