### PR TITLE
Allow use of `local_` to adjust regions for loops.

### DIFF
--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -857,23 +857,24 @@ let rec comp_expr env exp sz cont =
       comp_binary_test env cond ifso ifnot sz cont
   | Lsequence(exp1, exp2) ->
       comp_expr env exp1 sz (comp_expr env exp2 sz cont)
-  | Lwhile(cond, body) ->
+  | Lwhile {wh_cond; wh_body} ->
       let lbl_loop = new_label() in
       let lbl_test = new_label() in
       Kbranch lbl_test :: Klabel lbl_loop :: Kcheck_signals ::
-        comp_expr env body sz
+        comp_expr env wh_body sz
           (Klabel lbl_test ::
-            comp_expr env cond sz (Kbranchif lbl_loop :: add_const_unit cont))
-  | Lfor(param, start, stop, dir, body) ->
+            comp_expr env wh_cond sz
+              (Kbranchif lbl_loop :: add_const_unit cont))
+  | Lfor {for_id; for_from; for_to; for_dir; for_body} ->
       let lbl_loop = new_label() in
       let lbl_exit = new_label() in
-      let offset = match dir with Upto -> 1 | Downto -> -1 in
-      let comp = match dir with Upto -> Cgt | Downto -> Clt in
-      comp_expr env start sz
-        (Kpush :: comp_expr env stop (sz+1)
+      let offset = match for_dir with Upto -> 1 | Downto -> -1 in
+      let comp = match for_dir with Upto -> Cgt | Downto -> Clt in
+      comp_expr env for_from sz
+        (Kpush :: comp_expr env for_to (sz+1)
           (Kpush :: Kpush :: Kacc 2 :: Kintcomp comp :: Kbranchif lbl_exit ::
            Klabel lbl_loop :: Kcheck_signals ::
-           comp_expr (add_var param (sz+1) env) body (sz+2)
+           comp_expr (add_var for_id (sz+1) env) for_body (sz+2)
              (Kacc 1 :: Kpush :: Koffsetint offset :: Kassign 2 ::
               Kacc 1 :: Kintcomp Cne :: Kbranchif lbl_loop ::
               Klabel lbl_exit :: add_const_unit (add_pop 2 cont))))

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -398,8 +398,8 @@ type lambda =
   | Ltrywith of lambda * Ident.t * lambda * value_kind
   | Lifthenelse of lambda * lambda * lambda * value_kind
   | Lsequence of lambda * lambda
-  | Lwhile of lambda * lambda
-  | Lfor of Ident.t * lambda * lambda * direction_flag * lambda
+  | Lwhile of lambda_while
+  | Lfor of lambda_for
   | Lassign of Ident.t * lambda
   | Lsend of
       meth_kind * lambda * lambda * lambda list
@@ -417,6 +417,22 @@ and lfunction =
     loc: scoped_location;
     mode: alloc_mode;
     region: bool; }
