### PR TITLE
Add [@tail hint] annotation to select default behaviour explicitly

### DIFF
--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -140,6 +140,7 @@ val has_nonlocal: Parsetree.attributes -> bool
 (* These functions report Error if the builtin extension.* attributes
    are present despite the extension being disabled *)
 val has_local: Parsetree.attributes -> (bool,unit) result
-val tailcall : Parsetree.attributes -> ([`Tail|`Nontail] option, [`Conflict]) result
+val tailcall : Parsetree.attributes ->
+    ([`Tail|`Nontail|`Tail_if_possible] option, [`Conflict]) result
 val has_include_functor : Parsetree.attributes -> (bool,unit) result
 

--- a/testsuite/tests/basic-more/tailannots.ml
+++ b/testsuite/tests/basic-more/tailannots.ml
@@ -29,3 +29,32 @@ Line 2, characters 2-8:
       ^^^^^^
 Error: The tail-call annotation on this application is not on a tail call.
 |}]
+
+let bad_annot_3 () =
+  nop () [@tail hint] [@nontail];
+  nop ()
+[%%expect{|
+Line 2, characters 2-8:
+2 |   nop () [@tail hint] [@nontail];
+      ^^^^^^
+Error: The tail-call annotation on this application is contradictory.
+|}]
+
+let bad_annot_4 () =
+  nop () [@tail ajsdiof];
+  nop ()
+[%%expect{|
+Line 2, characters 9-24:
+2 |   nop () [@tail ajsdiof];
+             ^^^^^^^^^^^^^^^
+Warning 47 [attribute-payload]: illegal payload for attribute 'tail'.
+Only 'hint' is supported
+val bad_annot_4 : unit -> unit = <fun>
+|}]
+
+let good_annot_2 () =
+  nop () [@tail hint];
+  nop () [@tail hint]
+[%%expect{|
+val good_annot_2 : unit -> unit = <fun>
+|}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -235,8 +235,8 @@ let apply_position env (expected_mode : expected_mode) sexp : apply_position =
     Builtin_attributes.tailcall sexp.pexp_attributes,
     expected_mode.position
   with
-  | Ok None, Nontail -> Default
-  | Ok (None | Some `Tail), Tail -> Tail
+  | Ok (None | Some `Tail_if_possible), Nontail -> Default
+  | Ok (None | Some `Tail | Some `Tail_if_possible), Tail -> Tail
   | Ok (Some `Nontail), _ -> Nontail
   | Ok (Some `Tail), Nontail -> fail `Not_a_tailcall
   | Error `Conflict, _ -> fail `Conflict


### PR DESCRIPTION
This patch adds `[@tail_if_possible]`, which explicitly selects the current default tailcall behaviour (which may change with #40), but is not an error if used outside of tail position.

There is no reason for a programmer to ever write this annotation, since they're better off using `[@tail]` or `[@nontail]`. However, ppx generators such as `ppx_let` that may rely on tail-call behaviour can use this annotation to guarantee the current behaviour is preserved, without having to work out whether a given application is in tail position.