### PR TITLE
Backport PR 10090

### DIFF
--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -600,7 +600,8 @@ let rec comp_expr env exp sz cont =
       Stack.push to_compile functions_to_compile;
       comp_args env (List.map (fun n -> Lvar n) fv) sz
         (Kclosure(lbl, List.length fv) :: cont)
-  | Llet(_str, _k, id, arg, body) ->
+  | Llet(_, _k, id, arg, body)
+  | Lmutlet(_k, id, arg, body) ->
       comp_expr env arg sz
         (Kpush :: comp_expr (add_var id (sz+1) env) body (sz+1)
           (add_pop 1 cont))

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -533,7 +533,7 @@ module Storer =
 let rec comp_expr env exp sz cont =
   if sz > !max_stack_used then max_stack_used := sz;
   match exp with
-    Lvar id ->
+    Lvar id | Lmutvar id ->
       begin try
         let pos = Ident.find_same id env.ce_stack in
         Kacc(sz - pos) :: cont

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -897,6 +897,8 @@ let subst update_env ?(freshen_bound_variables = false) s input_lam =
        begin match Ident.Map.find id l with
           | id' -> Lmutvar id'
           | exception Not_found ->
+             (* Note: a mutable [id] should not appear in [s].
+                Keeping the behavior of Lvar case for now. *)
              begin try Ident.Map.find id s with Not_found -> lam end
         end
     | Lconst _ as l -> l

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -318,6 +318,7 @@ type scoped_location = Debuginfo.Scoped_location.t
 
 type lambda =
     Lvar of Ident.t
+  | Lmutvar of Ident.t
   | Lconst of structured_constant
   | Lapply of lambda_apply
   | Lfunction of lfunction

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -288,7 +288,7 @@ type function_kind = Curried of {nlocal: int} | Tupled
    before the resulting closure must be locally allocated.
    See [check_lfunction] for details *)
 
-type let_kind = Strict | Alias | StrictOpt | Variable
+type let_kind = Strict | Alias | StrictOpt
 (* Meaning of kinds for let x = e in e':
     Strict: e may have side-effects; always evaluate e first
       (If e is a simple expression, e.g. a variable or constant,
@@ -297,7 +297,6 @@ type let_kind = Strict | Alias | StrictOpt | Variable
       in e'
     StrictOpt: e does not have side-effects, but depend on the store;
       we can discard e if x does not appear in e'
-    Variable: the variable x is assigned later in e'
  *)
 
 type meth_kind = Self | Public | Cached
@@ -323,6 +322,7 @@ type lambda =
   | Lapply of lambda_apply
   | Lfunction of lfunction
   | Llet of let_kind * value_kind * Ident.t * lambda * lambda
+  | Lmutlet of value_kind * Ident.t * lambda * lambda
   | Lletrec of (Ident.t * lambda) list * lambda
   | Lprim of primitive * lambda list * scoped_location
   | Lswitch of lambda * lambda_switch * scoped_location * value_kind

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3525,6 +3525,7 @@ let simple_for_let ~scopes value_kind loc param pat body =
 
 let rec map_return f = function
   | Llet (str, k, id, l1, l2) -> Llet (str, k, id, l1, map_return f l2)
+  | Lmutlet (k, id, l1, l2) -> Lmutlet (k, id, l1, map_return f l2)
   | Lletrec (l1, l2) -> Lletrec (l1, map_return f l2)
   | Lifthenelse (lcond, lthen, lelse, k) ->
       Lifthenelse (lcond, map_return f lthen, map_return f lelse, k)

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3552,8 +3552,8 @@ let rec map_return f = function
           Option.map (map_return f) def,
           loc, k )
   | (Lstaticraise _ | Lprim (Praise _, _, _)) as l -> l
-  | ( Lvar _ | Lconst _ | Lapply _ | Lfunction _ | Lsend _ | Lprim _ | Lwhile _
-    | Lfor _ | Lassign _ | Lifused _ ) as l ->
+  | ( Lvar _ | Lmutvar _ | Lconst _ | Lapply _ | Lfunction _ | Lsend _ | Lprim _
+    | Lwhile _ | Lfor _ | Lassign _ | Lifused _ ) as l ->
       f l
   | Lregion l -> Lregion (map_return f l)
 

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -605,6 +605,8 @@ let apply_kind name pos mode =
 let rec lam ppf = function
   | Lvar id ->
       Ident.print ppf id
