### PR TITLE
Add [@tail] and [@nontail] annotations on applications to control tailcalls

### DIFF
--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -1104,7 +1104,8 @@ method emit_tail (env:environment) exp =
      end
   | Cphantom_let (_var, _defining_expr, body) ->
       self#emit_tail env body
-  | Cop((Capply(ty, pos)) as op, args, dbg) ->
+  | Cop((Capply(ty, ((Rc_close_at_apply | Rc_normal) as pos))) as op,
+        args, dbg) ->
       let tail = (pos = Lambda.Rc_close_at_apply) in
       let endregion = env.region_tail in
       begin match self#emit_parts_list env' args with

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -99,6 +99,7 @@ type initialization_or_assignment =
 
 type region_close =
   | Rc_normal
+  | Rc_nontail
   | Rc_close_at_apply
 
 type primitive =

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -65,8 +65,9 @@ type field_read_semantics =
 
 (* Tail calls can close their enclosing region early *)
 type region_close =
-  | Rc_normal
-  | Rc_close_at_apply
+  | Rc_normal         (* do not close region, may TCO if in tail position *)
+  | Rc_nontail        (* do not close region, must not TCO *)
+  | Rc_close_at_apply (* close region and tail call *)
 
 type primitive =
   | Pidentity

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -581,6 +581,7 @@ let apply_kind name pos mode =
   let name =
     match pos with
     | Rc_normal -> name
+    | Rc_nontail -> name ^ "nontail"
     | Rc_close_at_apply -> name ^ "tail"
   in
   name ^ alloc_kind mode

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -220,12 +220,12 @@ let simplify_exits lam =
   | Lprim(p, ll, loc) -> begin
     let ll = List.map simplif ll in
     match p, ll with
-    (* FIXME does this respect Rc_nontail? *)
         (* Simplify %revapply, for n-ary functions with n > 1 *)
-      | Prevapply Rc_normal, [x; Lapply ap]
-      | Prevapply Rc_normal, [x; Levent (Lapply ap,_)] ->
+      | Prevapply ((Rc_normal | Rc_nontail) as pos), [x; Lapply ap]
+      | Prevapply ((Rc_normal | Rc_nontail) as pos),
+        [x; Levent (Lapply ap,_)] ->
           Lapply {ap with ap_args = ap.ap_args @ [x]; ap_loc = loc;
-                          ap_region_close = Rc_normal}
+                          ap_region_close = pos}
       | Prevapply pos, [x; f] ->
           Lapply {
             ap_loc=loc;
@@ -239,10 +239,11 @@ let simplify_exits lam =
             ap_probe=None;
           }
         (* Simplify %apply, for n-ary functions with n > 1 *)