+
+and lambda_while =
+  { wh_cond : lambda;
+    wh_cond_region : bool;
+    wh_body : lambda;
+    wh_body_region : bool
+  }
+
+and lambda_for =
+  { for_id : Ident.t;
+    for_from : lambda;
+    for_to : lambda;
+    for_dir : direction_flag;
+    for_body : lambda;
+    for_region : bool;
+  }
 
 and lambda_apply =
   { ap_func : lambda;
@@ -649,10 +665,10 @@ let shallow_iter ~tail ~non_tail:f = function
       f e1; tail e2; tail e3
   | Lsequence(e1, e2) ->
       f e1; tail e2
-  | Lwhile(e1, e2) ->
-      f e1; f e2
-  | Lfor(_v, e1, e2, _dir, e3) ->
-      f e1; f e2; f e3
+  | Lwhile {wh_cond; wh_body} ->
+      f wh_cond; f wh_body
+  | Lfor {for_from; for_to; for_body} ->
+      f for_from; f for_to; f for_body
   | Lassign(_, e) ->
       f e
   | Lsend (_k, met, obj, args, _, _, _) ->
@@ -724,11 +740,12 @@ let rec free_variables = function
         (free_variables e3)
   | Lsequence(e1, e2) ->
       Ident.Set.union (free_variables e1) (free_variables e2)
-  | Lwhile(e1, e2) ->
-      Ident.Set.union (free_variables e1) (free_variables e2)
-  | Lfor(v, lo, hi, _dir, body) ->
-      let set = Ident.Set.union (free_variables lo) (free_variables hi) in
-      Ident.Set.union set (Ident.Set.remove v (free_variables body))
+  | Lwhile {wh_cond; wh_body} ->
+      Ident.Set.union (free_variables wh_cond) (free_variables wh_body)
+  | Lfor {for_id; for_from; for_to; for_body} ->
+      Ident.Set.union (free_variables for_from)
+        (Ident.Set.union (free_variables for_to)
+           (Ident.Set.remove for_id (free_variables for_body)))
   | Lassign(id, e) ->
       Ident.Set.add id (free_variables e)
   | Lsend (_k, met, obj, args, _, _, _) ->
@@ -889,10 +906,14 @@ let subst update_env ?(freshen_bound_variables = false) s input_lam =
     | Lifthenelse(e1, e2, e3,kind) ->
         Lifthenelse(subst s l e1, subst s l e2, subst s l e3,kind)
     | Lsequence(e1, e2) -> Lsequence(subst s l e1, subst s l e2)
-    | Lwhile(e1, e2) -> Lwhile(subst s l e1, subst s l e2)
-    | Lfor(v, lo, hi, dir, body) ->
-        let v, l' = bind v l in
-        Lfor(v, subst s l lo, subst s l hi, dir, subst s l' body)
+    | Lwhile lw -> Lwhile {lw with wh_cond = subst s l lw.wh_cond;
+                                   wh_body = subst s l lw.wh_body}
+    | Lfor lf ->
+        let for_id, l' = bind lf.for_id l in
+        Lfor {lf with for_id;
+                      for_from = subst s l lf.for_from;
+                      for_to = subst s l lf.for_to;
+                      for_body = subst s l' lf.for_body}
     | Lassign(id, e) ->
         assert (not (Ident.Map.mem id s));
         let id = try Ident.Map.find id l with Not_found -> id in
@@ -1011,10 +1032,13 @@ let shallow_map ~tail ~non_tail:f = function
       Lifthenelse (f e1, tail e2, tail e3, kind)
   | Lsequence (e1, e2) ->
       Lsequence (f e1, tail e2)
-  | Lwhile (e1, e2) ->
-      Lwhile (f e1, f e2)
-  | Lfor (v, e1, e2, dir, e3) ->
-      Lfor (v, f e1, f e2, dir, f e3)
+  | Lwhile lw ->
+      Lwhile { lw with wh_cond = f lw.wh_cond;
+                       wh_body = f lw.wh_body }
+  | Lfor lf ->
+      Lfor { lf with for_from = f lf.for_from;
+                     for_to = f lf.for_to;
+                     for_body = f lf.for_body }
   | Lassign (v, e) ->
       Lassign (v, f e)
   | Lsend (k, m, o, el, pos, mode, loc) ->

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -329,8 +329,8 @@ type lambda =
    evaluates f if e evaluates to any other value *)
   | Lifthenelse of lambda * lambda * lambda * value_kind
   | Lsequence of lambda * lambda
-  | Lwhile of lambda * lambda
-  | Lfor of Ident.t * lambda * lambda * direction_flag * lambda
+  | Lwhile of lambda_while
+  | Lfor of lambda_for
   | Lassign of Ident.t * lambda
   | Lsend of meth_kind * lambda * lambda * lambda list
              * region_close * alloc_mode * scoped_location
@@ -348,6 +348,25 @@ and lfunction =
     mode : alloc_mode;     (* alloc mode of the closure itself *)
     region : bool;         (* false if this function may locally
                               allocate in the caller's region *)
+  }
+
+and lambda_while =
+  { wh_cond : lambda;
+    wh_cond_region : bool; (* false if the condition may locally allocate in
+                              the region containing the loop *)
+    wh_body : lambda;
+    wh_body_region : bool  (* false if the body may locally allocate in
+                              the region containing the loop *)
+  }
+
+and lambda_for =
+  { for_id : Ident.t;
+    for_from : lambda;
+    for_to : lambda;
+    for_dir : direction_flag;
+    for_body : lambda;
+    for_region : bool;     (* false if the body may locally allocate in the
+                              region containing the loop *)
   }
 
 and lambda_apply =

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -709,13 +709,17 @@ let rec lam ppf = function
       fprintf ppf "@[<2>(if@ %a@ %a@ %a)@]" lam lcond lam lif lam lelse
   | Lsequence(l1, l2) ->
       fprintf ppf "@[<2>(seq@ %a@ %a)@]" lam l1 sequence l2
-  | Lwhile(lcond, lbody) ->
-      fprintf ppf "@[<2>(while@ %a@ %a)@]" lam lcond lam lbody
-  | Lfor(param, lo, hi, dir, body) ->
-      fprintf ppf "@[<2>(for %a@ %a@ %s@ %a@ %a)@]"
-       Ident.print param lam lo
-       (match dir with Upto -> "to" | Downto -> "downto")
-       lam hi lam body
+  | Lwhile {wh_cond; wh_cond_region; wh_body; wh_body_region} ->
+      let cond_mode = if wh_cond_region then alloc_heap else alloc_local in
+      let body_mode = if wh_body_region then alloc_heap else alloc_local in
+      fprintf ppf "@[<2>(while@ %s %a@ %s %a)@]"
+        (alloc_mode cond_mode) lam wh_cond (alloc_mode body_mode) lam wh_body
+  | Lfor {for_id; for_from; for_to; for_dir; for_body; for_region} ->
+      let mode = if for_region then alloc_heap else alloc_local in
+      fprintf ppf "@[<2>(for %a@ %a@ %s@ %a@ %s %a)@]"
+       Ident.print for_id lam for_from
+       (match for_dir with Upto -> "to" | Downto -> "downto")
+       lam for_to (alloc_mode mode) lam for_body
   | Lassign(id, expr) ->
       fprintf ppf "@[<2>(assign@ %a@ %a)@]" Ident.print id lam expr
   | Lsend (k, met, obj, largs, pos, reg, _) ->

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -78,11 +78,13 @@ let rec eliminate_ref id = function
                   eliminate_ref id e3, kind)
   | Lsequence(e1, e2) ->
       Lsequence(eliminate_ref id e1, eliminate_ref id e2)
-  | Lwhile(e1, e2) ->
-      Lwhile(eliminate_ref id e1, eliminate_ref id e2)
-  | Lfor(v, e1, e2, dir, e3) ->
-      Lfor(v, eliminate_ref id e1, eliminate_ref id e2,
-           dir, eliminate_ref id e3)
+  | Lwhile lw ->
+      Lwhile {lw with wh_cond = eliminate_ref id lw.wh_cond;
+                      wh_body = eliminate_ref id lw.wh_body}
+  | Lfor lf ->
+      Lfor {lf with for_from = eliminate_ref id lf.for_from;
+                    for_to = eliminate_ref id lf.for_to;
+                    for_body = eliminate_ref id lf.for_body }
   | Lassign(v, e) ->
       Lassign(v, eliminate_ref id e)
   | Lsend(k, m, o, el, pos, mode, loc) ->
@@ -163,8 +165,8 @@ let simplify_exits lam =
   | Ltrywith(l1, _v, l2, _kind) -> incr try_depth; count l1; decr try_depth; count l2
   | Lifthenelse(l1, l2, l3, _kind) -> count l1; count l2; count l3
   | Lsequence(l1, l2) -> count l1; count l2
-  | Lwhile(l1, l2) -> count l1; count l2
-  | Lfor(_, l1, l2, _dir, l3) -> count l1; count l2; count l3
+  | Lwhile lw -> count lw.wh_cond; count lw.wh_body
+  | Lfor lf -> count lf.for_from; count lf.for_to; count lf.for_body
   | Lassign(_v, l) -> count l
   | Lsend(_k, m, o, ll, _, _, _) -> List.iter count (m::o::ll)
   | Levent(l, _) -> count l
@@ -329,9 +331,12 @@ let simplify_exits lam =
       Ltrywith(l1, v, simplif l2, kind)
   | Lifthenelse(l1, l2, l3, kind) -> Lifthenelse(simplif l1, simplif l2, simplif l3, kind)
   | Lsequence(l1, l2) -> Lsequence(simplif l1, simplif l2)
-  | Lwhile(l1, l2) -> Lwhile(simplif l1, simplif l2)
-  | Lfor(v, l1, l2, dir, l3) ->
-      Lfor(v, simplif l1, simplif l2, dir, simplif l3)
+  | Lwhile lw -> Lwhile {lw with wh_cond = simplif lw.wh_cond;
+                                 wh_body = simplif lw.wh_body}
+  | Lfor lf ->
+      Lfor {lf with for_from = simplif lf.for_from;
+                    for_to = simplif lf.for_to;
+                    for_body = simplif lf.for_body}
   | Lassign(v, l) -> Lassign(v, simplif l)
   | Lsend(k, m, o, ll, pos, mode, loc) ->
       Lsend(k, simplif m, simplif o, List.map simplif ll, pos, mode, loc)
@@ -469,9 +474,10 @@ let simplify_lets lam =
   | Ltrywith(l1, _v, l2, _kind) -> count bv l1; count bv l2
   | Lifthenelse(l1, l2, l3, _kind) -> count bv l1; count bv l2; count bv l3
   | Lsequence(l1, l2) -> count bv l1; count bv l2
-  | Lwhile(l1, l2) -> count Ident.Map.empty l1; count Ident.Map.empty l2
-  | Lfor(_, l1, l2, _dir, l3) ->
-      count bv l1; count bv l2; count Ident.Map.empty l3
+  | Lwhile {wh_cond; wh_body} ->
+      count Ident.Map.empty wh_cond; count Ident.Map.empty wh_body
+  | Lfor {for_from; for_to; for_body} ->
+      count bv for_from; count bv for_to; count Ident.Map.empty for_body
   | Lassign(_v, l) ->
       (* Lalias-bound variables are never assigned, so don't increase
          v's refcount *)
@@ -612,9 +618,11 @@ let simplify_lets lam =
       then Lsequence(simplif l1, simplif l2)
       else simplif l2
   | Lsequence(l1, l2) -> Lsequence(simplif l1, simplif l2)
-  | Lwhile(l1, l2) -> Lwhile(simplif l1, simplif l2)
-  | Lfor(v, l1, l2, dir, l3) ->
-      Lfor(v, simplif l1, simplif l2, dir, simplif l3)
+  | Lwhile lw -> Lwhile {lw with wh_cond = simplif lw.wh_cond;
+                                 wh_body = simplif lw.wh_body}
+  | Lfor lf -> Lfor {lf with for_from = simplif lf.for_from;
+                             for_to = simplif lf.for_to;
+                             for_body = simplif lf.for_body}
   | Lassign(v, l) -> Lassign(v, simplif l)
   | Lsend(k, m, o, ll, pos, mode, loc) ->
       Lsend(k, simplif m, simplif o, List.map simplif ll, pos, mode, loc)
@@ -695,13 +703,13 @@ let rec emit_tail_infos is_tail lambda =
   | Lsequence (lam1, lam2) ->
       emit_tail_infos false lam1;
       emit_tail_infos is_tail lam2
-  | Lwhile (cond, body) ->
-      emit_tail_infos false cond;
-      emit_tail_infos false body
-  | Lfor (_, low, high, _, body) ->
-      emit_tail_infos false low;
-      emit_tail_infos false high;
-      emit_tail_infos false body
+  | Lwhile lw ->
+      emit_tail_infos false lw.wh_cond;
+      emit_tail_infos false lw.wh_body
+  | Lfor {for_from; for_to; for_body} ->
+      emit_tail_infos false for_from;
+      emit_tail_infos false for_to;
+      emit_tail_infos false for_body
   | Lassign (_, lam) ->
       emit_tail_infos false lam
   | Lsend (_, meth, obj, args, _, _, _loc) ->

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -697,8 +697,8 @@ let free_methods l =
         List.iter (fun (id, _) -> fv := Ident.Set.remove id !fv) vars
     | Ltrywith(_e1, exn, _e2, _k) ->
         fv := Ident.Set.remove exn !fv
-    | Lfor(v, _e1, _e2, _dir, _e3) ->
-        fv := Ident.Set.remove v !fv
+    | Lfor {for_id} ->
+        fv := Ident.Set.remove for_id !fv
     | Lassign _
     | Lvar _ | Lconst _ | Lapply _
     | Lprim _ | Lswitch _ | Lstringswitch _ | Lstaticraise _

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -132,13 +132,11 @@ let may_allocate_in_region lam =
     | Lregion _body ->
        (* [_body] might do local allocations, but not in the current region *)
        ()
-    | Lwhile (cond, _body) ->
-       (* [_body] already has a region *)
-       loop cond
-    | Lfor (_var, l, u, _dir, _body) ->
-       (* [_body] already has a region *)
-       loop l; loop u
-
+    | Lwhile {wh_cond_region=false} -> raise Exit
+    | Lwhile {wh_body_region=false} -> raise Exit
+    | Lwhile _ -> ()
+    | Lfor {for_region=false} -> raise Exit
+    | Lfor {for_from; for_to} -> loop for_from; loop for_to
     | ( Lapply _ | Llet _ | Lletrec _ | Lswitch _ | Lstringswitch _
       | Lstaticraise _ | Lstaticcatch _ | Ltrywith _
       | Lifthenelse _ | Lsequence _ | Lassign _ | Lsend _
@@ -584,9 +582,16 @@ and transl_exp0 ~in_new_scope ~scopes e =
   | Texp_sequence(expr1, expr2) ->
       Lsequence(transl_exp ~scopes expr1,
                 event_before ~scopes expr2 (transl_exp ~scopes expr2))
-  | Texp_while(cond, body) ->
-      Lwhile(maybe_region (transl_exp ~scopes cond),
-             event_before ~scopes body (maybe_region (transl_exp ~scopes body)))
+  | Texp_while {wh_body; wh_body_region; wh_cond; wh_cond_region} ->
+      let cond = transl_exp ~scopes wh_cond in
+      let body = transl_exp ~scopes wh_body in
+      Lwhile {
+        wh_cond = if wh_cond_region then maybe_region cond else cond;
+        wh_cond_region;
+        wh_body = event_before ~scopes wh_body
+                    (if wh_body_region then maybe_region body else body);
+        wh_body_region;
+      }
   | Texp_arr_comprehension (body, blocks) ->
     (*One block consists of comprehension statements connected by "and".*)
     let loc = of_location ~scopes e.exp_loc in
@@ -597,10 +602,18 @@ and transl_exp0 ~in_new_scope ~scopes e =
     let loc = of_location ~scopes e.exp_loc in
     Translcomprehension.transl_list_comprehension
       body blocks ~scopes ~loc ~transl_exp
-  | Texp_for(param, _, low, high, dir, body) ->
-      Lfor(param, transl_exp ~scopes low,
-           transl_exp ~scopes high, dir,
-           event_before ~scopes body (maybe_region (transl_exp ~scopes body)))
+  | Texp_for {for_id; for_from; for_to; for_dir; for_body; for_region} ->
+      let body = transl_exp ~scopes for_body in
+      Lfor {
+        for_id;
+        for_from = transl_exp ~scopes for_from;
+        for_to = transl_exp ~scopes for_to;
+        for_dir;
+        for_body = event_before ~scopes for_body
+                     (if for_region then maybe_region body else body);
+        for_region;
+      }
+
   | Texp_send(_, _, Some exp, _) -> transl_exp ~scopes exp
   | Texp_send(expr, met, None, pos) ->
       let obj = transl_exp ~scopes expr in

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -1322,15 +1322,15 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
       let (ulam1, _) = close env lam1 in
       let (ulam2, approx) = close env lam2 in
       (Usequence(ulam1, ulam2), approx)
-  | Lwhile(cond, body) ->
-      let (ucond, _) = close env cond in
-      let (ubody, _) = close env body in
+  | Lwhile {wh_cond; wh_body} ->
+      let (ucond, _) = close env wh_cond in
+      let (ubody, _) = close env wh_body in
       (Uwhile(ucond, ubody), Value_unknown)
-  | Lfor(id, lo, hi, dir, body) ->
-      let (ulo, _) = close env lo in
-      let (uhi, _) = close env hi in
-      let (ubody, _) = close env body in
-      (Ufor(VP.create id, ulo, uhi, dir, ubody), Value_unknown)
+  | Lfor {for_id; for_from; for_to; for_dir; for_body} ->
+      let (ulo, _) = close env for_from in
+      let (uhi, _) = close env for_to in
+      let (ubody, _) = close env for_body in
+      (Ufor(VP.create for_id, ulo, uhi, for_dir, ubody), Value_unknown)
   | Lassign(id, lam) ->
       let (ulam, _) = close env lam in
       (Uassign(id, ulam), Value_unknown)

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -551,15 +551,16 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
     let lam1 = Flambda.Expr (close t env lam1) in
     let lam2 = close t env lam2 in
     Flambda.create_let var lam1 lam2
-  | Lwhile (cond, body) -> While (close t env cond, close t env body)
-  | Lfor (id, lo, hi, direction, body) ->
-    let bound_var = Variable.create_with_same_name_as_ident id in
+  | Lwhile {wh_cond; wh_body} ->
+    While (close t env wh_cond, close t env wh_body)
+  | Lfor {for_id; for_from; for_to; for_dir; for_body} ->
+    let bound_var = Variable.create_with_same_name_as_ident for_id in
     let from_value = Variable.create Names.for_from in
     let to_value = Variable.create Names.for_to in
-    let body = close t (Env.add_var env id bound_var) body in
-    Flambda.create_let from_value (Expr (close t env lo))
-      (Flambda.create_let to_value (Expr (close t env hi))
-        (For { bound_var; from_value; to_value; direction; body; }))
+    let body = close t (Env.add_var env for_id bound_var) for_body in
+    Flambda.create_let from_value (Expr (close t env for_from))
+      (Flambda.create_let to_value (Expr (close t env for_to))
+        (For { bound_var; from_value; to_value; direction=for_dir; body; }))
   | Lassign (id, new_value) ->
     let being_assigned =
       match Env.find_mutable_var_exn env id with

--- a/testsuite/tests/typing-local/loop_regions.heap.reference
+++ b/testsuite/tests/typing-local/loop_regions.heap.reference
@@ -1,0 +1,6 @@
+                local for: [0; 0; 0]
+            non-local for: [0; 0; 0]
+         local while body: [0; 0; 0]
+      nonlocal while body: [0; 0; 0]
+         local while cond: [0; 0; 0]
+      nonlocal while cond: [0; 0; 0]

--- a/testsuite/tests/typing-local/loop_regions.ml
+++ b/testsuite/tests/typing-local/loop_regions.ml
@@ -1,0 +1,117 @@
+(* TEST
+   * native *)
+
+external local_stack_offset : unit -> int = "caml_local_stack_offset"
+external opaque_local : ('a[@local_opt]) -> ('a[@local_opt]) = "%opaque"
+
+let check_expected_offsets (name,actual,expected) =
+  let p xs = String.concat "; " (List.map Int.to_string xs) in
+  if List.equal (=) actual expected then
+    Printf.printf "%25s: OK\n%!" name
+  else
+    Printf.printf "%25s: Error.  Expected: [%s],  Saw: [%s]\n%!"
+      name (p expected) (p actual)
+
+(* local_ for allocates in parent region *)
+let loc_for () =
+  let offset_loop = ref (-1) in
+  let offset1 = local_stack_offset () in
+  for i = 0 to 0 do local_
+    let z = local_ (Some (Sys.opaque_identity 42)) in
+    let _ = (opaque_local z) in
+    offset_loop := local_stack_offset ()
+  done;
+  let offset2 = local_stack_offset () in
+  [offset1; !offset_loop; offset2]
+
+let loc_for_expect = [0; 16; 16]
+
+(* Non local loop allocates in its own region *)
+let nonloc_for () =
+  let offset_loop = ref (-1) in
+  let offset1 = local_stack_offset () in
+  for i = 0 to 0 do
+    let z = local_ (Some (Sys.opaque_identity 42)) in
+    let _ = (opaque_local z) in
+    offset_loop := local_stack_offset ()
+  done;
+  let offset2 = local_stack_offset () in
+  [offset1; !offset_loop; offset2]
+
+let nonloc_for_expect = [0; 16; 0]
+
+(* Local while body should allocate in parent *)
+let loc_while_body () =
+  let offset_loop = ref (-1) in
+  let offset1 = local_stack_offset () in
+  let cond = ref true in
+  while !cond do local_
+    let z = local_ (Some (Sys.opaque_identity 42)) in
+    let _ = (opaque_local z) in
+    offset_loop := local_stack_offset ();
+    cond := false
+  done;
+  let offset2 = local_stack_offset () in
+  [offset1; !offset_loop; offset2]
+
+let loc_while_body_expect = [0;16;16]
+
+(* Nonlocal while body should allocate in its own region*)
+let nonloc_while_body () =
+  let offset_loop = ref (-1) in
+  let offset1 = local_stack_offset () in
+  let cond = ref true in
+  while !cond do
+    let z = local_ (Some (Sys.opaque_identity 42)) in
+    let _ = (opaque_local z) in
+    offset_loop := local_stack_offset ();
+    cond := false
+  done;
+  let offset2 = local_stack_offset () in
+  [offset1; !offset_loop; offset2]
+
+let nonloc_while_body_expect = [0;16;0]
+
+(* Local while condition should allocate in parent *)
+let loc_while_cond () =
+  let offset_loop = ref (-1) in
+  let offset1 = local_stack_offset () in
+  while local_
+    let z = local_ (Some (Sys.opaque_identity 42)) in
+    let _ = (opaque_local z) in
+    offset_loop := local_stack_offset ();
+    false
+  do
+    ()
+  done;
+  let offset2 = local_stack_offset () in
+  [offset1; !offset_loop; offset2]
+
+let loc_while_cond_expect = [0;16;16]
+
+(* Nonlocal while condition should allocate in its own region *)
+let nonloc_while_cond () =
+  let offset_loop = ref (-1) in
+  let offset1 = local_stack_offset () in
+  while
+    let z = local_ (Some (Sys.opaque_identity 42)) in
+    let _ = (opaque_local z) in
+    offset_loop := local_stack_offset ();
+    false
+  do
+    ()
+  done;
+  let offset2 = local_stack_offset () in
+  [offset1; !offset_loop; offset2]
+
+let nonloc_while_cond_expect = [0;16;0]
+
+let () =
+  List.iter check_expected_offsets [
+    "local for",           loc_for (),           loc_for_expect;
+    "non-local for",       nonloc_for (),        nonloc_for_expect;
+    "local while body",    loc_while_body (),    loc_while_body_expect;
+    "nonlocal while body", nonloc_while_body (), nonloc_while_body_expect;
+    "local while cond",    loc_while_cond (),    loc_while_cond_expect;
+    "nonlocal while cond", nonloc_while_cond (), nonloc_while_cond_expect;
+  ]

--- a/testsuite/tests/typing-local/loop_regions.reference
+++ b/testsuite/tests/typing-local/loop_regions.reference
@@ -1,6 +1,0 @@
-                local for: OK
-            non-local for: OK
-         local while body: OK
-      nonlocal while body: OK
-         local while cond: OK
-      nonlocal while cond: OK

--- a/testsuite/tests/typing-local/loop_regions.reference
+++ b/testsuite/tests/typing-local/loop_regions.reference
@@ -1,0 +1,6 @@
+                local for: OK
+            non-local for: OK
+         local while body: OK
+      nonlocal while body: OK
+         local while cond: OK
+      nonlocal while cond: OK

--- a/testsuite/tests/typing-local/loop_regions.stack.reference
+++ b/testsuite/tests/typing-local/loop_regions.stack.reference
@@ -1,0 +1,6 @@
+                local for: [0; 16; 16]
+            non-local for: [0; 16; 0]
+         local while body: [0; 16; 16]
+      nonlocal while body: [0; 16; 0]
+         local while cond: [0; 16; 16]
+      nonlocal while cond: [0; 16; 0]

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -401,10 +401,12 @@ and expression i ppf x =
       line i ppf "Texp_sequence\n";
       expression i ppf e1;
       expression i ppf e2;
-  | Texp_while (e1, e2) ->
+  | Texp_while {wh_cond; wh_cond_region; wh_body; wh_body_region} ->
       line i ppf "Texp_while\n";
-      expression i ppf e1;
-      expression i ppf e2;
+      line i ppf "cond_region %b\n" wh_cond_region;
+      expression i ppf wh_cond;
+      line i ppf "body_region %b\n" wh_body_region;
+      expression i ppf wh_body;
   | Texp_list_comprehension(e1, type_comp) ->
     line i ppf "Texp_list_comprehension\n";
     expression i ppf e1;
@@ -413,11 +415,13 @@ and expression i ppf x =
     line i ppf "Texp_arr_comprehension\n";
     expression i ppf e1;
     comprehension i ppf type_comp
-  | Texp_for (s, _, e1, e2, df, e3) ->
-      line i ppf "Texp_for \"%a\" %a\n" fmt_ident s fmt_direction_flag df;
-      expression i ppf e1;
-      expression i ppf e2;
-      expression i ppf e3;
+  | Texp_for {for_id; for_from; for_to; for_dir; for_body; for_region} ->
+      line i ppf "Texp_for \"%a\" %a\n"
+        fmt_ident for_id fmt_direction_flag for_dir;
+      expression i ppf for_from;
+      expression i ppf for_to;
+      line i ppf "region %b\n" for_region;
+      expression i ppf for_body
   | Texp_send (e, Tmeth_name s, eo, _) ->
       line i ppf "Texp_send \"%s\"\n" s;
       expression i ppf e;

--- a/typing/rec_check.ml
+++ b/typing/rec_check.ml
@@ -562,7 +562,7 @@ let rec expression : Typedtree.expression -> term_judg =
             Guard
       in
       join ((expression body << array_mode)::(comprehension comp_types))
-    | Texp_for (_, _, low, high, _, body) ->
+    | Texp_for tf ->
       (*
         G1 |- low: m[Dereference]
         G2 |- high: m[Dereference]
@@ -571,9 +571,9 @@ let rec expression : Typedtree.expression -> term_judg =
         G1 + G2 + G3 |- for _ = low to high do body done: m
       *)
       join [
-        expression low << Dereference;
-        expression high << Dereference;
-        expression body << Guard;
+        expression tf.for_from << Dereference;
+        expression tf.for_to << Dereference;
+        expression tf.for_body << Guard;
       ]
     | Texp_constant _ ->
       empty
@@ -709,7 +709,7 @@ let rec expression : Typedtree.expression -> term_judg =
         expression e1 << Guard;
         expression e2;
       ]
-    | Texp_while (cond, body) ->
+    | Texp_while {wh_cond; wh_body} ->
       (*
         G1 |- cond: m[Dereference]
         G2 |- body: m[Guard]
@@ -717,8 +717,8 @@ let rec expression : Typedtree.expression -> term_judg =
         G1 + G2 |- while cond do body done: m
       *)
       join [
-        expression cond << Dereference;
-        expression body << Guard;
+        expression wh_cond << Dereference;
+        expression wh_body << Guard;
       ]
     | Texp_send (e1, _, eo, _) ->
       (*

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -228,9 +228,9 @@ let expr sub {exp_extra; exp_desc; exp_env; _} =
   | Texp_sequence (exp1, exp2) ->
       sub.expr sub exp1;
       sub.expr sub exp2
-  | Texp_while (exp1, exp2) ->
-      sub.expr sub exp1;
-      sub.expr sub exp2
+  | Texp_while { wh_cond; wh_body } ->
+      sub.expr sub wh_cond;
+      sub.expr sub wh_body
   | Texp_list_comprehension (exp1, type_comps)
   | Texp_arr_comprehension (exp1, type_comps) ->
     sub.expr sub exp1;
@@ -242,10 +242,10 @@ let expr sub {exp_extra; exp_desc; exp_env; _} =
           ) clauses;
         Option.iter (fun g -> sub.expr sub g) guard)
       type_comps
-  | Texp_for (_, _, exp1, exp2, _, exp3) ->
-      sub.expr sub exp1;
-      sub.expr sub exp2;
-      sub.expr sub exp3
+  | Texp_for {for_from; for_to; for_body} ->
+      sub.expr sub for_from;
+      sub.expr sub for_to;
+      sub.expr sub for_body
   | Texp_send (exp, _, expo, _) ->
       sub.expr sub exp;
       Option.iter (sub.expr sub) expo

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -322,11 +322,10 @@ let expr sub x =
           sub.expr sub exp1,
           sub.expr sub exp2
         )