+  | Lmutvar id ->
+      fprintf ppf "*%a" Ident.print id
   | Lconst cst ->
       struct_const ppf cst
   | Lapply ap ->
@@ -638,7 +640,7 @@ let rec lam ppf = function
         (alloc_kind mode) pr_params params
         function_attribute attr return_kind (rmode, return) lam body
   | Llet _ as expr ->
-      let kind = function
+     let kind = function
         Alias -> "a" | Strict -> "" | StrictOpt -> "o" | Variable -> "v"
       in
       let rec letbody ~sp = function

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -639,7 +639,6 @@ let rec lam ppf = function
       fprintf ppf "@[<2>(function%s%a@ %a%a%a)@]"
         (alloc_kind mode) pr_params params
         function_attribute attr return_kind (rmode, return) lam body
-
   | (Llet _ | Lmutlet _) as expr ->
       let let_kind = begin function
         | Llet(str,_,_,_,_) ->

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -641,7 +641,7 @@ let rec lam ppf = function
         function_attribute attr return_kind (rmode, return) lam body
   | Llet _ as expr ->
      let kind = function
-        Alias -> "a" | Strict -> "" | StrictOpt -> "o" | Variable -> "v"
+         Alias -> "a" | Strict -> "" | StrictOpt -> "o"
       in
       let rec letbody ~sp = function
         | Llet(str, k, id, arg, body) ->
@@ -653,6 +653,17 @@ let rec lam ppf = function
       in
       fprintf ppf "@[<2>(let@ @[<hv 1>(";
       let expr = letbody ~sp:false expr in
+      fprintf ppf ")@]@ %a)@]" lam expr
+  | Lmutlet(k, id, arg, body) ->
+      let rec letbody = function
+        | Lmutlet(k, id, arg, body) ->
+            fprintf ppf "@ @[<2>%a =%a@ %a@]"
+              Ident.print id value_kind k lam arg;
+            letbody body
+        | expr -> expr in
+      fprintf ppf "@[<2>(let[mut]@ @[<hv 1>(@[<2>%a =%a@ %a@]"
+        Ident.print id value_kind k lam arg;
+      let expr = letbody body in
       fprintf ppf ")@]@ %a)@]" lam expr
   | Lletrec(id_arg_list, body) ->
       let bindings ppf id_arg_list =

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -37,6 +37,8 @@ let rec eliminate_ref id = function
       else lam
   | Llet(str, kind, v, e1, e2) ->
       Llet(str, kind, v, eliminate_ref id e1, eliminate_ref id e2)
+  | Lmutlet(kind, v, e1, e2) ->
+      Lmutlet(kind, v, eliminate_ref id e1, eliminate_ref id e2)
   | Lletrec(idel, e2) ->
       Lletrec(List.map (fun (v, e) -> (v, eliminate_ref id e)) idel,
               eliminate_ref id e2)
@@ -128,7 +130,8 @@ let simplify_exits lam =
   | (Lvar _ | Lmutvar _ | Lconst _) -> ()
   | Lapply ap -> count ap.ap_func; List.iter count ap.ap_args
   | Lfunction {body} -> count body
-  | Llet(_str, _kind, _v, l1, l2) ->
+  | Llet(_, _kind, _v, l1, l2)
+  | Lmutlet(_kind, _v, l1, l2) ->
       count l2; count l1
   | Lletrec(bindings, body) ->
       List.iter (fun (_v, l) -> count l) bindings;
@@ -216,6 +219,7 @@ let simplify_exits lam =
   | Lfunction{kind; params; return; body = l; attr; loc; mode; region} ->
      Lfunction{kind; params; return; body=simplif l; attr; loc; mode; region}
   | Llet(str, kind, v, l1, l2) -> Llet(str, kind, v, simplif l1, simplif l2)
+  | Lmutlet(kind, v, l1, l2) -> Lmutlet(kind, v, simplif l1, simplif l2)
   | Lletrec(bindings, body) ->
       Lletrec(List.map (fun (v, l) -> (v, simplif l)) bindings, simplif body)
   | Lprim(p, ll, loc) -> begin
