### PR TITLE
Propagate escaping_context to Env locks to hint about errors

### DIFF
--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -1056,6 +1056,17 @@ Error: This local value escapes its region
   Hint: This argument cannot be local, because this is a tail call
 |}]
 
+let local_cb (local_ f) = f ()
+let foo (local_ x) = local_cb (fun () -> x := 17; 42)
+[%%expect{|
+val local_cb : local_ (unit -> 'a) -> 'a = <fun>
+Line 2, characters 41-42:
+2 | let foo (local_ x) = local_cb (fun () -> x := 17; 42)
+                                             ^
+Error: The value x is local, so cannot be used inside a closure that might escape
+Hint: The closure might escape because it is an argument to a tail call
+|}]
+
 let foo x =
   let r = local_ { contents = x } in
   print r;

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -214,8 +214,14 @@ module TycompTbl =
 
 type empty = |
 
+type escaping_context =
+  | Return
+  | Tailcall_argument
+  | Tailcall_function
+  | Partial_application
+
 type value_lock =
-  | Lock of { mode : Value_mode.t; }
+  | Lock of { mode : Value_mode.t; escaping_context : escaping_context option }
   | Region_lock
 
 module IdTbl =
@@ -563,7 +569,7 @@ type lookup_error =
   | Generative_used_as_applicative of Longident.t
   | Illegal_reference_to_recursive_module
   | Cannot_scrape_alias of Longident.t * Path.t
-  | Local_value_used_in_closure of Longident.t
+  | Local_value_used_in_closure of Longident.t * escaping_context option
 
 type error =
   | Missing_module of Location.t * Path.t * Path.t
@@ -2009,8 +2015,9 @@ let enter_cltype ~scope name desc env =
 let enter_module ~scope ?arg s presence mty env =
   enter_module_declaration ~scope ?arg s presence (md mty) env
 
-let add_lock mode env =
-  { env with values = IdTbl.add_lock (Lock {mode}) env.values }
+let add_lock ?escaping_context mode env =
+  let lock = Lock { mode; escaping_context } in
+  { env with values = IdTbl.add_lock lock env.values }
 
 let add_region_lock env =
   { env with values = IdTbl.add_lock Region_lock env.values }
@@ -2436,12 +2443,12 @@ let lock_mode ~errors ~loc env id vmode locks =
     (fun vmode lock ->
       match lock with
       | Region_lock -> Value_mode.local_to_regional vmode
-      | Lock {mode} ->
+      | Lock {mode; escaping_context} ->
           match Value_mode.submode vmode mode with
           | Ok () -> vmode
           | Error _ ->
               may_lookup_error errors loc env
-                (Local_value_used_in_closure id))
+                (Local_value_used_in_closure (id, escaping_context)))
     vmode locks
 
 let lookup_ident_value ~errors ~use ~loc name env =
@@ -3276,12 +3283,17 @@ let report_lookup_error _loc env ppf = function
       fprintf ppf
         "The module %a is an alias for module %a, which %s"
         !print_longident lid !print_path p cause
-  | Local_value_used_in_closure lid ->
+  | Local_value_used_in_closure (lid, context) ->
       fprintf ppf
         "@[The value %a is local, so cannot be used \
            inside a closure that might escape@]"
-        !print_longident lid
-
+        !print_longident lid;
+      begin match context with
+      | Some Tailcall_argument ->
+         fprintf ppf "@.@[Hint: The closure might escape because it \
+                          is an argument to a tail call@]"
+      | _ -> ()
+      end
 
 let report_error ppf = function
   | Missing_module(_, path1, path2) ->

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -155,6 +155,12 @@ type unbound_value_hint =
   | No_hint
   | Missing_rec of Location.t
 
+type escaping_context =
+  | Return
+  | Tailcall_argument
+  | Tailcall_function
+  | Partial_application
+
 type lookup_error =
   | Unbound_value of Longident.t * unbound_value_hint
   | Unbound_type of Longident.t
@@ -176,7 +182,7 @@ type lookup_error =
   | Generative_used_as_applicative of Longident.t
   | Illegal_reference_to_recursive_module
   | Cannot_scrape_alias of Longident.t * Path.t
-  | Local_value_used_in_closure of Longident.t
+  | Local_value_used_in_closure of Longident.t * escaping_context option
 
 val lookup_error: Location.t -> t -> lookup_error -> 'a
 
@@ -357,7 +363,8 @@ val enter_unbound_value : string -> value_unbound_reason -> t -> t
 val enter_unbound_module : string -> module_unbound_reason -> t -> t
 
 (* Lock the environment *)
-val add_lock : Types.value_mode -> t -> t
+
+val add_lock : ?escaping_context:escaping_context -> Types.value_mode -> t -> t
 val add_region_lock : t -> t
 
 (* Initialize the cache of in-core module interfaces. *)

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -78,12 +78,6 @@ type existential_restriction =
   | In_class_def (** or in [class c = let ... in ...] *)
   | In_self_pattern (** or in self pattern *)
 
-type escaping_context =
-  | Return
-  | Tailcall_argument
-  | Tailcall_function
-  | Partial_application
-
 val type_binding:
         Env.t -> rec_flag ->
           Parsetree.value_binding list ->
@@ -207,7 +201,7 @@ type error =
   | Letop_type_clash of string * Ctype.Unification_trace.t
   | Andop_type_clash of string * Ctype.Unification_trace.t
   | Bindings_type_clash of Ctype.Unification_trace.t
-  | Local_value_escapes of Btype.Value_mode.error * escaping_context option
+  | Local_value_escapes of Btype.Value_mode.error * Env.escaping_context option
   | Param_mode_mismatch of type_expr
   | Uncurried_function_escapes
   | Local_return_annotation_mismatch of Location.t


### PR DESCRIPTION
Adds the following hint when local values are used inside closures that are tail call arguments:
```
Error: The value x is local, so cannot be used inside a closure that might escape
Hint: the closure might escape because it is an argument to a tail call
```
(We already have the hint for values other than closures)