-      | Pdirapply Rc_normal, [Lapply ap; x]
-      | Pdirapply Rc_normal, [Levent (Lapply ap,_); x] ->
+      | Pdirapply ((Rc_normal | Rc_nontail) as pos), [Lapply ap; x]
+      | Pdirapply ((Rc_normal | Rc_nontail) as pos),
+        [Levent (Lapply ap,_); x] ->
           Lapply {ap with ap_args = ap.ap_args @ [x];
-                          ap_loc = loc; ap_region_close=Rc_normal}
+                          ap_loc = loc; ap_region_close=pos}
       | Pdirapply pos, [f; x] ->
           Lapply {
             ap_loc=loc;

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -220,6 +220,7 @@ let simplify_exits lam =
   | Lprim(p, ll, loc) -> begin
     let ll = List.map simplif ll in
     match p, ll with
+    (* FIXME does this respect Rc_nontail? *)
         (* Simplify %revapply, for n-ary functions with n > 1 *)
       | Prevapply Rc_normal, [x; Lapply ap]
       | Prevapply Rc_normal, [x; Levent (Lapply ap,_)] ->
@@ -883,7 +884,7 @@ let simplify_local_functions lam =
     | Lapply {ap_func = Lvar id; ap_args; ap_region_close; _} ->
         let curr_scope =
           match ap_region_close with
-          | Rc_normal -> !current_scope
+          | Rc_normal | Rc_nontail -> !current_scope
           | Rc_close_at_apply -> !current_region_scope
         in
         begin match Hashtbl.find_opt slots id with

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -902,7 +902,6 @@ and transl_tupled_cases ~scopes patl_expr_list =
   List.map (fun (patl, guard, expr) -> (patl, transl_guard ~scopes guard expr))
     patl_expr_list
 
-(* FIXME: Does this respect Rc_nontail? *)
 and transl_apply ~scopes
       ?(tailcall=Default_tailcall)
       ?(inlined = Default_inlined)
@@ -917,7 +916,8 @@ and transl_apply ~scopes
         Lsend(k, lmet, lobj, args, pos, mode, loc)
     | Lsend(Cached, lmet, lobj, ([_; _] as largs), _, _, _), _ ->
         Lsend(Cached, lmet, lobj, largs @ args, pos, mode, loc)
-    | Lsend(k, lmet, lobj, largs, Rc_normal, _, _), Rc_normal ->
+    | Lsend(k, lmet, lobj, largs, (Rc_normal | Rc_nontail), _, _),
+      (Rc_normal | Rc_nontail) ->
         Lsend(k, lmet, lobj, largs @ args, pos, mode, loc)
     | Levent(
       Lsend((Self | Public) as k, lmet, lobj, [], _, _, _), _), _ ->
@@ -926,9 +926,11 @@ and transl_apply ~scopes
       Lsend(Cached, lmet, lobj, ([_; _] as largs), _, _, _), _), _ ->
         Lsend(Cached, lmet, lobj, largs @ args, pos, mode, loc)
     | Levent(
-      Lsend(k, lmet, lobj, largs, Rc_normal, _, _), _), Rc_normal ->
+      Lsend(k, lmet, lobj, largs, (Rc_normal | Rc_nontail), _, _), _),
+      (Rc_normal | Rc_nontail) ->
         Lsend(k, lmet, lobj, largs @ args, pos, mode, loc)
-    | Lapply ({ ap_region_close = Rc_normal } as ap), Rc_normal ->
+    | Lapply ({ ap_region_close = (Rc_normal | Rc_nontail) } as ap),
+      (Rc_normal | Rc_nontail) ->
         Lapply
           {ap with ap_args = ap.ap_args @ args; ap_loc = loc;
                    ap_region_close = pos; ap_mode = mode}

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -108,7 +108,8 @@ let transl_pat_mode p = transl_value_mode p.pat_mode
 
 let transl_apply_position position =
   match position with
-  | Nontail -> Rc_normal
+  | Default -> Rc_normal
+  | Nontail -> Rc_nontail
   | Tail ->
     if Config.stack_allocation then Rc_close_at_apply
     else Rc_normal
@@ -316,7 +317,7 @@ let can_apply_primitive p pmode pos args =
     let nargs = List.length args in
     if nargs = p.prim_arity then true
     else if nargs < p.prim_arity then false
-    else if pos = Typedtree.Nontail then true
+    else if pos <> Typedtree.Tail then true
     else begin
       let return_mode = Ctype.prim_mode pmode p.prim_native_repr_res in
       is_heap_mode (transl_alloc_mode return_mode)
@@ -901,6 +902,7 @@ and transl_tupled_cases ~scopes patl_expr_list =
   List.map (fun (patl, guard, expr) -> (patl, transl_guard ~scopes guard expr))
     patl_expr_list
 
+(* FIXME: Does this respect Rc_nontail? *)
 and transl_apply ~scopes
       ?(tailcall=Default_tailcall)
       ?(inlined = Default_inlined)

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -880,7 +880,7 @@ let direct_apply env fundesc ufunct uargs pos mode ~probe ~loc ~attribute =
   | Some(params, body), _  ->
      let body =
        match pos with
-       | Rc_normal -> body
+       | Rc_normal | Rc_nontail -> body
        | Rc_close_at_apply -> tail body
      in
      bind_params env loc fundesc params uargs ufunct body
