### PR TITLE
Refactor the treatment of type variables

### DIFF
--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1376,14 +1376,14 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
          }
   | Pcl_constraint (scl', scty) ->
       Ctype.begin_class_def ();
-      let context = Typetexp.narrow () in
+      Typetexp.narrow ();
       let cl = class_expr cl_num val_env met_env virt self_scope scl' in
       complete_class_type cl.cl_loc val_env virt Class_type cl.cl_type;
-      Typetexp.widen context;
-      let context = Typetexp.narrow () in
+      Typetexp.widen ();
+      Typetexp.narrow ();
       let clty = class_type val_env virt self_scope scty in
       complete_class_type clty.cltyp_loc val_env virt Class clty.cltyp_type;
-      Typetexp.widen context;
+      Typetexp.widen ();
       Ctype.end_def ();
 
       Ctype.limited_generalize_class_type

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -259,9 +259,9 @@ let unify_delayed_method_type loc env label ty expected_ty=
       raise(Error(loc, env, Field_type_mismatch ("method", label, trace)))
 
 let type_constraint val_env sty sty' loc =
-  let cty  = transl_simple_type val_env false Global sty in
+  let cty  = transl_simple_type val_env ~fixed:false Global sty in
   let ty = cty.ctyp_type in
-  let cty' = transl_simple_type val_env false Global sty' in
+  let cty' = transl_simple_type val_env ~fixed:false Global sty' in
   let ty' = cty'.ctyp_type in
   begin
     try Ctype.unify val_env ty ty' with Ctype.Unify err ->
@@ -301,7 +301,7 @@ let rec class_type_field env sign self_scope ctf =
   | Pctf_val ({txt=lab}, mut, virt, sty) ->
       mkctf_with_attrs
         (fun () ->
-          let cty = transl_simple_type env false Global sty in
+          let cty = transl_simple_type env ~fixed:false Global sty in
           let ty = cty.ctyp_type in
           add_instance_variable ~strict:false loc env lab mut virt ty sign;
           Tctf_val (lab, mut, virt, cty))
@@ -325,7 +325,7 @@ let rec class_type_field env sign self_scope ctf =
                  ) :: !delayed_meth_specs;
                Tctf_method (lab, priv, virt, returned_cty)
            | _ ->
-               let cty = transl_simple_type env false Global sty in
+               let cty = transl_simple_type env ~fixed:false Global sty in
                let ty = cty.ctyp_type in
                add_method loc env lab priv virt ty sign;
                Tctf_method (lab, priv, virt, cty))
@@ -349,7 +349,7 @@ and class_signature virt env pcsig self_scope loc =
   (* Introduce a dummy method preventing self type from being closed. *)
   Ctype.add_dummy_method env ~scope:self_scope sign;
 
-  let self_cty = transl_simple_type env false Global sty in
+  let self_cty = transl_simple_type env ~fixed:false Global sty in
   let self_type = self_cty.ctyp_type in
   begin try
     Ctype.unify env self_type sign.csig_self
