### PR TITLE
Improve typing of local unboxed values

### DIFF
--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -1209,6 +1209,19 @@ Line 1, characters 37-51:
 Error: This value escapes its region
 |}]
 
+(* Unboxed type constructors do not affect regionality *)
+type 'a unb1 = A of 'a [@@unboxed]
+type 'a unb2 = { foo : 'a } [@@unboxed]
+type 'a unb3 = B of { bar : 'a } [@@unboxed]
+let f (local_ x) = B { bar = { foo = A x } }
+[%%expect{|
+type 'a unb1 = A of 'a [@@unboxed]
+type 'a unb2 = { foo : 'a; } [@@unboxed]
+type 'a unb3 = B of { bar : 'a; } [@@unboxed]
+val f : local_ 'a -> local_ 'a unb1 unb2 unb3 = <fun>
+|}]
+
+
 (* Fields have the same mode unless they are nonlocal or mutable *)
 
 type 'a imm = { imm : 'a }

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -256,9 +256,14 @@ let mode_subcomponent expected_mode =
     tuple_modes = [] }
 
 let mode_nonlocal expected_mode =
+  let mode =
+    expected_mode.mode
+    |> Value_mode.regional_to_global
+    |> Value_mode.local_to_regional
+  in
   { position = Nontail;
     escaping_context = None;
-    mode = Value_mode.local_to_regional expected_mode.mode;
+    mode;
     tuple_modes = [] }
 
 let mode_tailcall_function mode =


### PR DESCRIPTION
This patch makes unboxed type constructors avoid using `mode_subcomponent`, so that they can be e.g. passed to tail calls.