@@ -1110,7 +1110,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
           in
           let body =
             match pos with
-            | Rc_normal -> body
+            | Rc_normal | Rc_nontail -> body
             | Rc_close_at_apply -> tail body
           in
           let result =

--- a/middle_end/flambda/flambda_invariants.ml
+++ b/middle_end/flambda/flambda_invariants.ml
@@ -187,7 +187,7 @@ let variable_and_symbol_invariants (program : Flambda.program) =
     (* Everything else: *)
     | Var var -> check_variable_is_bound env var
     | Apply { func; args; kind; dbg; inlined; specialise; probe;
-              reg_close = (Rc_close_at_apply|Rc_normal);
+              reg_close = (Rc_close_at_apply|Rc_normal|Rc_nontail);
               mode = (Alloc_heap|Alloc_local) } ->
       check_variable_is_bound env func;
       check_variables_are_bound env args;
@@ -200,7 +200,7 @@ let variable_and_symbol_invariants (program : Flambda.program) =
       check_mutable_variable_is_bound env being_assigned;
       check_variable_is_bound env new_value
     | Send { kind; meth; obj; args; dbg;
-             reg_close = (Rc_normal | Rc_close_at_apply);
+             reg_close = (Rc_normal | Rc_close_at_apply | Rc_nontail);
              mode = (Alloc_heap | Alloc_local) } ->
       ignore_meth_kind kind;
       check_variable_is_bound env meth;

--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -917,7 +917,7 @@ and simplify_over_application env r ~args ~args_approxs ~function_decls
   let expr =
     match reg_close with
     | Lambda.Rc_close_at_apply -> Flambda.Tail expr
-    | Lambda.Rc_normal -> expr
+    | Lambda.Rc_normal | Lambda.Rc_nontail -> expr
   in
   simplify (E.set_never_inline env) r expr
 

--- a/middle_end/flambda/inlining_transforms.ml
+++ b/middle_end/flambda/inlining_transforms.ml
@@ -131,7 +131,7 @@ let inline_by_copying_function_body ~env ~r
   let body =
     match reg_close with
     | Lambda.Rc_close_at_apply -> Flambda.Tail body
-    | Lambda.Rc_normal -> body
+    | Lambda.Rc_normal | Lambda.Rc_nontail -> body
   in
   let bindings_for_params_to_args =
     (* Bind the function's parameters to the arguments from the call site. *)

--- a/middle_end/printclambda.ml
+++ b/middle_end/printclambda.ml
@@ -104,9 +104,9 @@ and uconstant ppf = function
   | Uconst_int i -> fprintf ppf "%i" i
 
 and apply_kind ppf : apply_kind -> unit = function
-  | Rc_normal, Alloc_heap -> fprintf ppf "apply"
+  | (Rc_normal | Rc_nontail) , Alloc_heap -> fprintf ppf "apply"
   | Rc_close_at_apply, Alloc_heap -> fprintf ppf "apply[end_region]"
-  | Rc_normal, Alloc_local -> fprintf ppf "apply[L]"
+  | (Rc_normal | Rc_nontail), Alloc_local -> fprintf ppf "apply[L]"
   | Rc_close_at_apply, Alloc_local -> fprintf ppf "apply[end_region][L]"
 
 and lam ppf = function
@@ -246,7 +246,7 @@ and lam ppf = function
   | Usend (k, met, obj, largs, (pos,_) , _) ->
       let form =
         match pos with
-        | Rc_normal -> "send"
+        | Rc_normal | Rc_nontail -> "send"
         | Rc_close_at_apply -> "send[end_region]"
       in
       let args ppf largs =

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -426,3 +426,12 @@ let check_local ext_names other_names attr =
 
 let has_local attr =
   check_local ["extension.local"] ["ocaml.local"; "local"] attr
+
+let tailcall attr =
+  let has_tail = List.exists (check ["ocaml.tail"; "tail"]) attr in
+  let has_nontail = List.exists (check ["ocaml.nontail"; "nontail"]) attr in
+  match has_tail, has_nontail with
+  | true, false -> Ok (Some `Tail)
+  | false, true -> Ok (Some `Nontail)
+  | false, false -> Ok None
+  | true, true -> Error `Conflict

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -99,3 +99,5 @@ val has_nonlocal: Parsetree.attributes -> bool
 (* These functions report Error if the builtin extension.* attributes
    are present despite the extension being disabled *)
 val has_local: Parsetree.attributes -> (bool,unit) result
+
+val tailcall : Parsetree.attributes -> ([`Tail|`Nontail] option, [`Conflict]) result

