### PR TITLE
Add subtyping between arrows of related modes

### DIFF
--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -715,7 +715,7 @@ Error: Multiple definition of the type name t.
 
 fun x -> (x :> < m : 'a -> 'a > as 'a);;
 [%%expect{|
-- : < m : (< m : 'a > as 'b) -> 'b as 'a; .. > -> 'b = <fun>
+- : < m : (< m : 'a -> 'a > as 'a) -> 'a; .. > -> 'a = <fun>
 |}];;
 
 fun x -> (x : int -> bool :> 'a -> 'a);;

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -1075,11 +1075,18 @@ module Alloc_mode = struct
   let newvar () = Amodevar (fresh ())
 
   let newvar_below = function
-    | Amode Global -> Amode Global
+    | Amode Global -> Amode Global, false
     | m ->
        let v = newvar () in
        submode_exn v m;
-       v
+       v, true
+
+  let newvar_above = function
+    | Amode Local -> Amode Local, false
+    | m ->
+       let v = newvar () in
+       submode_exn m v;
+       v, true
 
   let check_const = function
     | Amode m -> Some m

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -290,7 +290,9 @@ module Alloc_mode : sig
 
   val newvar : unit -> t
 
-  val newvar_below : t -> t
+  val newvar_below : t -> t * bool
+
+  val newvar_above : t -> t * bool
 
   val check_const : t -> const option
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5287,7 +5287,7 @@ and type_argument ?explanation ?recarg env (mode : expected_mode) sarg
 and type_apply_arg env ~funct ~index ~position ~partial_app (lbl, arg) =
   match arg with
   | Arg (Unknown_arg { sarg; ty_arg; mode_arg }) ->
-      let mode = Alloc_mode.newvar_below mode_arg in
+      let mode, _ = Alloc_mode.newvar_below mode_arg in
       let expected_mode =
         mode_argument ~funct ~index ~position ~partial_app mode in
       let arg = type_expect env expected_mode sarg (mk_expected ty_arg) in
@@ -5295,7 +5295,7 @@ and type_apply_arg env ~funct ~index ~position ~partial_app (lbl, arg) =
         unify_exp env arg (type_option(newvar()));
       (lbl, Arg arg)
   | Arg (Known_arg { sarg; ty_arg; ty_arg0; mode_arg; wrapped_in_some }) ->
-      let mode = Alloc_mode.newvar_below mode_arg in
+      let mode, _ = Alloc_mode.newvar_below mode_arg in
       let expected_mode =
         mode_argument ~funct ~index ~position ~partial_app mode in
       let arg =


### PR DESCRIPTION
Add the obvious subtyping relationship between arrows of related modes, including support in `build_subtype`.