### PR TITLE
Make empty types immediate

### DIFF
--- a/testsuite/tests/typing-immediate/immediate.ml
+++ b/testsuite/tests/typing-immediate/immediate.ml
@@ -57,16 +57,7 @@ module FM_valid : S
 (* Valid for empty types *)
 module Empty_valid : S = struct type t = | end;;
 [%%expect{|
-Line 1, characters 25-46:
-1 | module Empty_valid : S = struct type t = | end;;
-                             ^^^^^^^^^^^^^^^^^^^^^
-Error: Signature mismatch:
-       Modules do not match: sig type t = | end is not included in S
-       Type declarations do not match:
-         type t = |
-       is not included in
-         type t [@@immediate]
-       The first is not an immediate type.
+module Empty_valid : S
 |}];;
 
 (* Practical usage over modules *)

--- a/testsuite/tests/typing-immediate/immediate.ml
+++ b/testsuite/tests/typing-immediate/immediate.ml
@@ -54,6 +54,21 @@ module M_valid : S
 module FM_valid : S
 |}];;
 
+(* Valid for empty types *)
+module Empty_valid : S = struct type t = | end;;
+[%%expect{|
+Line 1, characters 25-46:
+1 | module Empty_valid : S = struct type t = | end;;
+                             ^^^^^^^^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match: sig type t = | end is not included in S
+       Type declarations do not match:
+         type t = |
+       is not included in
+         type t [@@immediate]
+       The first is not an immediate type.
+|}];;
+
 (* Practical usage over modules *)
 module Foo : sig type t val x : t ref end = struct
   type t = int

--- a/typing/typedecl_immediacy.ml
+++ b/typing/typedecl_immediacy.ml
@@ -33,7 +33,7 @@ let compute_decl env tdecl =
         | Type_immediacy.Always -> Type_immediacy.Always_on_64bits
         | Type_immediacy.Always_on_64bits | Type_immediacy.Unknown as x -> x
     end
-  | (Type_variant (_ :: _ as cstrs), _) ->
+  | (Type_variant cstrs, _) ->
     if not (List.exists (fun c -> c.Types.cd_args <> Types.Cstr_tuple []) cstrs)
     then
       Type_immediacy.Always


### PR DESCRIPTION
Updates the logic for determining which types are immediate to include empty types such as `type t = |`.  This will close ocaml/ocaml#9975 once I make the equivalent PR upstream.