### PR TITLE
Better error message on nonsense code

### DIFF
--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -77,6 +77,18 @@ Error: This local value escapes its region
   Hint: Cannot return local value without an explicit "local_" annotation
 |}]
 
+(* If both type and mode are wrong, complain about type *)
+let f () =
+  let local_ r = ref 42 in
+  print_endline r
+[%%expect{|
+Line 3, characters 16-17:
+3 |   print_endline r
+                    ^
+Error: This expression has type int ref
+       but an expression was expected of type string
+|}]
+
 (*
  * Type equalities of function types
  *)


### PR DESCRIPTION
This patch changes the typing of identifiers to check their type before their mode, because in a really nonsensical application the type error is more informative than the mode error. For instance `print_string (local_ ref 42)` now complains that an `int ref` is not a string, instead of giving an escape error.