### PR TITLE
temp fix for linker error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
 
           - name: i386
             config: CC='cc32' AS='as --32' ASPP='gcc -m32 -c' -host i386-linux PARTIALLD='ld -r -melf_i386'
-            os: ubuntu-latest
+            os: ubuntu-20.04
             ocamlparam: ''
             boot_config: CC='cc32' AS='as --32' ASPP='gcc -m32 -c' -host i386-linux PARTIALLD='ld -r -melf_i386'
             boot_cachekey: 32bit


### PR DESCRIPTION
This temporarily fixes the linker warning that's causing hundreds of tests to fail in CI for i386. https://github.com/ocaml-flambda/flambda-backend/pull/1014