@@ -450,6 +454,8 @@ let simplify_lets lam =
       count (bind_var bv v) l2;
       (* If v is unused, l1 will be removed, so don't count its variables *)
       if str = Strict || count_var v > 0 then count bv l1
+  | Lmutlet(_kind, v, _l1, l2) ->
+      count (bind_var bv v) l2
   | Lletrec(bindings, body) ->
       List.iter (fun (_v, l) -> count bv l) bindings;
       count bv body
@@ -514,10 +520,17 @@ let simplify_lets lam =
 (* This (small)  optimisation is always legal, it may uncover some
    tail call later on. *)
 
-  let mklet str kind v e1 e2  = match e2 with
-  | Lvar w when optimize && Ident.same v w -> e1
-  | _ -> Llet (str, kind,v,e1,e2) in
+  let mklet str kind v e1 e2 =
+    match e2 with
+    | Lvar w when optimize && Ident.same v w -> e1
+    | _ -> Llet (str, kind,v,e1,e2)
+  in
 
+  let mkmutlet kind v e1 e2 =
+    match e2 with
+    | Lmutvar w when optimize && Ident.same v w -> e1
+    | _ -> Lmutlet (kind,v,e1,e2)
+  in
 
   let rec simplif = function
     Lvar v | Lmutvar v as l ->
@@ -575,7 +588,7 @@ let simplify_lets lam =
           | Some [field_kind] -> field_kind
           | Some _ -> assert false
         in
-        mklet Variable kind v slinit (eliminate_ref v slbody)
+        mkmutlet kind v slinit (eliminate_ref v slbody)
       with Real_reference ->
         mklet Strict kind v (Lprim(prim, [slinit], loc)) slbody
       end
@@ -591,6 +604,7 @@ let simplify_lets lam =
       | _ -> mklet StrictOpt kind v (simplif l1) (simplif l2)
       end
   | Llet(str, kind, v, l1, l2) -> mklet str kind v (simplif l1) (simplif l2)
+  | Lmutlet(kind, v, l1, l2) -> mkmutlet kind v (simplif l1) (simplif l2)
   | Lletrec(bindings, body) ->
       Lletrec(List.map (fun (v, l) -> (v, simplif l)) bindings, simplif body)
   | Lprim(p, ll, loc) -> Lprim(p, List.map simplif ll, loc)
@@ -663,7 +677,8 @@ let rec emit_tail_infos is_tail lambda =
       list_emit_tail_infos false ap.ap_args
   | Lfunction {body = lam} ->
       emit_tail_infos true lam
-  | Llet (_str, _k, _, lam, body) ->
+  | Llet (_, _k, _, lam, body)
+  | Lmutlet (_k, _, lam, body) ->
       emit_tail_infos false lam;
       emit_tail_infos is_tail body
   | Lletrec (bindings, body) ->

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -47,7 +47,7 @@ let rec eliminate_ref id = function
   | Lprim(Psetfield(0, _, _), [Lvar v; e], _) when Ident.same v id ->
       Lassign(id, eliminate_ref id e)
   | Lprim(Poffsetref delta, [Lvar v], loc) when Ident.same v id ->
-      Lassign(id, Lprim(Poffsetint delta, [Lvar id], loc))
+      Lassign(id, Lprim(Poffsetint delta, [Lmutvar id], loc))
   | Lprim(p, el, loc) ->
       Lprim(p, List.map (eliminate_ref id) el, loc)
   | Lswitch(e, sw, loc, kind) ->
@@ -535,13 +535,13 @@ let simplify_lets lam =
   in
 
   let rec simplif = function
-    Lvar v | Lmutvar v as l ->
+    Lvar v as l ->
       begin try
         Hashtbl.find subst v
       with Not_found ->
         l
       end
-  | Lconst _ as l -> l
+  | Lmutvar _ | Lconst _ as l -> l
   | Lapply ({ap_func = ll; ap_args = args} as ap) ->
       let no_opt () =
         Lapply {ap with ap_func = simplif ap.ap_func;

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -25,9 +25,9 @@ open Debuginfo.Scoped_location
 exception Real_reference
 
 let rec eliminate_ref id = function
-    Lvar v | Lmutvar v as lam ->
+    Lvar v as lam ->
       if Ident.same v id then raise Real_reference else lam
-  | Lconst _ as lam -> lam
+  | Lmutvar _ | Lconst _ as lam -> lam
   | Lapply ap ->
       Lapply{ap with ap_func = eliminate_ref id ap.ap_func;
                      ap_args = List.map (eliminate_ref id) ap.ap_args}
@@ -430,8 +430,9 @@ let simplify_lets lam =
 
   let rec count bv = function
   | Lconst _ -> ()
-  | Lvar v | Lmutvar v ->
-      use_var bv v 1
+  | Lvar v ->
+     use_var bv v 1
+  | Lmutvar _ -> ()
   | Lapply{ap_func = ll; ap_args = args} ->
       let no_opt () = count bv ll; List.iter (count bv) args in
       begin match ll with
@@ -454,8 +455,9 @@ let simplify_lets lam =
       count (bind_var bv v) l2;
       (* If v is unused, l1 will be removed, so don't count its variables *)
       if str = Strict || count_var v > 0 then count bv l1
-  | Lmutlet(_kind, v, _l1, l2) ->
-      count (bind_var bv v) l2
+  | Lmutlet(_kind, _v, l1, l2) ->
+     count bv l1;
+     count bv l2
   | Lletrec(bindings, body) ->
       List.iter (fun (_v, l) -> count bv l) bindings;
       count bv body

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -25,7 +25,7 @@ open Debuginfo.Scoped_location
 exception Real_reference
 
 let rec eliminate_ref id = function
-    Lvar v as lam ->
+    Lvar v | Lmutvar v as lam ->
       if Ident.same v id then raise Real_reference else lam
   | Lconst _ as lam -> lam
   | Lapply ap ->
@@ -41,9 +41,8 @@ let rec eliminate_ref id = function
       Lletrec(List.map (fun (v, e) -> (v, eliminate_ref id e)) idel,
               eliminate_ref id e2)
   | Lprim(Pfield (0, _sem), [Lvar v], _) when Ident.same v id ->
-      Lvar id
-  | Lprim(Psetfield(0, _, _), [Lvar v; e], _)
-    when Ident.same v id ->
+      Lmutvar id
+  | Lprim(Psetfield(0, _, _), [Lvar v; e], _) when Ident.same v id ->
       Lassign(id, eliminate_ref id e)
   | Lprim(Poffsetref delta, [Lvar v], loc) when Ident.same v id ->
       Lassign(id, Lprim(Poffsetint delta, [Lvar id], loc))
@@ -126,7 +125,7 @@ let simplify_exits lam =
   in
 
   let rec count = function
-  | (Lvar _| Lconst _) -> ()
+  | (Lvar _ | Lmutvar _ | Lconst _) -> ()
   | Lapply ap -> count ap.ap_func; List.iter count ap.ap_args
   | Lfunction {body} -> count body
   | Llet(_str, _kind, _v, l1, l2) ->
@@ -210,7 +209,7 @@ let simplify_exits lam =
   let subst = Hashtbl.create 17 in
 
   let rec simplif = function
-  | (Lvar _|Lconst _) as l -> l
+  | (Lvar _ | Lmutvar _ | Lconst _) as l -> l
   | Lapply ap ->
       Lapply{ap with ap_func = simplif ap.ap_func;
                      ap_args = List.map simplif ap.ap_args}
@@ -427,7 +426,7 @@ let simplify_lets lam =
 
   let rec count bv = function
   | Lconst _ -> ()
-  | Lvar v ->
+  | Lvar v | Lmutvar v ->
       use_var bv v 1
   | Lapply{ap_func = ll; ap_args = args} ->
       let no_opt () = count bv ll; List.iter (count bv) args in
@@ -521,7 +520,7 @@ let simplify_lets lam =
 
 
   let rec simplif = function
-    Lvar v as l ->
+    Lvar v | Lmutvar v as l ->
       begin try
         Hashtbl.find subst v
       with Not_found ->
@@ -640,6 +639,7 @@ let simplify_lets lam =
 let rec emit_tail_infos is_tail lambda =
   match lambda with
   | Lvar _ -> ()
+  | Lmutvar _ -> ()
   | Lconst _ -> ()
   | Lapply ap ->
       begin

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -689,7 +689,8 @@ let free_methods l =
     | Lsend _ -> ()
     | Lfunction{params} ->
         List.iter (fun (param, _) -> fv := Ident.Set.remove param !fv) params
-    | Llet(_str, _k, id, _arg, _body) ->
+    | Llet(_, _k, id, _arg, _body)
+    | Lmutlet(_k, id, _arg, _body) ->
         fv := Ident.Set.remove id !fv
     | Lletrec(decl, _body) ->
         List.iter (fun (id, _exp) -> fv := Ident.Set.remove id !fv) decl

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -700,7 +700,7 @@ let free_methods l =
     | Lfor {for_id} ->
         fv := Ident.Set.remove for_id !fv
     | Lassign _
-    | Lvar _ | Lconst _ | Lapply _
+    | Lvar _ | Lmutvar _ | Lconst _ | Lapply _
     | Lprim _ | Lswitch _ | Lstringswitch _ | Lstaticraise _
     | Lifthenelse _ | Lsequence _ | Lwhile _
     | Levent _ | Lifused _ | Lregion _ -> ()

--- a/lambda/translcomprehension.ml
+++ b/lambda/translcomprehension.ml
@@ -4,17 +4,28 @@ open Asttypes
 
 let int n = Lconst (Const_base (Const_int n))
 
+type let_kind_or_mut =
+  | Mutlet
+  | Let of let_kind
+
 type binding =
-  { let_kind : let_kind;
+  { let_kind : let_kind_or_mut;
     value_kind : value_kind;
     var : Ident.t;
     init : lambda }
 
 let binding let_kind value_kind var init =
-  {let_kind; value_kind; var; init}
+  {let_kind=Let let_kind; value_kind; var; init}
+
+let binding_mut value_kind var init =
+  {let_kind=Mutlet; value_kind; var; init}
 
 let gen_binding {let_kind; value_kind; var; init} body =
-  Llet(let_kind, value_kind, var, init, body)
+  match let_kind with
+  | Let let_kind ->
+    Llet(let_kind, value_kind, var, init, body)
+  | Mutlet ->
+    Lmutlet(value_kind, var, init, body)
 
 let gen_bindings bindings body =
   List.fold_right gen_binding bindings body
@@ -24,6 +35,12 @@ let valuekind_of_arraykind = function
   | Paddrarray | Pintarray -> Pintval
   | Pfloatarray -> Pfloatval
 
+(* Pgenarray results in a mutable variable that should be referenced with
+   Lmutvar *)
+let array_var ~kind array =
+  match kind with
+  | Pgenarray -> Lmutvar array
+  | (Pintarray | Paddrarray | Pfloatarray) -> Lvar array
 
 (* Translate a clause into some initialising bindings, a variable
    that will be bound to the number of iterations in the clause by
@@ -149,7 +166,7 @@ let make_array ~loc ~kind ~size ~array =
          replaced when an example value (to create the array) is known.
          That is also why the biding is a Variable. *)
       let init = Lprim(Pmakearray(Pgenarray, Immutable, alloc_heap), [], loc) in
-      binding Variable Pgenval array init
+      binding_mut Pgenval array init
   | Pintarray | Paddrarray ->
       let init = make_array_prim ~loc size (int 0) in
       binding Strict Pgenval array init
@@ -160,7 +177,7 @@ let make_array ~loc ~kind ~size ~array =
 (* Generate code to initialise an element of an "uninitialised" array *)
 let init_array_elem ~loc ~kind ~size ~array ~index ~value =
   let set_elem =
-    Lprim(Parraysetu kind, [Lvar array; Lvar index; Lvar value], loc)
+    Lprim(Parraysetu kind, [array_var ~kind array; Lvar index; Lvar value], loc)
   in
   match kind with
   | Pgenarray ->
@@ -175,13 +192,14 @@ let init_array_elem ~loc ~kind ~size ~array ~index ~value =
 
 (* Generate code to blit elements into an "uninitialised" array *)
 let init_array_elems ~loc ~kind ~size ~array ~index ~src ~len =
+  let array_var = array_var ~kind array in
   let blit =
-    blit_array_prim ~loc (Lvar src) (int 0) (Lvar array) (Lvar index) (Lvar len)
+    blit_array_prim ~loc (Lvar src) (int 0) array_var (Lmutvar index) (Lvar len)
   in
   match kind with
   | Pgenarray ->
       let is_first_iteration =
-        Lprim(Pintcomp Ceq, [Lvar index; int 0], loc)
+        Lprim(Pintcomp Ceq, [Lmutvar index; int 0], loc)
       in
       let is_not_empty =
         Lprim(Pintcomp(Cne), [Lvar len; int 0], loc)
@@ -201,11 +219,11 @@ let init_array_elems ~loc ~kind ~size ~array ~index ~src ~len =
 
 (* Binding for a counter *)
 let make_counter counter =
-  binding Variable Pintval counter (int 0)
+  binding_mut Pintval counter (int 0)
 
 (* Code to increment a counter *)
 let increment_counter ~loc counter step =
-  Lassign(counter, Lprim(Paddint, [Lvar counter; step], loc))
+  Lassign(counter, Lprim(Paddint, [Lmutvar counter; step], loc))
 
 type block_lambda =
   | Without_size of { body : lambda }
@@ -219,16 +237,17 @@ let transl_arr_block ~transl_exp ~loc ~scopes
     | Without_size _ -> Lvar length_var
     | With_size _ -> Lprim(Pmulint, [Lvar length_var; int 2], loc)
   in
-  let result_array_var = Ident.create_local "arr" in
+  let result_array_name = Ident.create_local "arr" in
+  let result_array_var = array_var ~kind:array_kind result_array_name in
   let result_array_binding =
-    make_array ~loc ~kind:array_kind ~size ~array:result_array_var
+    make_array ~loc ~kind:array_kind ~size ~array:result_array_name
   in
   let counter_var = Ident.create_local "counter" in
   let counter_binding = make_counter counter_var in
   let elem_var = Ident.create_local "elem" in
   let init_elem =
     init_array_elem ~loc ~kind:array_kind ~size
-      ~array:result_array_var ~index:counter_var ~value:elem_var
+      ~array:result_array_name ~index:counter_var ~value:elem_var
   in
   let set_result =
     match body with
@@ -239,8 +258,8 @@ let transl_arr_block ~transl_exp ~loc ~scopes
         let elem_len_var = Ident.create_local "len" in
         let set_len =
           Lprim(Parraysetu Paddrarray,
-            [Lvar result_array_var;
-             Lprim(Paddint, [Lvar counter_var; int 1], loc);
+            [result_array_var;
+             Lprim(Paddint, [Lmutvar counter_var; int 1], loc);
              Lvar elem_len_var], loc)
         in
         Lstaticcatch(body,
@@ -260,21 +279,22 @@ let transl_arr_block ~transl_exp ~loc ~scopes
     | Some global_counter_var ->
       let len =
         match body with
-        | Without_size _ -> Lvar counter_var
-        | With_size _ -> Lprim(Pdivint Unsafe, [Lvar counter_var; int 2], loc)
+        | Without_size _ -> Lmutvar counter_var
+        | With_size _ ->
+          Lprim(Pdivint Unsafe, [Lmutvar counter_var; int 2], loc)
       in
       Lsequence(loops, increment_counter ~loc global_counter_var len)
   in
   match block.guard with
   | None ->
       let body =
-        gen_bindings bindings (Lsequence(body, Lvar result_array_var))
+        gen_bindings bindings (Lsequence(body, result_array_var))
       in
       Without_size { body }
   | Some _ ->
       let raise_count = next_raise_count () in
       let return =
-        Lstaticraise(raise_count, [Lvar result_array_var; Lvar counter_var])
+        Lstaticraise(raise_count, [result_array_var; Lmutvar counter_var])
       in
       let body =
         gen_bindings bindings (Lsequence(body, return))
@@ -308,9 +328,10 @@ type intermediate_array_shape =
   | Array_of_filtered_arrays of intermediate_array_shape
 
 let concat_arrays ~loc arr kind shape global_count_var =
-  let res_var = Ident.create_local "res" in
+  let res_name = Ident.create_local "res" in
+  let res_var = array_var ~kind res_name in
   let res_binding =
-    make_array ~loc ~kind ~size:(Lvar global_count_var) ~array:res_var
+    make_array ~loc ~kind ~size:(Lmutvar global_count_var) ~array:res_name
   in
   let counter_var = Ident.create_local "counter" in
   let counter_binding = make_counter counter_var in
@@ -333,8 +354,8 @@ let concat_arrays ~loc arr kind shape global_count_var =
     | Array_of_elements ->
         gen_bindings bindings
           (Lsequence(
-             init_array_elems ~loc ~kind ~size:(Lvar global_count_var)
-               ~array:res_var ~index:counter_var ~src:arr_var ~len:len_var,
+             init_array_elems ~loc ~kind ~size:(Lmutvar global_count_var)
+               ~array:res_name ~index:counter_var ~src:arr_var ~len:len_var,
              increment_counter ~loc counter_var (Lvar len_var)))
     | Array_of_arrays shape ->
         let index_var = Ident.create_local "index" in
@@ -385,7 +406,7 @@ let concat_arrays ~loc arr kind shape global_count_var =
              (gen_binding counter_binding
                 (Lsequence
                    (loop shape array_var None,
-                    Lvar res_var))))
+                    res_var))))
   | With_size { body; raise_count } ->
       let array_var = Ident.create_local "array" in
       let len_var = Ident.create_local "len" in
@@ -395,7 +416,7 @@ let concat_arrays ~loc arr kind shape global_count_var =
              (gen_binding counter_binding
                 ((Lsequence
                     (loop shape array_var (Some len_var),
-                     Lvar res_var)))), Pgenval)
+                     res_var)))), Pgenval)
 
 let transl_arr_comprehension ~transl_exp ~loc ~scopes
       ~array_kind exp blocks =

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -116,7 +116,7 @@ let transl_apply_position position =
 
 let may_allocate_in_region lam =
   let rec loop = function
