### PR TITLE
Enable support for Jane Street's internal Merlin configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -295,3 +295,5 @@ _build
 /.for-jane-street-merlin/
 /.merlin-binaries
 /.ocaml-lib
+/.local-merlin-binaries
+/.local-ocaml-lib

--- a/.gitignore
+++ b/.gitignore
@@ -291,3 +291,7 @@ _build
 
 /otherlibs/dynlink/natdynlinkops
 
+# Jane Street Merlin support
+/.for-jane-street-merlin/
+/.merlin-binaries
+/.ocaml-lib

--- a/.ocaml-bin
+++ b/.ocaml-bin
@@ -1,0 +1,1 @@
+Stub for Jane Street .merlin-binaries search

--- a/Makefile.common-jst
+++ b/Makefile.common-jst
@@ -2,6 +2,9 @@
 # Build rules common to ocaml-jst and flambda-backend
 #
 
+# Get Merlin along with any Dune command
+dune := '$(CURDIR)/jane-street-merlin-setup.sh' ; '$(dune)'
+
 ws_boot   = --root=. --workspace=duneconf/boot.ws
 ws_runstd = --root=. --workspace=duneconf/runtime_stdlib.ws
 ws_main   = --root=. --workspace=duneconf/main.ws

--- a/jane-street-merlin-setup.sh
+++ b/jane-street-merlin-setup.sh
@@ -12,17 +12,16 @@ fi
 set -e
 
 merlin_dir="$(dirname "$ocamlmerlin")"
+echo "$merlin_dir" > .local-merlin-binaries
+ocamlc -where > .local-ocaml-lib
 
-# The stub files `jenga.conf` and `.ocaml-lib` should be deleted if
-# `.local-merlin-binaries` exists or if the `.merlin-binaries` search ever stops
-# looking for a tree file first.
+# When `.local-merlin-binaries` is fully supported (rather than just supported
+# in dev Emacs), we can drop the extra directory `.for-jane-street-merlin` as
+# well as the stub `jenga.conf` file.
 
-# When `.local-merlin-binaries` is fully supported we can just point it at
-# `$MERLIN_DIR` and drop this extra directory *and* the stub files entirely.
-# This will require updating the `.gitignore`, too.
 mkdir -p .for-jane-street-merlin
 ln -sfn "$merlin_dir" .for-jane-street-merlin/dev
 ln -sfn "$merlin_dir" .for-jane-street-merlin/prod
 
 echo "$PWD/.for-jane-street-merlin" > .merlin-binaries
-ocamlc -where > .ocaml-lib
+cp .local-ocaml-lib .ocaml-lib

--- a/jane-street-merlin-setup.sh
+++ b/jane-street-merlin-setup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+cd "$(dirname "$0")"
+
+ocamlmerlin="$(which ocamlmerlin 2>&-)"
+ocamlmerlin_status=$?
+if [[ $ocamlmerlin_status -ne 0 ]]; then
+  echo >&2 'No ocamlmerlin on $PATH'
+  exit $ocamlmerlin_status
+fi
+
+set -e
+
+merlin_dir="$(dirname "$ocamlmerlin")"
+
+# The stub files `jenga.conf` and `.ocaml-lib` should be deleted if
+# `.local-merlin-binaries` exists or if the `.merlin-binaries` search ever stops
+# looking for a tree file first.
+
+# When `.local-merlin-binaries` is fully supported we can just point it at
+# `$MERLIN_DIR` and drop this extra directory *and* the stub files entirely.
+# This will require updating the `.gitignore`, too.
+mkdir -p .for-jane-street-merlin
+ln -sfn "$merlin_dir" .for-jane-street-merlin/dev
+ln -sfn "$merlin_dir" .for-jane-street-merlin/prod
+
+echo "$PWD/.for-jane-street-merlin" > .merlin-binaries
+ocamlc -config | grep standard_library: | cut -d' ' -f2 > .ocaml-lib

--- a/jane-street-merlin-setup.sh
+++ b/jane-street-merlin-setup.sh
@@ -25,4 +25,4 @@ ln -sfn "$merlin_dir" .for-jane-street-merlin/dev
 ln -sfn "$merlin_dir" .for-jane-street-merlin/prod
 
 echo "$PWD/.for-jane-street-merlin" > .merlin-binaries
-ocamlc -config | grep standard_library: | cut -d' ' -f2 > .ocaml-lib
+ocamlc -where > .ocaml-lib

--- a/jenga.conf
+++ b/jenga.conf
@@ -1,0 +1,1 @@
+Stub for Jane Street .merlin-binaries search


### PR DESCRIPTION
Now Jane Street internal developers can get Merlin within the compiler when building with `dune`.

Once we improve the internal tooling in a couple of ways (see comments) we can simplify some of the way this is done.

@stedolan: Why is `dune-project` only created from `dune-project.jst`?