### PR TITLE
Allow `make -C testuite promote` to take `TEST` and `LIST` variables

### DIFF
--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -101,7 +101,10 @@ default:
 	@echo "  one TEST=f      launch just this single test"
 	@echo "  one DIR=p       launch the tests located in path p"
 	@echo "  one LIST=f      launch the tests listed in f (one per line)"
-	@echo "  promote DIR=p   promote the reference files for the tests in p"
+	@echo "  promote TEST=f  promote the output for this single test"
+	@echo "  promote DIR=p   promote the output for the tests located in path p"
+	@echo "  promote LIST=f  promote the output for the tests listed in f (one \
+	per line)"
 	@echo "  lib             build library modules"
 	@echo "  tools           build test tools"
 	@echo "  clean           delete generated files"
@@ -220,7 +223,7 @@ one: lib tools
 	@case "$(words $(DIR) $(LIST) $(TEST))" in \
    0) echo 'No value set for variable DIR, LIST or TEST'>&2; exit 1;; \
    1) exit 0;; \
-   *) echo 'Please specify just one of DIR, LIST or TEST'>&2; exit 1;; \
+   *) echo 'Please specify exactly one of DIR, LIST or TEST'>&2; exit 1;; \
    esac
 	@if [ -n '$(DIR)' ] && [ ! -d '$(DIR)' ]; then \
     echo "Directory '$(DIR)' does not exist."; exit 1; \
@@ -280,22 +283,8 @@ clean-one:
 	fi
 
 .PHONY: promote
-promote:
-	@if [ -z "$(DIR)" ]; then \
-	  echo "No value set for variable 'DIR'."; \
-	  exit 1; \
-	fi
-	@if [ ! -d $(DIR) ]; then \
-	  echo "Directory '$(DIR)' does not exist."; \
-	  exit 1; \
-	fi
-	@if $(ocamltest) -list-tests $(DIR) >/dev/null 2>&1; then \
-	  $(MAKE) exec-ocamltest DIR=$(DIR) \
-	    OCAMLTESTENV="OCAMLTESTDIR=$(OCAMLTESTDIR_CYGPATH)" \
-	    PROMOTE="true"; \
-	else \
-	  cd $(DIR) && $(MAKE) TERM=dumb BASEDIR=$(BASEDIR) promote; \
-	fi
+promote: lib tools
+	@$(MAKE) one PROMOTE=true
 
 .PHONY: lib
 lib:


### PR DESCRIPTION
The status quo is that you can run any of

```
make -C testsuite one DIR=tests/typing-modules
make -C testsuite one TEST=tests/typing-modules/printing.ml
make -C testsuite one LIST=file
```

if you want to run tests, but you have to run

```
make -C testsuite promote DIR=tests/typing-modules
```

if you want to promote new test output.  This PR attempts to update the machinery for `promote` to be the same as the machinery for `one`, so you can now say

```
make -C testsuite promote TEST=tests/typing-modules/printing.ml
make -C testsuite promote LIST=file
```

as well.

This also fixes an issue where `promote` didn't correctly depend on (`lib` and?) `tools`.

---

I'm not 100% confident this is implemented correctly, and I don't know if we have the requisite expertise or if we want to kick this upstream – let me know.