-    | Texp_while (exp1, exp2) ->
-        Texp_while (
-          sub.expr sub exp1,
-          sub.expr sub exp2
-        )
+    | Texp_while wh ->
+        Texp_while { wh with wh_cond = sub.expr sub wh.wh_cond;
+                             wh_body = sub.expr sub wh.wh_body
+                   }
     | Texp_list_comprehension(e1, type_comp) ->
         Texp_list_comprehension(
           sub.expr sub e1,
@@ -337,15 +336,10 @@ let expr sub x =
         sub.expr sub e1,
         map_comprehension type_comp
       )
-    | Texp_for (id, p, exp1, exp2, dir, exp3) ->
-        Texp_for (
-          id,
-          p,
-          sub.expr sub exp1,
-          sub.expr sub exp2,
-          dir,
-          sub.expr sub exp3
-        )
+    | Texp_for tf ->
+        Texp_for {tf with for_from = sub.expr sub tf.for_from;
+                          for_to = sub.expr sub tf.for_to;
+                          for_body = sub.expr sub tf.for_body}
     | Texp_send (exp, meth, expo, pos) ->
         Texp_send
           (

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3919,38 +3919,51 @@ and type_expect_
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
   | Pexp_while(scond, sbody) ->
-      let cond =
-        type_expect (Env.add_region_lock env) (mode_var ()) scond
+      let cond_env,wh_cond_region =
+        if is_local_returning_expr scond then env, false
+        else Env.add_region_lock env, true
+      in
+      let wh_cond =
+        type_expect cond_env (mode_var ()) scond
           (mk_expected ~explanation:While_loop_conditional Predef.type_bool)
       in
-      let body =
-        type_statement ~explanation:While_loop_body (Env.add_region_lock env) sbody
+      let body_env,wh_body_region =
+        if is_local_returning_expr sbody then env, false
+        else Env.add_region_lock env, true
+      in
+      let wh_body =
+        type_statement ~explanation:While_loop_body body_env sbody
       in
       rue {
-        exp_desc = Texp_while(cond, body);
+        exp_desc =
+          Texp_while {wh_cond; wh_cond_region; wh_body; wh_body_region};
         exp_loc = loc; exp_extra = [];
         exp_type = instance Predef.type_unit;
         exp_mode = expected_mode.mode;
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
   | Pexp_for(param, slow, shigh, dir, sbody) ->
-      let low =
+      let for_from =
         type_expect env (mode_var ()) slow
           (mk_expected ~explanation:For_loop_start_index Predef.type_int)
       in
-      let high =
+      let for_to =
         type_expect env (mode_var ()) shigh
           (mk_expected ~explanation:For_loop_stop_index Predef.type_int)
       in
-      let id, new_env =
+      let for_id, new_env =
         type_for_loop_index ~loc ~env ~param Predef.type_int
       in
-      let body =
-        type_statement ~explanation:For_loop_body
-          (Env.add_region_lock new_env) sbody
+      let new_env, for_region =
+        if is_local_returning_expr sbody then new_env, false
+        else Env.add_region_lock new_env, true
+      in
+      let for_body =
+        type_statement ~explanation:For_loop_body new_env sbody
       in
       rue {
-        exp_desc = Texp_for(id, param, low, high, dir, body);
+        exp_desc = Texp_for {for_id; for_pat = param; for_from; for_to;
+                             for_dir = dir; for_body; for_region};
         exp_loc = loc; exp_extra = [];
         exp_type = instance Predef.type_unit;
         exp_mode = expected_mode.mode;

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -123,14 +123,25 @@ and expression_desc =
   | Texp_array of expression list
   | Texp_ifthenelse of expression * expression * expression option
   | Texp_sequence of expression * expression
-  | Texp_while of expression * expression
+  | Texp_while of {
+      wh_cond : expression;
+      wh_cond_region : bool;
+      wh_body : expression;
+      wh_body_region : bool
+    }
   | Texp_list_comprehension of
       expression * comprehension list
   | Texp_arr_comprehension of
       expression * comprehension list
-  | Texp_for of
-      Ident.t * Parsetree.pattern * expression * expression * direction_flag *
-        expression
+  | Texp_for of {
+      for_id  : Ident.t;
+      for_pat : Parsetree.pattern;
+      for_from : expression;
+      for_to   : expression;
+      for_dir  : direction_flag;
+      for_body : expression;
+      for_region : bool;
+    }
   | Texp_send of expression * meth * expression option * apply_position
   | Texp_new of
       Path.t * Longident.t loc * Types.class_declaration * apply_position

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -251,14 +251,27 @@ and expression_desc =
   | Texp_array of expression list
   | Texp_ifthenelse of expression * expression * expression option
   | Texp_sequence of expression * expression
-  | Texp_while of expression * expression
-  | Texp_list_comprehension of 
+  | Texp_while of {
+      wh_cond : expression;
+      wh_cond_region : bool; (* False means allocates in outer region *)
+      wh_body : expression;
+      wh_body_region : bool  (* False means allocates in outer region *)
+    }
+  | Texp_list_comprehension of
       expression * comprehension list
-  | Texp_arr_comprehension of 
+  | Texp_arr_comprehension of
       expression * comprehension list
-  | Texp_for of
-      Ident.t * Parsetree.pattern * expression * expression * direction_flag *
-        expression
+  | Texp_for of {
+      for_id  : Ident.t;
+      for_pat : Parsetree.pattern;
+      for_from : expression;
+      for_to   : expression;
+      for_dir  : direction_flag;
+      for_body : expression;
+      for_region : bool;
+      (* for_region = true means we create a region for the body.  false means
+         it may allocated in the containing region *)
+    }
   | Texp_send of expression * meth * expression option * apply_position
   | Texp_new of
       Path.t * Longident.t loc * Types.class_declaration * apply_position

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -469,8 +469,8 @@ let expression sub exp =
           Option.map (sub.expr sub) expo)
     | Texp_sequence (exp1, exp2) ->
         Pexp_sequence (sub.expr sub exp1, sub.expr sub exp2)
-    | Texp_while (exp1, exp2) ->
-        Pexp_while (sub.expr sub exp1, sub.expr sub exp2)
+    | Texp_while {wh_cond; wh_body} ->
+        Pexp_while (sub.expr sub wh_cond, sub.expr sub wh_body)
     | Texp_list_comprehension(exp1, type_comp) ->
       Pexp_extension
       (Extensions.payload_of_extension_expr ~loc
@@ -481,10 +481,10 @@ let expression sub exp =
         (Extensions.payload_of_extension_expr ~loc
           (Extensions.Eexp_arr_comprehension(
             sub.expr sub exp1, map_comprehension type_comp)))
-    | Texp_for (_id, name, exp1, exp2, dir, exp3) ->
-        Pexp_for (name,
-          sub.expr sub exp1, sub.expr sub exp2,
-          dir, sub.expr sub exp3)
+    | Texp_for {for_pat; for_from; for_to; for_dir; for_body} ->
+        Pexp_for (for_pat,
+          sub.expr sub for_from, sub.expr sub for_to,
+          for_dir, sub.expr sub for_body)
     | Texp_send (exp, meth, _, _) ->
         Pexp_send (sub.expr sub exp, match meth with
             Tmeth_name name -> mkloc name loc


### PR DESCRIPTION
This patch changes the local stack region behavior for the body of for loops,
and the body and condition of while loops.  Now, the user may request that no
new stack region is created for these positions, and instead local allocations
happen in the region containing the loop.

This is of limited use in isolation, but is useful with the coming "let mutable"
patch, where we want to allow locals in a loop body to "escape" to mutable
variables declared in the scope containing the loop.