--- a/testsuite/tests/backtrace/names.ml
+++ b/testsuite/tests/backtrace/names.ml
@@ -101,6 +101,10 @@ let[@inline never] lazy_ f =
   let x = Sys.opaque_identity (lazy (1 + f ())) in
   Lazy.force x
 
+
+let[@inline never] nontailcall f =
+  f () [@nontail]
+
 let () =
   Printexc.record_backtrace true;
   match
@@ -121,6 +125,7 @@ let () =
     (new klass)#meth @@ fun _ ->
     inline_object @@ fun _ ->
     lazy_ @@ fun _ ->
+    nontailcall @@ fun _ ->
     bang ()
   with
   | _ -> assert false

--- a/testsuite/tests/backtrace/names.reference
+++ b/testsuite/tests/backtrace/names.reference
@@ -1,4 +1,5 @@
 Raised at Names.bang in file "names.ml", line 9, characters 29-39
+Called from Names.nontailcall in file "names.ml", line 106, characters 2-6
 Called from Names.lazy_ in file "names.ml", line 101, characters 41-45
 Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 37, characters 17-27
 Re-raised at CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 42, characters 4-11
@@ -26,4 +27,4 @@ Called from Names.Mod1.Nested.apply in file "names.ml", line 21, characters 33-3
 Called from Names.fn_poly in file "names.ml", line 17, characters 2-5
 Called from Names.fn_function in file "names.ml", line 14, characters 9-13
 Called from Names.fn_multi in file "names.ml", line 11, characters 36-40
-Called from Names in file "names.ml", line 107, characters 4-467
+Called from Names in file "names.ml", line 111, characters 4-495

--- a/testsuite/tests/basic-more/tailannots.ml
+++ b/testsuite/tests/basic-more/tailannots.ml
@@ -1,0 +1,31 @@
+(* TEST
+   * expect *)
+
+let nop () = ()
+
+let good_annot () =
+  nop () [@nontail];
+  nop () [@tail]
+[%%expect{|
+val nop : unit -> unit = <fun>
+val good_annot : unit -> unit = <fun>
+|}]
+
+let bad_annot_1 () =
+  nop () [@tail] [@nontail]
+[%%expect{|
+Line 2, characters 2-8:
+2 |   nop () [@tail] [@nontail]
+      ^^^^^^
+Error: The tail-call annotation on this application is contradictory.
+|}]
+
+let bad_annot_2 () =
+  nop () [@tail];
+  nop ()
+[%%expect{|
+Line 2, characters 2-8:
+2 |   nop () [@tail];
+      ^^^^^^
+Error: The tail-call annotation on this application is not on a tail call.
+|}]

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -118,7 +118,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                     expression (test_locations.ml[19,572+9]..test_locations.ml[19,572+20])
                       value_mode <modevar>
                       Texp_apply
-                      apply_mode Nontail
+                      apply_mode Default
                       expression (test_locations.ml[19,572+9]..test_locations.ml[19,572+12])
                         value_mode <modevar>
                         Texp_ident "fib"
@@ -128,7 +128,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                           expression (test_locations.ml[19,572+13]..test_locations.ml[19,572+20])
                             value_mode global
                             Texp_apply
