### PR TITLE
Remove mode variables in ocamlc -i

### DIFF
--- a/testsuite/tests/typing-ocamlc-i/local.compilers.reference
+++ b/testsuite/tests/typing-ocamlc-i/local.compilers.reference
@@ -1,0 +1,2 @@
+val f : 'a ref -> 'a
+val g : unit -> int

--- a/testsuite/tests/typing-ocamlc-i/local.ml
+++ b/testsuite/tests/typing-ocamlc-i/local.ml
@@ -1,0 +1,9 @@
+(* TEST
+flags = "-i -extension local"
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+*** check-ocamlc.byte-output
+*)
+
+let f r = !r
+let g () = 1 + f (ref 42)

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2768,6 +2768,7 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
         type_structure initial_env ast in
       let simple_sg = Signature_names.simplify finalenv names sg in
       if !Clflags.print_types then begin
+        remove_mode_variables finalenv sg;
         Typecore.force_delayed_checks ();
         Typecore.optimise_allocations ();
         Printtyp.wrap_printing_env ~error:false initial_env


### PR DESCRIPTION
The `ocamlc -i` mode, which prints the inferred signature of a module, is missing a call to `remove_mode_variables`. This means that the signature that it prints may have more local annotations than the signature that would be inferred by `ocamlc -c` (with no mli file), and this patch makes them agree again.