@@ -399,7 +399,7 @@ and class_type_aux env virt self_scope scty =
                                                    List.length styl)));
       let ctys = List.map2
         (fun sty ty ->
-          let cty' = transl_simple_type env false Global sty in
+          let cty' = transl_simple_type env ~fixed:false Global sty in
           let ty' = cty'.ctyp_type in
           begin
            try Ctype.unify env ty' ty with Ctype.Unify err ->
@@ -419,7 +419,7 @@ and class_type_aux env virt self_scope scty =
       cltyp (Tcty_signature clsig) typ
 
   | Pcty_arrow (l, sty, scty) ->
-      let cty = transl_simple_type env false Global sty in
+      let cty = transl_simple_type env ~fixed:false Global sty in
       let ty = cty.ctyp_type in
       let ty =
         if Btype.is_optional l
@@ -651,7 +651,7 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
       with_attrs
         (fun () ->
            if !Clflags.principal then Ctype.begin_def ();
-           let cty = Typetexp.transl_simple_type val_env false Global styp in
+           let cty = Typetexp.transl_simple_type val_env ~fixed:false Global styp in
            let ty = cty.ctyp_type in
            if !Clflags.principal then begin
              Ctype.end_def ();
@@ -725,7 +725,7 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
       with_attrs
         (fun () ->
            let sty = Ast_helper.Typ.force_poly sty in
-           let cty = transl_simple_type val_env false Global sty in
+           let cty = transl_simple_type val_env ~fixed:false Global sty in
            let ty = cty.ctyp_type in
            add_method loc val_env label.txt priv Virtual ty sign;
            let field =
@@ -765,7 +765,7 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
              | Some sty ->
                  let sty = Ast_helper.Typ.force_poly sty in
                  let cty' =
-                   Typetexp.transl_simple_type val_env false Global sty
+                   Typetexp.transl_simple_type val_env ~fixed:false Global sty
                  in
                  cty'.ctyp_type
            in
@@ -1073,7 +1073,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
       if Path.same decl.cty_path unbound_class then
         raise(Error(scl.pcl_loc, val_env, Unbound_class_2 lid.txt));
       let tyl = List.map
-          (fun sty -> transl_simple_type val_env false Global sty)
+          (fun sty -> transl_simple_type val_env ~fixed:false Global sty)
           styl
       in
       let (params, clty) =
@@ -1376,11 +1376,11 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
          }
   | Pcl_constraint (scl', scty) ->
       Ctype.begin_class_def ();
-      let cl = Typetexp.narrow_in (fun () ->
+      let cl = Typetexp.TyVarEnv.narrow_in (fun () ->
         let cl = class_expr cl_num val_env met_env virt self_scope scl' in
         complete_class_type cl.cl_loc val_env virt Class_type cl.cl_type;
         cl) in
-      let clty = Typetexp.narrow_in (fun () ->
+      let clty = Typetexp.TyVarEnv.narrow_in (fun () ->
         let clty = class_type val_env virt self_scope scty in
         complete_class_type clty.cltyp_loc val_env virt Class clty.cltyp_type;
         clty) in
@@ -1549,7 +1549,7 @@ let class_infos define_class kind
      constr_type, dummy_class)
     (res, env) =
 
-  reset_type_variables ();
+  TyVarEnv.reset ();
   Ctype.begin_class_def ();
 
   (* Introduce class parameters *)

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1376,14 +1376,14 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
          }
   | Pcl_constraint (scl', scty) ->
       Ctype.begin_class_def ();
-      Typetexp.narrow ();
-      let cl = class_expr cl_num val_env met_env virt self_scope scl' in
-      complete_class_type cl.cl_loc val_env virt Class_type cl.cl_type;
-      Typetexp.widen ();
-      Typetexp.narrow ();
-      let clty = class_type val_env virt self_scope scty in
-      complete_class_type clty.cltyp_loc val_env virt Class clty.cltyp_type;
-      Typetexp.widen ();
+      let cl = Typetexp.narrow_in (fun () ->
+        let cl = class_expr cl_num val_env met_env virt self_scope scl' in
+        complete_class_type cl.cl_loc val_env virt Class_type cl.cl_type;
+        cl) in
+      let clty = Typetexp.narrow_in (fun () ->
+        let clty = class_type val_env virt self_scope scty in
+        complete_class_type clty.cltyp_loc val_env virt Class clty.cltyp_type;
+        clty) in
       Ctype.end_def ();
 
       Ctype.limited_generalize_class_type

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -999,7 +999,7 @@ let solve_Ppat_construct ~refine env loc constr no_existentials
         let ty_args, ty_res, ty_ex =
           instance_constructor ?in_pattern constr in
         let equated_types = unify_res ty_res in
-        let ty_args_ty, ty_args_gf = List.split ty_args in 
+        let ty_args_ty, ty_args_gf = List.split ty_args in
         let ty_args_ty, existential_ctyp =
           solve_constructor_annotation env name_list sty ty_args_ty ty_ex in
         ty_args_ty, ty_args_gf, ty_res, equated_types, existential_ctyp
@@ -2020,7 +2020,7 @@ and type_pat_aux
       assert construction_not_used_in_counterexamples;
       type_pat Value sq expected_ty (fun q ->
         let ty_var, mode = solve_Ppat_alias ~refine env q in
-        let mode = mode_cross !env expected_ty mode in 
+        let mode = mode_cross !env expected_ty mode in
         let id =
           enter_variable ~is_as_variable:true loc name mode
             ty_var sp.ppat_attributes
@@ -3872,13 +3872,13 @@ and type_expect_
               (try unify_var env (newvar()) ty_arg
                with Unify _ -> assert false);
               ret_tvar (TypeSet.add ty seen) ty_fun
-          | Tvar _ -> 
-              let v = newvar () in 
-              let rt = get_level ty > get_level v in 
+          | Tvar _ ->
+              let v = newvar () in
+              let rt = get_level ty > get_level v in
               unify_var env v ty;
               rt
-          | _ -> 
-            let v = newvar () in 
+          | _ ->
+            let v = newvar () in
             unify_var env v ty;
             false
       in
@@ -3892,7 +3892,7 @@ and type_expect_
         end;
         let ty = instance funct.exp_type in
         end_def ();
-        let rt = wrap_trace_gadt_instances env (ret_tvar TypeSet.empty) ty in 
+        let rt = wrap_trace_gadt_instances env (ret_tvar TypeSet.empty) ty in
         rt, funct
       in
       let type_sfunct_args sfunct extra_args =
@@ -4263,7 +4263,7 @@ and type_expect_
       let to_unify = Predef.type_array ty in
       with_explanation (fun () ->
         unify_exp_types loc env to_unify (generic_instance ty_expected));
-      let argument_mode = expect_mode_cross env ty mode_global in 
+      let argument_mode = expect_mode_cross env ty mode_global in
       let argl =
         List.map
           (fun sarg -> type_expect env argument_mode sarg (mk_expected ty))
@@ -4674,7 +4674,7 @@ and type_expect_
       let ty = newvar() in
       (* remember original level *)
       begin_def ();
-      let context = Typetexp.narrow () in
+      Typetexp.narrow ();
       let modl, md_shape = !type_module env smodl in
       Mtype.lower_nongen (get_level ty) modl.mod_type;
       let pres =
@@ -4696,7 +4696,7 @@ and type_expect_
           in
           Some id, env
       in
-      Typetexp.widen context;
+      Typetexp.widen ();
       (* ideally, we should catch Expr_type_clash errors
          in type_expect triggered by escaping identifiers from the local module
          and refine them into Scoping_let_module errors
@@ -5224,8 +5224,8 @@ and type_function ?in_function loc attrs env (expected_mode : expected_mode)
       let ret_value_mode =
         if region_locked then Value_mode.local_to_regional ret_value_mode
         else ret_value_mode
-      in  
-      let ret_value_mode = mode_cross env ty_res ret_value_mode in 
+      in
+      let ret_value_mode = mode_cross env ty_res ret_value_mode in
       mode_return ret_value_mode,
       Final_arg { partial_mode = Alloc_mode.join [arg_mode; alloc_mode] }
     end
@@ -5881,9 +5881,9 @@ and type_application env app_loc expected_mode position funct funct_mode sargs r
         filter_arrow_mono env (instance funct.exp_type) Nolabel
       in
       if !Clflags.principal then begin
-        end_def (); 
+        end_def ();
         generalize_structure ty_res
-      end; 
+      end;
       let mode = mode_cross env ty_res (Value_mode.of_alloc mres) in
       submode ~loc:app_loc ~env
         mode expected_mode;
@@ -6075,7 +6075,7 @@ and type_unpacks ?(in_function : (Location.t * type_expr * bool) option)
   let extended_env, tunpacks =
     List.fold_left (fun (env, tunpacks) unpack ->
       begin_def ();
-      let context = Typetexp.narrow () in
+      Typetexp.narrow ();
       let modl, md_shape =
         !type_module env
           Ast_helper.(
@@ -6100,7 +6100,7 @@ and type_unpacks ?(in_function : (Location.t * type_expr * bool) option)
         Env.enter_module_declaration ~scope ~shape:md_shape
           unpack.tu_name.txt pres md env
       in
-      Typetexp.widen context;
+      Typetexp.widen ();
       env, (id, unpack.tu_name, pres, modl) :: tunpacks
     ) (env, []) unpacks
   in

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -293,10 +293,9 @@ let make_constructor env loc type_path type_params svars sargs sret_type =
         transl_constructor_arguments env None true sargs
       in
         targs, None, args, None
-  | Some sret_type ->
-      (* if it's a generalized constructor we must first narrow and
-         then widen so as to not introduce any new constraints *)
-      narrow ();
+  | Some sret_type -> narrow_in begin fun () ->
+      (* if it's a generalized constructor we must work in a narrowed
+         context so as to not introduce any new constraints *)
       reset_type_variables ();
       let univars, closed =
         match svars with
@@ -337,8 +336,8 @@ let make_constructor env loc type_path type_params svars sargs sret_type =
          Btype.iter_type_expr_cstr_args set_level args;
          set_level ret_type;
       end;
-      widen ();
       targs, Some tret_type, args, Some ret_type
+    end
 
 let transl_declaration env sdecl (id, uid) =
   (* Bind type parameters *)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -215,8 +215,8 @@ let transl_global_flags loc attrs =
     | Ok b -> b
     | Error () -> raise(Error(loc, Local_not_enabled))
   in
-  let global = transl_global_flag loc (Builtin_attributes.has_global attrs) in 
-  let nonlocal = transl_global_flag loc (Builtin_attributes.has_nonlocal attrs) in 
+  let global = transl_global_flag loc (Builtin_attributes.has_global attrs) in
+  let nonlocal = transl_global_flag loc (Builtin_attributes.has_nonlocal attrs) in
   match global, nonlocal with
   | true, true -> raise(Error(loc, Global_and_nonlocal))
   | true, false -> Types.Global
@@ -296,7 +296,7 @@ let make_constructor env loc type_path type_params svars sargs sret_type =
   | Some sret_type ->
       (* if it's a generalized constructor we must first narrow and
          then widen so as to not introduce any new constraints *)
-      let z = narrow () in
+      narrow ();
       reset_type_variables ();
       let univars, closed =
         match svars with
@@ -337,7 +337,7 @@ let make_constructor env loc type_path type_params svars sargs sret_type =
          Btype.iter_type_expr_cstr_args set_level args;
          set_level ret_type;
       end;
-      widen z;
+      widen ();
       targs, Some tret_type, args, Some ret_type
 
 let transl_declaration env sdecl (id, uid) =

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3037,10 +3037,11 @@ let type_package env m p fl =
   (* Same as Pexp_letmodule *)
   (* remember original level *)
   Ctype.begin_def ();
-  Typetexp.narrow ();
-  let modl, _mod_shape = type_module env m in
-  let scope = Ctype.create_scope () in
-  Typetexp.widen ();
+  let modl, scope = Typetexp.narrow_in begin fun () ->
+    let modl, _mod_shape = type_module env m in
+    let scope = Ctype.create_scope () in
+    modl, scope
+  end in
   let fl', env =
     match fl with
     | [] -> [], env

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3037,10 +3037,10 @@ let type_package env m p fl =
   (* Same as Pexp_letmodule *)
   (* remember original level *)
   Ctype.begin_def ();
-  let context = Typetexp.narrow () in
+  Typetexp.narrow ();
   let modl, _mod_shape = type_module env m in
   let scope = Ctype.create_scope () in
-  Typetexp.widen context;
+  Typetexp.widen ();
   let fl', env =
     match fl with
     | [] -> [], env

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3037,7 +3037,7 @@ let type_package env m p fl =
   (* Same as Pexp_letmodule *)
   (* remember original level *)
   Ctype.begin_def ();
-  let modl, scope = Typetexp.narrow_in begin fun () ->
+  let modl, scope = Typetexp.TyVarEnv.narrow_in begin fun () ->
     let modl, _mod_shape = type_module env m in
     let scope = Ctype.create_scope () in
     modl, scope
@@ -3534,4 +3534,4 @@ let () =
 let reset ~preserve_persistent_env =
   Env.reset_cache ~preserve_persistent_env;
   Envaux.reset_cache ~preserve_persistent_env;
-  Typetexp.reset_type_variables ()
+  Typetexp.TyVarEnv.reset ()

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -55,30 +55,59 @@ exception Error_forward of Location.error
 
 module TyVarEnv : sig
   val reset : unit -> unit
+  (* see mli file *)
+
   val is_in_scope : string -> bool
+
   val add : string -> type_expr -> unit
+  (* add a global type variable to the environment *)
 
   val narrow_in : (unit -> 'a) -> 'a
+  (* see mli file *)
 
   type poly_univars
   val with_univars : poly_univars -> (unit -> 'a) -> 'a
+  (* evaluate with a locally extended set of univars *)
+
   val make_poly_univars : string list -> poly_univars
+  (* see mli file *)
+
   val check_poly_univars : Env.t -> Location.t -> poly_univars -> type_expr list
+  (* see mli file *)
 
   type policy
-  val fixed_policy : policy
-  val extensible_policy : policy
-  val univars_policy : policy
+  val fixed_policy : policy (* no wildcards allowed *)
+  val extensible_policy : policy (* common case *)
+  val univars_policy : policy (* fresh variables are univars (in methods) *)
   val new_any_var : Location.t -> Env.t -> policy -> type_expr
+    (* create a new variable to represent a _; fails for fixed_policy *)
   val new_var : ?name:string -> policy -> type_expr
+    (* create a new variable according to the given policy *)
+
   val add_pre_univar : type_expr -> policy -> unit
+    (* remember that a variable might become a univar if it isn't unified *)
   val collect_pre_univars : (unit -> 'a) -> 'a * type_expr list
+    (* collect univars during a computation; returns the univars
+       postcondition: the returned type_exprs are all Tunivar *)
 
   val reset_locals : ?univars:poly_univars -> unit -> unit
+    (* clear out the local type variable env't; call this when starting
+       a new e.g. type signature. Optionally pass some univars that
+       are in scope. *)
+
   val lookup_local : string -> type_expr
+    (* look up a local type variable; throws Not_found if it isn't in scope *)
+
   val remember_used : string -> type_expr -> Location.t -> unit
+    (* remember that a given name is bound to a given type at a given location *)
+
   val globalize_used_variables : globals_only:bool -> Env.t ->
     fixed:bool -> unit -> unit
+    (* after finishing with a type signature, add used variables to the
+       global type variable scope; with globals_only, only already-in-scope
+       variables are considered (but they are still unified with the global
+       type variables *)
+
 end = struct
   (** Map indexed by type variable names. *)
   module TyVarMap = Misc.Stdlib.String.Map

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -27,7 +27,8 @@ open Ctype
 exception Already_bound
 
 type error =
-    Unbound_type_variable of string
+  | Unbound_type_variable of string * string list
+  | No_type_wildcards
   | Undefined_type_constructor of Path.t
   | Type_arity_mismatch of Longident.t * int * int
   | Bound_type_variable of string
@@ -52,8 +53,155 @@ type error =
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
-(** Map indexed by type variable names. *)
-module TyVarMap = Misc.Stdlib.String.Map
+module TyVarEnv : sig
+  val reset : unit -> unit
+  val is_in_scope : string -> bool
+  val add : string -> type_expr -> unit
+
+  val narrow_in : (unit -> 'a) -> 'a
+
+  type poly_univars
+  val new_pre_univar : ?name:string -> unit -> type_expr
+  val add_pre_univar : type_expr -> unit
+  val collect_pre_univars : (unit -> 'a) -> 'a * type_expr list
+
+  val with_univars : poly_univars -> (unit -> 'a) -> 'a
+  val make_poly_univars : string list -> poly_univars
+  val check_poly_univars : Env.t -> Location.t -> poly_univars -> type_expr list
+
+  val reset_locals : ?univars:poly_univars -> unit -> unit
+  val lookup_local : string -> type_expr
+  val remember_used : string -> type_expr -> Location.t -> unit
+  val globalize_used_variables : globals_only:bool -> Env.t ->
+    fixed:bool -> unit -> unit
+end = struct
+  (** Map indexed by type variable names. *)
+  module TyVarMap = Misc.Stdlib.String.Map
+
+  let type_variables = ref (TyVarMap.empty : type_expr TyVarMap.t)
+  let univars        = ref ([] : (string * type_expr) list)
+  let pre_univars    = ref ([] : type_expr list)
+  let used_variables = ref (TyVarMap.empty : (type_expr * Location.t) TyVarMap.t)
+
+  let reset () =
+    reset_global_level ();
+    Ctype.reset_reified_var_counter ();
+    type_variables := TyVarMap.empty
+
+  let is_in_scope name =
+    TyVarMap.mem name !type_variables
+
+  let add name v =
+    type_variables := TyVarMap.add name v !type_variables
+
+  let narrow_in f =
+    let old_gl = increase_global_level () in
+    let old_tv = !type_variables in
+    Fun.protect
+      f
+      ~finally:(fun () ->
+        restore_global_level old_gl;
+        type_variables := old_tv)
+
+  (* throws Not_found if the variable is not in scope *)
+  let lookup_global_type_variable name =
+    TyVarMap.find name !type_variables
+
+  let get_in_scope_names () =
+    let add_name name _ l = if name = "_" then l else ("'" ^ name) :: l in
+    TyVarMap.fold add_name !type_variables []
+
+  (*****)
+  type poly_univars = (string * type_expr) list
+
+  let add_pre_univar tv =
+    pre_univars := tv :: !pre_univars
+
+  let new_pre_univar ?name () =
+    let v = newvar ?name () in
+    add_pre_univar v;
+    v
+
+  let collect_pre_univars f =
+    pre_univars := [];
+    let result = f () in
+    let univs =
+      List.fold_left
+        (fun acc v ->
+           match get_desc v with
+           | Tvar name when get_level v = Btype.generic_level ->
+               set_type_desc v (Tunivar name);
+               v :: acc
+           | _ -> acc)
+        [] !pre_univars in
+    result, univs
+
+  let with_univars new_ones f =
+    let old_univars = !univars in
+    univars := new_ones @ !univars;
+    Fun.protect
+      f
+      ~finally:(fun () -> univars := old_univars)
+
+  let make_poly_univars vars =
+    List.map (fun name -> name, newvar ~name ()) vars
+
+  let check_poly_univars env loc vars =
+    vars |> List.iter (fun (_, v) -> generalize v);
+    vars |> List.map (fun (name, ty1) ->
+      let v = Btype.proxy ty1 in
+      begin match get_desc v with
+      | Tvar name when get_level v = Btype.generic_level ->
+         set_type_desc v (Tunivar name)
+      | _ ->
+         raise (Error (loc, env, Cannot_quantify(name, v)))
+      end;
+      v)
+
+  (*****)
+  let reset_locals ?univars:(uvs=[]) () =
+    univars := uvs;
+    used_variables := TyVarMap.empty
+
+  (* throws Not_found if the variable is not in scope *)
+  let lookup_local name =
+    let v =
+      try
+        List.assoc name !univars
+      with Not_found ->
+        fst (TyVarMap.find name !used_variables)
+    in
+    instance v
+
+  let remember_used name v loc =
+    used_variables := TyVarMap.add name (v, loc) !used_variables
+
+  let globalize_used_variables ~globals_only env ~fixed =
+    let r = ref [] in
+    TyVarMap.iter
+      (fun name (ty, loc) ->
+        if not globals_only || is_in_scope name then
+          let v = new_global_var () in
+          let snap = Btype.snapshot () in
+          if try unify env v ty; true with _ -> Btype.backtrack snap; false
+          then try
+            r := (loc, v, lookup_global_type_variable name) :: !r
+          with Not_found ->
+            if fixed && Btype.is_Tvar ty then
+              raise(Error(loc, env,
+                          Unbound_type_variable ("'"^name, get_in_scope_names ())));
+            let v2 = new_global_var () in
+            r := (loc, v, v2) :: !r;
+            add name v2)
+      !used_variables;
+    used_variables := TyVarMap.empty;
+    fun () ->
+      List.iter
+        (function (loc, t1, t2) ->
+          try unify env t1 t2 with Unify err ->
+            raise (Error(loc, env, Type_mismatch err)))
+        !r
+end
 
 (* Support for first-class modules. *)
 
@@ -88,24 +236,6 @@ let create_package_mty fake loc env (p, l) =
 
 (* Translation of type expressions *)
 
-let type_variables = ref (TyVarMap.empty : type_expr TyVarMap.t)
-let univars        = ref ([] : (string * type_expr) list)
-let pre_univars    = ref ([] : type_expr list)
-let used_variables = ref (TyVarMap.empty : (type_expr * Location.t) TyVarMap.t)
-
-let reset_type_variables () =
-  reset_global_level ();
-  Ctype.reset_reified_var_counter ();
-  type_variables := TyVarMap.empty
-
-let narrow_in f =
-  let old_gl = increase_global_level () in
-  let old_tv = !type_variables in
-  let result = f () in
-  restore_global_level old_gl;
-  type_variables := old_tv;
-  result
-
 let strict_ident c = (c = '_' || c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z')
 
 let validate_name = function
@@ -117,12 +247,6 @@ let new_global_var ?name () =
   new_global_var ?name:(validate_name name) ()
 let newvar ?name () =
   newvar ?name:(validate_name name) ()
-
-let type_variable loc name =
-  try
-    TyVarMap.find name !type_variables
-  with Not_found ->
-    raise(Error(loc, Env.empty, Unbound_type_variable ("'" ^ name)))
 
 let valid_tyvar_name name =
   name <> "" && name.[0] <> '_'
@@ -136,15 +260,13 @@ let transl_type_param env styp =
           ctyp_loc = loc; ctyp_attributes = styp.ptyp_attributes; }
   | Ptyp_var name ->
       let ty =
-        try
           if not (valid_tyvar_name name) then
             raise (Error (loc, Env.empty, Invalid_variable_name ("'" ^ name)));
-          ignore (TyVarMap.find name !type_variables);
-          raise Already_bound
-        with Not_found ->
+          if TyVarEnv.is_in_scope name then
+            raise Already_bound;
           let v = new_global_var ~name () in
-            type_variables := TyVarMap.add name v !type_variables;
-            v
+          TyVarEnv.add name v;
+          v
       in
         { ctyp_desc = Ttyp_var name; ctyp_type = ty; ctyp_env = env;
           ctyp_loc = loc; ctyp_attributes = styp.ptyp_attributes; }
@@ -177,27 +299,8 @@ let rec extract_params styp =
       (l, arg_mode, a) :: params, ret, ret_mode
   | _ -> final styp
 
-let new_pre_univar ?name () =
-  let v = newvar ?name () in pre_univars := v :: !pre_univars; v
-
-type poly_univars = (string * type_expr) list
-let make_poly_univars vars =
-  List.map (fun name -> name, newvar ~name ()) vars
-
-let check_poly_univars env loc vars =
-  vars |> List.iter (fun (_, v) -> generalize v);
-  vars |> List.map (fun (name, ty1) ->
-    let v = Btype.proxy ty1 in
-    begin match get_desc v with
-    | Tvar name when get_level v = Btype.generic_level ->
-       set_type_desc v (Tunivar name)
-    | _ ->
-       raise (Error (loc, env, Cannot_quantify(name, v)))
-    end;
-    v)
-
 let instance_poly_univars env loc vars =
-  let vs = check_poly_univars env loc vars in
+  let vs = TyVarEnv.check_poly_univars env loc vars in
   vs |> List.iter (fun v ->
     match get_desc v with
     | Tunivar name ->
@@ -229,9 +332,9 @@ and transl_type_aux env policy mode styp =
   match styp.ptyp_desc with
     Ptyp_any ->
       let ty =
-        if policy = Univars then new_pre_univar () else
+        if policy = Univars then TyVarEnv.new_pre_univar () else
           if policy = Fixed then
-            raise (Error (styp.ptyp_loc, env, Unbound_type_variable "_"))
+            raise (Error (styp.ptyp_loc, env, No_type_wildcards))
           else newvar ()
       in
       ctyp Ttyp_any ty
@@ -240,14 +343,12 @@ and transl_type_aux env policy mode styp =
       if not (valid_tyvar_name name) then
         raise (Error (styp.ptyp_loc, env, Invalid_variable_name ("'" ^ name)));
       begin try
-        instance (List.assoc name !univars)
-      with Not_found -> try
-        instance (fst (TyVarMap.find name !used_variables))
+        TyVarEnv.lookup_local name
       with Not_found ->
         let v =
-          if policy = Univars then new_pre_univar ~name () else newvar ~name ()
+          if policy = Univars then TyVarEnv.new_pre_univar ~name () else newvar ~name ()
         in
-        used_variables := TyVarMap.add name (v, styp.ptyp_loc) !used_variables;
+        TyVarEnv.remember_used name v styp.ptyp_loc;
         v
       end
     in
@@ -385,14 +486,14 @@ and transl_type_aux env policy mode styp =
           in
           (* NB: row is always non-static here; more is thus never Tnil *)
           let more =
-            if policy = Univars then new_pre_univar () else newvar () in
+            if policy = Univars then TyVarEnv.new_pre_univar () else newvar () in
           let row =
             create_row ~fields ~more
               ~closed:true ~fixed:None ~name:(Some (path, ty_args)) in
           newty (Tvariant row)
       | Tobject (fi, _) ->
           let _, tv = flatten_fields fi in
-          if policy = Univars then pre_univars := tv :: !pre_univars;
+          if policy = Univars then TyVarEnv.add_pre_univar tv;
           ty
       | _ ->
           assert false
@@ -401,11 +502,7 @@ and transl_type_aux env policy mode styp =
   | Ptyp_alias(st, alias) ->
       let cty =
         try
-          let t =
-            try List.assoc alias !univars
-            with Not_found ->
-              instance (fst(TyVarMap.find alias !used_variables))
-          in
+          let t = TyVarEnv.lookup_local alias in
           let ty = transl_type env policy mode st in
           begin try unify_var env t ty.ctyp_type with Unify err ->
             let err = Errortrace.swap_unification_error err in
@@ -415,8 +512,7 @@ and transl_type_aux env policy mode styp =
         with Not_found ->
           if !Clflags.principal then begin_def ();
           let t = newvar () in
-          used_variables :=
-            TyVarMap.add alias (t, styp.ptyp_loc) !used_variables;
+          TyVarEnv.remember_used alias t styp.ptyp_loc;
           let ty = transl_type env policy mode st in
           begin try unify_var env t ty.ctyp_type with Unify err ->
              let err = Errortrace.swap_unification_error err in
@@ -528,29 +624,28 @@ and transl_type_aux env policy mode styp =
       in
       let more =
         if Btype.static_row (make_row (newvar ())) then newty Tnil else
-        if policy = Univars then new_pre_univar () else newvar ()
+        if policy = Univars then TyVarEnv.new_pre_univar () else newvar ()
       in
       let ty = newty (Tvariant (make_row more)) in
       ctyp (Ttyp_variant (tfields, closed, present)) ty
   | Ptyp_poly(vars, st) ->
       let vars = List.map (fun v -> v.txt) vars in
       begin_def();
-      let new_univars = make_poly_univars vars in
-      let old_univars = !univars in
-      univars := new_univars @ !univars;
-      let cty = transl_type env policy mode st in
+      let new_univars = TyVarEnv.make_poly_univars vars in
+      let cty = TyVarEnv.with_univars new_univars begin fun () ->
+        transl_type env policy mode st
+      end in
       let ty = cty.ctyp_type in
-      univars := old_univars;
       end_def();
       generalize ty;
-      let ty_list = check_poly_univars env styp.ptyp_loc new_univars in
+      let ty_list = TyVarEnv.check_poly_univars env styp.ptyp_loc new_univars in
       let ty_list = List.filter (fun v -> deep_occur v ty) ty_list in
       let ty' = Btype.newgenty (Tpoly(ty, ty_list)) in
       unify_var env (newvar()) ty';
       ctyp (Ttyp_poly (vars, cty)) ty'
   | Ptyp_package (p, l) ->
       let l, mty = create_package_mty true styp.ptyp_loc env (p, l) in
-      let mty = narrow_in (fun () -> !transl_modtype env mty) in
+      let mty = TyVarEnv.narrow_in (fun () -> !transl_modtype env mty) in
       let ptys = List.map (fun (s, pty) ->
                              s, transl_type env policy Alloc_mode.Global pty
                           ) l in
@@ -626,7 +721,7 @@ and transl_fields env policy o fields =
   let ty_init =
      match o, policy with
      | Closed, _ -> newty Tnil
-     | Open, Univars -> new_pre_univar ()
+     | Open, Univars -> TyVarEnv.new_pre_univar ()
      | Open, _ -> newvar () in
   let ty = List.fold_left (fun ty (s, ty') ->
       newty (Tfield (s, field_public, ty', ty))) ty_init fields in
@@ -662,67 +757,31 @@ let make_fixed_univars ty =
 
 let create_package_mty = create_package_mty false
 
-let globalize_used_variables env fixed =
-  let r = ref [] in
-  TyVarMap.iter
-    (fun name (ty, loc) ->
-      let v = new_global_var () in
-      let snap = Btype.snapshot () in
-      if try unify env v ty; true with _ -> Btype.backtrack snap; false
-      then try
-        r := (loc, v,  TyVarMap.find name !type_variables) :: !r
-      with Not_found ->
-        if fixed && Btype.is_Tvar ty then
-          raise(Error(loc, env, Unbound_type_variable ("'"^name)));
-        let v2 = new_global_var () in
-        r := (loc, v, v2) :: !r;
-        type_variables := TyVarMap.add name v2 !type_variables)
-    !used_variables;
-  used_variables := TyVarMap.empty;
-  fun () ->
-    List.iter
-      (function (loc, t1, t2) ->
-        try unify env t1 t2 with Unify err ->
-          raise (Error(loc, env, Type_mismatch err)))
-      !r
-
-let transl_simple_type env ?univars:(uvs=[]) fixed mode styp =
-  univars := uvs; used_variables := TyVarMap.empty;
+let transl_simple_type env ?univars ~fixed mode styp =
+  TyVarEnv.reset_locals ?univars ();
   let typ = transl_type env (if fixed then Fixed else Extensible) mode styp in
-  globalize_used_variables env fixed ();
+  TyVarEnv.globalize_used_variables ~globals_only:false env ~fixed ();
   make_fixed_univars typ.ctyp_type;
   typ
 
 let transl_simple_type_univars env styp =
-  univars := []; used_variables := TyVarMap.empty; pre_univars := [];
-  begin_def ();
-  let typ = transl_type env Univars Alloc_mode.Global styp in
-  (* Only keep already global variables in used_variables *)
-  let new_variables = !used_variables in
-  used_variables := TyVarMap.empty;
-  TyVarMap.iter
-    (fun name p ->
-      if TyVarMap.mem name !type_variables then
-        used_variables := TyVarMap.add name p !used_variables)
-    new_variables;
-  globalize_used_variables env false ();
-  end_def ();
-  generalize typ.ctyp_type;
-  let univs =
-    List.fold_left
-      (fun acc v ->
-        match get_desc v with
-          Tvar name when get_level v = Btype.generic_level ->
-            set_type_desc v (Tunivar name); v :: acc
-        | _ -> acc)
-      [] !pre_univars
-  in
+  TyVarEnv.reset_locals ();
+  let typ, univs = TyVarEnv.collect_pre_univars begin fun () ->
+    begin_def ();
+    let typ = transl_type env Univars Alloc_mode.Global styp in
+    (* Globalize only local occurrences of variables that are already in global
+       scope; others will be univars and dealt with in make_fixed_univars. *)
+    TyVarEnv.globalize_used_variables ~globals_only:true env ~fixed:false ();
+    end_def ();
+    generalize typ.ctyp_type;
+    typ
+  end in
   make_fixed_univars typ.ctyp_type;
     { typ with ctyp_type =
         instance (Btype.newgenty (Tpoly (typ.ctyp_type, univs))) }
 
 let transl_simple_type_delayed env mode styp =
-  univars := []; used_variables := TyVarMap.empty;
+  TyVarEnv.reset_locals ();
   begin_def ();
   let typ = transl_type env Extensible mode styp in
   end_def ();
@@ -730,19 +789,19 @@ let transl_simple_type_delayed env mode styp =
   (* This brings the used variables to the global level, but doesn't link them
      to their other occurrences just yet. This will be done when [force] is
      called. *)
-  let force = globalize_used_variables env false in
+  let force = TyVarEnv.globalize_used_variables ~globals_only:false env ~fixed:false in
   (* Generalizes everything except the variables that were just globalized. *)
   generalize typ.ctyp_type;
   (typ, instance typ.ctyp_type, force)
 
 let transl_type_scheme env styp =
-  reset_type_variables();
+  TyVarEnv.reset ();
   match styp.ptyp_desc with
   | Ptyp_poly (vars, st) ->
      begin_def();
      let vars = List.map (fun v -> v.txt) vars in
-     let univars = make_poly_univars vars in
-     let typ = transl_simple_type env ~univars true Alloc_mode.Global st in
+     let univars = TyVarEnv.make_poly_univars vars in
+     let typ = transl_simple_type env ~univars ~fixed:true Alloc_mode.Global st in
      end_def();
      generalize typ.ctyp_type;
      let _ = instance_poly_univars env styp.ptyp_loc univars in
@@ -753,7 +812,7 @@ let transl_type_scheme env styp =
        ctyp_attributes = styp.ptyp_attributes }
   | _ ->
      begin_def();
-     let typ = transl_simple_type env false Alloc_mode.Global styp in
+     let typ = transl_simple_type env ~fixed:false Alloc_mode.Global styp in
      end_def();
      generalize typ.ctyp_type;
      typ
@@ -765,12 +824,12 @@ open Format
 open Printtyp
 
 let report_error env ppf = function
-  | Unbound_type_variable name ->
-      let add_name name _ l = if name = "_" then l else ("'" ^ name) :: l in
-      let names = TyVarMap.fold add_name !type_variables [] in
+  | Unbound_type_variable (name, in_scope_names) ->
     fprintf ppf "The type variable %s is unbound in this type declaration.@ %a"
       name
-      did_you_mean (fun () -> Misc.spellcheck names name )
+      did_you_mean (fun () -> Misc.spellcheck in_scope_names name )
+  | No_type_wildcards ->
+    fprintf ppf "A type wildcard \"_\" is not allowed here."
   | Undefined_type_constructor p ->
     fprintf ppf "The type constructor@ %a@ is not yet completely defined"
       path p

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -53,8 +53,8 @@ val transl_type_param:
 
 val get_alloc_mode : Parsetree.core_type -> alloc_mode_const
 
-val narrow: unit -> unit
-val widen: unit -> unit
+val narrow_in: (unit -> 'a) -> 'a
+  (* Evaluate in a narrowed type-variable scope *)
 
 exception Already_bound
 

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -17,23 +17,32 @@
 
 open Types
 
+module TyVarEnv : sig
+  val reset : unit -> unit
+  (* removes all type variables from scope *)
+
+  val narrow_in: (unit -> 'a) -> 'a
+  (* Evaluate in a narrowed type-variable scope *)
+
+  type poly_univars
+  val make_poly_univars : string list -> poly_univars
+    (* Create a set of univars with given names *)
+  val check_poly_univars :
+     Env.t -> Location.t -> poly_univars -> type_expr list
+    (* Verify that the given univars are universally quantified,
+       and return the list of variables. The type in which the
+       univars are used must be generalised *)
+end
+
 val valid_tyvar_name : string -> bool
 
-type poly_univars
-val make_poly_univars : string list -> poly_univars
-  (* Create a set of univars with given names *)
-val check_poly_univars :
-   Env.t -> Location.t -> poly_univars -> type_expr list
-  (* Verify that the given univars are universally quantified,
-     and return the list of variables. The type in which the
-     univars are used must be generalised *)
 val instance_poly_univars :
-   Env.t -> Location.t -> poly_univars -> type_expr list
+   Env.t -> Location.t -> TyVarEnv.poly_univars -> type_expr list
   (* Same as [check_poly_univars], but instantiates the resulting
      type scheme (i.e. variables become Tvar rather than Tunivar) *)
 
 val transl_simple_type:
-        Env.t -> ?univars:poly_univars -> bool -> alloc_mode_const
+        Env.t -> ?univars:TyVarEnv.poly_univars -> fixed:bool -> alloc_mode_const
         -> Parsetree.core_type -> Typedtree.core_type
 val transl_simple_type_univars:
         Env.t -> Parsetree.core_type -> Typedtree.core_type
@@ -46,20 +55,16 @@ val transl_simple_type_delayed
            function that binds the type variable. *)
 val transl_type_scheme:
         Env.t -> Parsetree.core_type -> Typedtree.core_type
-val reset_type_variables: unit -> unit
-val type_variable: Location.t -> string -> type_expr
 val transl_type_param:
   Env.t -> Parsetree.core_type -> Typedtree.core_type
 
 val get_alloc_mode : Parsetree.core_type -> alloc_mode_const
 
-val narrow_in: (unit -> 'a) -> 'a
-  (* Evaluate in a narrowed type-variable scope *)
-
 exception Already_bound
 
 type error =
-    Unbound_type_variable of string
+  | Unbound_type_variable of string * string list
+  | No_type_wildcards
   | Undefined_type_constructor of Path.t
   | Type_arity_mismatch of Longident.t * int * int
   | Bound_type_variable of string

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -53,9 +53,8 @@ val transl_type_param:
 
 val get_alloc_mode : Parsetree.core_type -> alloc_mode_const
 
-type variable_context
-val narrow: unit -> variable_context
-val widen: variable_context -> unit
+val narrow: unit -> unit
+val widen: unit -> unit
 
 exception Already_bound
 

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -18,18 +18,23 @@
 open Types
 
 module TyVarEnv : sig
+  (* this is just the subset of [TyVarEnv] that is needed outside
+     of [Typetexp]. See the ml file for more. *)
+
   val reset : unit -> unit
-  (* removes all type variables from scope *)
+  (** removes all type variables from scope *)
 
   val narrow_in: (unit -> 'a) -> 'a
-  (* Evaluate in a narrowed type-variable scope *)
+  (** Evaluate in a narrowed type-variable scope *)
 
   type poly_univars
   val make_poly_univars : string list -> poly_univars
-    (* Create a set of univars with given names *)
+    (** remember that a list of strings connotes univars; this must
+        always be paired with a [check_poly_univars]. *)
+
   val check_poly_univars :
      Env.t -> Location.t -> poly_univars -> type_expr list
-    (* Verify that the given univars are universally quantified,
+    (** Verify that the given univars are universally quantified,
        and return the list of variables. The type in which the
        univars are used must be generalised *)
 end


### PR DESCRIPTION
It seemed to me that the code for handling type variable environments was distributed across a bunch of space within Typetexp. So I gathered it all together and modularized it. There should be no change in behavior.

This PR comprises 5 commits, each expressing an independent idea. We can pick and choose which one(s) we want to keep.

If this looks good locally, I will upstream.