-                            apply_mode Nontail
+                            apply_mode Default
                             expression (test_locations.ml[19,572+16]..test_locations.ml[19,572+17])
                               value_mode <modevar>
                               Texp_ident "Stdlib!.-"
@@ -150,7 +150,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                     expression (test_locations.ml[19,572+23]..test_locations.ml[19,572+34])
                       value_mode <modevar>
                       Texp_apply
-                      apply_mode Nontail
+                      apply_mode Default
                       expression (test_locations.ml[19,572+23]..test_locations.ml[19,572+26])
                         value_mode <modevar>
                         Texp_ident "fib"
@@ -160,7 +160,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                           expression (test_locations.ml[19,572+27]..test_locations.ml[19,572+34])
                             value_mode global
                             Texp_apply
-                            apply_mode Nontail
+                            apply_mode Default
                             expression (test_locations.ml[19,572+30]..test_locations.ml[19,572+31])
                               value_mode <modevar>
                               Texp_ident "Stdlib!.-"

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -118,7 +118,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                     expression 
                       value_mode <modevar>
                       Texp_apply
-                      apply_mode Nontail
+                      apply_mode Default
                       expression 
                         value_mode <modevar>
                         Texp_ident "fib"
@@ -128,7 +128,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                           expression 
                             value_mode global
                             Texp_apply
-                            apply_mode Nontail
+                            apply_mode Default
                             expression 
                               value_mode <modevar>
                               Texp_ident "Stdlib!.-"
@@ -150,7 +150,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                     expression 
                       value_mode <modevar>
                       Texp_apply
-                      apply_mode Nontail
+                      apply_mode Default
                       expression 
                         value_mode <modevar>
                         Texp_ident "fib"
@@ -160,7 +160,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                           expression 
                             value_mode global
                             Texp_apply
-                            apply_mode Nontail
+                            apply_mode Default
                             expression 
                               value_mode <modevar>
                               Texp_ident "Stdlib!.-"

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -1082,6 +1082,14 @@ let foo x =
 val foo : string -> local_ unit = <fun>
 |}]
 
+(* Can pass local values to calls explicitly marked as nontail *)
+let foo x =
+  let local_ r = ref x in
+  print r [@nontail]
+[%%expect{|
+val foo : string -> unit = <fun>
+|}]
+
 (* Cannot call local values in tail calls *)
 
 let foo x =

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -351,7 +351,10 @@ and expression i ppf x =
   | Texp_apply (e, l, m) ->
       line i ppf "Texp_apply\n";
       line i ppf "apply_mode %s\n"
-        (match m with Tail -> "Tail" | Nontail -> "Nontail");
+        (match m with
+         | Tail -> "Tail"
+         | Nontail -> "Nontail"
+         | Default -> "Default");
       expression i ppf e;
       list i label_x_apply_arg ppf l;
   | Texp_match (e, l, _partial) ->

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -205,6 +205,8 @@ type error =
   | Param_mode_mismatch of type_expr
   | Uncurried_function_escapes
   | Local_return_annotation_mismatch of Location.t
+  | Bad_tail_annotation of [`Conflict|`Not_a_tailcall]
+
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -211,6 +211,7 @@ and apply_arg = (expression, omitted_parameter) arg_or_omitted
 and apply_position =
   | Tail
   | Nontail
+  | Default
 
 (* Value expressions for the class language *)
 

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -340,8 +340,9 @@ and omitted_parameter =
 and apply_arg = (expression, omitted_parameter) arg_or_omitted
 
 and apply_position =
-  | Tail
-  | Nontail
+  | Tail          (* must be tail-call optimised *)
+  | Nontail       (* must not be tail-call optimised *)
+  | Default       (* tail-call optimised if in tail position *)
 
 (* Value expressions for the class language *)
 


### PR DESCRIPTION
Applications marked [@nontail] are now never tailcalls, even if in tail position, and always preserve backtraces.

Applications marked [@tail] are always tailcalls and must be in tail position. (This is the same as the existing `[@ocaml.tailcall]`, but the syntax is nicer since the annotation is on the application rather than the function being applied)