-    | Lvar _ | Lconst _ -> ()
+    | Lvar _ | Lmutvar _ | Lconst _ -> ()
 
     | Lfunction {mode=Alloc_heap} -> ()
     | Lfunction {mode=Alloc_local} -> raise Exit
@@ -138,7 +138,7 @@ let may_allocate_in_region lam =
     | Lwhile _ -> ()
     | Lfor {for_region=false} -> raise Exit
     | Lfor {for_from; for_to} -> loop for_from; loop for_to
-    | ( Lapply _ | Llet _ | Lletrec _ | Lswitch _ | Lstringswitch _
+    | ( Lapply _ | Llet _ | Lmutlet _ | Lletrec _ | Lswitch _ | Lstringswitch _
       | Lstaticraise _ | Lstaticcatch _ | Ltrywith _
       | Lifthenelse _ | Lsequence _ | Lassign _ | Lsend _
       | Levent _ | Lifused _) as lam ->

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -1134,23 +1134,24 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
        Value_unknown)
   | Llet(str, kind, id, lam, body) ->
       let (ulam, alam) = close_named env id lam in
-      begin match (str, alam) with
-        (Variable, _) ->
-          let env = {env with mutable_vars = V.Set.add id env.mutable_vars} in
-          let (ubody, abody) = close env body in
-          (Ulet(Mutable, kind, VP.create id, ulam, ubody), abody)
-      | (_, Value_const _)
-        when str = Alias || is_pure ulam ->
-          close { backend; fenv = (V.Map.add id alam fenv); cenv; mutable_vars }
-            body
-      | (_, _) ->
-          let (ubody, abody) =
-            close
-              { backend; fenv = (V.Map.add id alam fenv); cenv; mutable_vars }
-              body
-          in
-          (Ulet(Immutable, kind, VP.create id, ulam, ubody), abody)
+      begin match alam with
+        Value_const _
+           when str = Alias || is_pure ulam ->
+         close { backend; fenv = (V.Map.add id alam fenv); cenv; mutable_vars }
+           body
+      | _ ->
+         let (ubody, abody) =
+           close
+             { backend; fenv = (V.Map.add id alam fenv); cenv; mutable_vars }
+             body
+         in
+         (Ulet(Immutable, kind, VP.create id, ulam, ubody), abody)
       end
