### PR TITLE
Replace var with local for faster mode checking

### DIFF
--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -118,7 +118,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                     expression (test_locations.ml[19,572+9]..test_locations.ml[19,572+20])
                       Texp_apply
                       apply_mode Default
-                      alloc_mode <modevar>
+                      alloc_mode global
                       expression (test_locations.ml[19,572+9]..test_locations.ml[19,572+12])
                         Texp_ident "fib"
                       [
@@ -127,7 +127,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                           expression (test_locations.ml[19,572+13]..test_locations.ml[19,572+20])
                             Texp_apply
                             apply_mode Default
-                            alloc_mode <modevar>
+                            alloc_mode global
                             expression (test_locations.ml[19,572+16]..test_locations.ml[19,572+17])
                               Texp_ident "Stdlib!.-"
                             [
@@ -146,7 +146,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                     expression (test_locations.ml[19,572+23]..test_locations.ml[19,572+34])
                       Texp_apply
                       apply_mode Default
-                      alloc_mode <modevar>
+                      alloc_mode global
                       expression (test_locations.ml[19,572+23]..test_locations.ml[19,572+26])
                         Texp_ident "fib"
                       [
@@ -155,7 +155,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                           expression (test_locations.ml[19,572+27]..test_locations.ml[19,572+34])
                             Texp_apply
                             apply_mode Default
-                            alloc_mode <modevar>
+                            alloc_mode global
                             expression (test_locations.ml[19,572+30]..test_locations.ml[19,572+31])
                               Texp_ident "Stdlib!.-"
                             [

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -105,7 +105,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
             <case>
               pattern (test_locations.ml[19,572+4]..test_locations.ml[19,572+5])
                 Tpat_var "n"
-                alloc_mode <modevar>
+                alloc_mode global
               expression (test_locations.ml[19,572+9]..test_locations.ml[19,572+34])
                 Texp_apply
                 apply_mode Tail

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -118,7 +118,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                     expression 
                       Texp_apply
                       apply_mode Default
-                      alloc_mode <modevar>
+                      alloc_mode global
                       expression 
                         Texp_ident "fib"
                       [
@@ -127,7 +127,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                           expression 
                             Texp_apply
                             apply_mode Default
-                            alloc_mode <modevar>
+                            alloc_mode global
                             expression 
                               Texp_ident "Stdlib!.-"
                             [
@@ -146,7 +146,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                     expression 
                       Texp_apply
                       apply_mode Default
-                      alloc_mode <modevar>
+                      alloc_mode global
                       expression 
                         Texp_ident "fib"
                       [
@@ -155,7 +155,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                           expression 
                             Texp_apply
                             apply_mode Default
-                            alloc_mode <modevar>
+                            alloc_mode global
                             expression 
                               Texp_ident "Stdlib!.-"
                             [

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -105,7 +105,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
             <case>
               pattern 
                 Tpat_var "n"
-                alloc_mode <modevar>
+                alloc_mode global
               expression 
                 Texp_apply
                 apply_mode Tail

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -760,10 +760,10 @@ let baduse (f : _ -> _ -> _) x y = lazy (f x y)
 let result = baduse (fun a b -> local_ (a,b)) 1 2
 [%%expect{|
 val baduse : ('a -> 'b -> 'c) -> 'a -> 'b -> 'c lazy_t = <fun>
-Line 2, characters 32-44:
+Line 2, characters 20-45:
 2 | let result = baduse (fun a b -> local_ (a,b)) 1 2
-                                    ^^^^^^^^^^^^
-Error: This value escapes its region
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This function is local returning, which mismatches with the type signature
 |}]
 
 
@@ -1403,10 +1403,10 @@ val foo : unit -> local_ string = <fun>
 
 let foo : unit -> string = fun () -> local_ "hello"
 [%%expect{|
-Line 1, characters 37-51:
+Line 1, characters 27-51:
 1 | let foo : unit -> string = fun () -> local_ "hello"
-                                         ^^^^^^^^^^^^^^
-Error: This value escapes its region
+                               ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This function is local returning, which mismatches with the type signature
 |}]
 
 (* Unboxed type constructors do not affect regionality *)

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -763,7 +763,7 @@ val baduse : ('a -> 'b -> 'c) -> 'a -> 'b -> 'c lazy_t = <fun>
 Line 2, characters 20-45:
 2 | let result = baduse (fun a b -> local_ (a,b)) 1 2
                         ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This function is local returning, which mismatches with the type signature
+Error: This function is local returning, but was expected otherwise
 |}]
 
 
@@ -1406,7 +1406,7 @@ let foo : unit -> string = fun () -> local_ "hello"
 Line 1, characters 27-51:
 1 | let foo : unit -> string = fun () -> local_ "hello"
                                ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This function is local returning, which mismatches with the type signature
+Error: This function is local returning, but was expected otherwise
 |}]
 
 (* Unboxed type constructors do not affect regionality *)

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -315,7 +315,7 @@ type escaping_context =
   | Partial_application
 
 type value_lock =
-  | Lock of { mode : Value_mode.t; escaping_context : escaping_context option }
+  | Lock of { mode : Alloc_mode.t; escaping_context : escaping_context option }
   | Region_lock
 
 module IdTbl =
@@ -2852,7 +2852,7 @@ let lock_mode ~errors ~loc env id vmode locks =
       match lock with
       | Region_lock -> Value_mode.local_to_regional vmode
       | Lock {mode; escaping_context} ->
-          match Value_mode.submode vmode mode with
+          match Value_mode.submode vmode (Value_mode.of_alloc mode) with
           | Ok () -> vmode
           | Error _ ->
               may_lookup_error errors loc env

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -387,7 +387,7 @@ val enter_unbound_module : string -> module_unbound_reason -> t -> t
 
 (* Lock the environment *)
 
-val add_lock : ?escaping_context:escaping_context -> Types.value_mode -> t -> t
+val add_lock : ?escaping_context:escaping_context -> Types.alloc_mode -> t -> t
 val add_region_lock : t -> t
 
 (* Initialize the cache of in-core module interfaces. *)

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -967,8 +967,8 @@ and class_fields_second_pass cl_num sign met_env fields =
 and class_structure cl_num virt self_scope final val_env met_env loc
   { pcstr_self = spat; pcstr_fields = str } =
   (* Environment for substructures *)
-  let val_env = Env.add_lock Value_mode.global val_env in
-  let met_env = Env.add_lock Value_mode.global met_env in
+  let val_env = Env.add_lock Alloc_mode.global val_env in
+  let met_env = Env.add_lock Alloc_mode.global met_env in
   let par_env = met_env in
 
   (* Location of self. Used for locations of self arguments *)
@@ -1193,7 +1193,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
         Typecore.check_partial val_env pat.pat_type pat.pat_loc
           [{c_lhs = pat; c_guard = None; c_rhs = dummy}]
       in
-      let val_env' = Env.add_lock Value_mode.global val_env' in
+      let val_env' = Env.add_lock Alloc_mode.global val_env' in
       Ctype.raise_nongen_level ();
       let cl = class_expr cl_num val_env' met_env virt self_scope scl' in
       Ctype.end_def ();

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4000,9 +4000,6 @@ and type_expect_
        [Nolabel, sbody]) ->
       if txt = "extension.local" && not (Clflags.Extension.is_enabled Local) then
         raise (Typetexp.Error (loc, Env.empty, Unsupported_extension Local));
-      (* CR zqian: should copy `position` from expected_mode;
-        currently can't because would trigger a bug that causes false error about
-        tail call arguments escaping, in a local returning function. *)
       let mode = mode_exact Value_mode.local in
       if not (mode_cross env ty_expected) then
         submode ~loc ~env ~reason:Other mode.mode expected_mode;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -275,10 +275,21 @@ type expected_mode =
     escaping_context : Env.escaping_context option;
     (* the upper bound of mode*)
     mode : Value_mode.t;
-    (* in some scnearios, the above `mode` will be the exact mode of the typed
-    expression. For most allocations, they already use expected_mode.mode as
-    exact, because they want to be as local as possible anyway, so this bit can
-    be safely ignored.
+    (* in some scnearios, the above `mode` will be the exact mode of the
+        expression to be typed, indicated by the `exact` field.
+
+    - In any case, there is no risk of miscompilation in taking an upper bound
+    as exact. We might lose some range and trigger some false mode errors.
+
+    - Taking an exact as upper bound could cause issues. In particular
+    for the inner function of an uncurried function.
+
+
+    Therefore, if we just take it as exact regardless of the `exact`
+    field, we should be safe. Moreover, note that for most allocations, they
+    want to use expected_mode.mode as exact anyway, because that would be the
+    only constraint and they want to be as local as possible. The only exception
+    is uncurried functions where the mode constraints are tricky.
     *)
     exact : bool;
     tuple_modes : Value_mode.t list;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4001,7 +4001,7 @@ and type_expect_
 
       let mode = if mode_cross env ty_expected then begin
         (* when mode crosses, we check the inner expr with the most relaxed mode *)
-        {expected_mode with mode = Value_mode.local}
+        {expected_mode with mode = Value_mode.local; exact = false}
         (* moreover, because mode crosses, expected_mode is completely useless *)
       end else begin
         (* if mode does not cross, we require the inner expr to be exact local *)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4000,7 +4000,8 @@ and type_expect_
        [Nolabel, sbody]) ->
       if txt = "extension.local" && not (Clflags.Extension.is_enabled Local) then
         raise (Typetexp.Error (loc, Env.empty, Unsupported_extension Local));
-      let mode = mode_exact Value_mode.local in
+      (* note that we inherit position from expected_mode *)
+      let mode = {expected_mode with mode = Value_mode.local; exact = true} in
       if not (mode_cross env ty_expected) then
         submode ~loc ~env ~reason:Other mode.mode expected_mode;
       let exp =
@@ -5375,14 +5376,14 @@ and type_function ?in_function loc attrs env (expected_mode : expected_mode)
     else begin
       let ret_value_mode = Value_mode.of_alloc ret_mode in
       let ret_value_mode =
-        if region_locked then Value_mode.local_to_regional ret_value_mode
-        else ret_value_mode
+        if region_locked then mode_return (Value_mode.local_to_regional ret_value_mode)
+        else mode_nontail ret_value_mode
       in
       let ret_value_mode =
         if mode_cross env ty_res
-          then Value_mode.local else ret_value_mode
+          then mode_local else ret_value_mode
       in
-      mode_return ret_value_mode,
+      ret_value_mode,
       Final_arg { partial_mode = Alloc_mode.join [arg_mode; alloc_mode] }
     end
   in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3999,16 +3999,15 @@ and type_expect_
       if txt = "extension.local" && not (Clflags.Extension.is_enabled Local) then
         raise (Typetexp.Error (loc, Env.empty, Unsupported_extension Local));
 
-      let mode = if mode_cross env ty_expected then begin
+      let mode = if mode_cross env ty_expected then
         (* when mode crosses, we check the inner expr with the most relaxed mode *)
         {expected_mode with mode = Value_mode.local; exact = false}
         (* moreover, because mode crosses, expected_mode is completely useless *)
-      end else begin
-        (* if mode does not cross, we require the inner expr to be exact local *)
-        let mode = {expected_mode with mode = Value_mode.local; exact = true} in
-        (* morever, expected.mode must be local too *)
+      else begin
+        (* if mode does not cross, expected.mode must be local *)
         submode ~loc ~env ~reason:Other Value_mode.local expected_mode;
-        mode
+        (* and we require the inner expr to be exact local *)
+        {expected_mode with mode = Value_mode.local; exact = true}
       end
       in
       let exp =

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -257,8 +257,10 @@ type error =
   | Param_mode_mismatch of type_expr
   | Uncurried_function_escapes
   | Local_return_annotation_mismatch of Location.t
+  | Function_returns_local
   | Bad_tail_annotation of [`Conflict|`Not_a_tailcall]
   | Optional_poly_param
+
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2300,7 +2300,7 @@ and type_module_aux ~alias sttn funct_body anchor env smod =
           Named (id, param, mty), Types.Named (id, mty.mty_type), newenv,
           var, true
       in
-      let newenv = Env.add_lock Value_mode.global newenv in
+      let newenv = Env.add_lock Alloc_mode.global newenv in
       let body, body_shape = type_module true funct_body None newenv sbody in
       { mod_desc = Tmod_functor(t_arg, body);
         mod_type = Mty_functor(ty_arg, body.mod_type);


### PR DESCRIPTION
During type checking there were several places where the returning value's mode can be relaxed to `local`, thus making mode checking faster.