+  | Lmutlet(kind, id, lam, body) ->
+     let (ulam, _) = close_named env id lam in
+     let env = {env with mutable_vars = V.Set.add id env.mutable_vars} in
+     let (ubody, abody) = close env body in
+     (Ulet(Mutable, kind, VP.create id, ulam, ubody), abody)
   | Lletrec(defs, body) ->
       if List.for_all
            (function (_id, Lfunction _) -> true | _ -> false)

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -948,8 +948,9 @@ let close_var env id =
 let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
   let module B = (val backend : Backend_intf.S) in
   match lam with
-  | Lvar id | Lmutvar id ->
-      close_approx_var env id
+  | Lvar id ->
+     close_approx_var env id
+  | Lmutvar id -> (Uvar id, Value_unknown)
   | Lconst cst ->
       let str ?(shared = true) cst =
         let name =

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -948,7 +948,7 @@ let close_var env id =
 let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
   let module B = (val backend : Backend_intf.S) in
   match lam with
-  | Lvar id ->
+  | Lvar id | Lmutvar id ->
       close_approx_var env id
   | Lconst cst ->
       let str ?(shared = true) cst =

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -177,16 +177,21 @@ let lambda_const_int i : Lambda.structured_constant =
 
 let rec close t env (lam : Lambda.lambda) : Flambda.t =
   match lam with
-  | Lvar id | Lmutvar id ->
-    begin match Env.find_var_exn env id with
-    | var -> Var var
-    | exception Not_found ->
-      match Env.find_mutable_var_exn env id with
-      | mut_var ->
-        name_expr (Read_mutable mut_var) ~name:Names.read_mutable
-      | exception Not_found ->
+  | Lvar id ->
+     begin match Env.find_var_exn env id with
+     | var -> Var var
+     | exception Not_found ->
         Misc.fatal_errorf "Closure_conversion.close: unbound identifier %a"
           Ident.print id
+     end
+  | Lmutvar id ->
+    begin match Env.find_mutable_var_exn env id with
+    | mut_var ->
+       name_expr (Read_mutable mut_var) ~name:Names.read_mutable
+    | exception Not_found ->
+       Misc.fatal_errorf
+         "Closure_conversion.close: unbound mutable identifier %a"
+         Ident.print id
     end
   | Lconst cst ->
     let cst, name = close_const t cst in

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -199,7 +199,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
     in
     let body = close t (Env.add_var env id var) body in
     Flambda.create_let var defining_expr body
-  | Llet (Variable, block_kind, id, defining_expr, body) ->
+  | Lmutlet (block_kind, id, defining_expr, body) ->
     let mut_var = Mutable_variable.create_with_same_name_as_ident id in
     let var = Variable.create_with_same_name_as_ident id in
     let defining_expr =

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -177,7 +177,7 @@ let lambda_const_int i : Lambda.structured_constant =
 
 let rec close t env (lam : Lambda.lambda) : Flambda.t =
   match lam with
-  | Lvar id ->
+  | Lvar id | Lmutvar id ->
     begin match Env.find_var_exn env id with
     | var -> Var var
     | exception Not_found ->


### PR DESCRIPTION
Pulling in [upstream PR 10090](https://github.com/ocaml/ocaml/pull/10090).

This is needed for let mutable, because it fixes bugs in how `lambda/simplif.ml` deals with mutable variables.  We initially thought we could get away with a small tweak to simplif to prevent a let binding like `let mutable x = .. in ..` from being substituted away.  But there are trickier cases where subsequent non-mutable lets whose bound variable is defined in terms of `x` are themselves substituted away (which is bad, as the programmer wanted the value of `x` at the place it was mentioned).  Preventing that requires tracking which variables are mutable in lambda, which is what this PR does, so we may as well just take all of it.

The backport was mostly straightforward, except that `translcomprehension.ml` needed a lot of work because it used the removed `Variable` let kind.  The printing of lets in `printlambda.ml` also needed manual merging.