### PR TITLE
Make immediate64 things mode cross

### DIFF
--- a/testsuite/tests/typing-local/crossing.ml
+++ b/testsuite/tests/typing-local/crossing.ml
@@ -343,4 +343,16 @@ module M : sig type t [@@immediate] end
 type t2 = { x : int; } [@@unboxed]
 val f : local_ M.t -> M.t = <fun>
 val f : local_ t2 -> t2 = <fun>
-|}]  
+|}]
+
+
+(* Mode crossing works on immediate64 types *)
+module F (M : sig type t [@@immediate64] end) = struct
+  let f : local_ M.t -> _ = fun t -> t
+end
+
+[%%expect{|
+module F :
+  functor (M : sig type t [@@immediate64] end) ->
+    sig val f : local_ M.t -> M.t end
+|}]

--- a/testsuite/tests/typing-local/crossing.ml
+++ b/testsuite/tests/typing-local/crossing.ml
@@ -344,15 +344,3 @@ type t2 = { x : int; } [@@unboxed]
 val f : local_ M.t -> M.t = <fun>
 val f : local_ t2 -> t2 = <fun>
 |}]
-
-
-(* Mode crossing works on immediate64 types *)
-module F (M : sig type t [@@immediate64] end) = struct
-  let f : local_ M.t -> _ = fun t -> t
-end
-
-[%%expect{|
-module F :
-  functor (M : sig type t [@@immediate64] end) ->
-    sig val f : local_ M.t -> M.t end
-|}]

--- a/testsuite/tests/typing-local/crossing_64.ml
+++ b/testsuite/tests/typing-local/crossing_64.ml
@@ -1,0 +1,14 @@
+(* TEST
+ * arch64
+ ** expect *)
+
+(* Mode crossing works on immediate64 types *)
+module F (M : sig type t [@@immediate64] end) = struct
+  let f : local_ M.t -> _ = fun t -> t
+end
+
+[%%expect{|
+module F :
+  functor (M : sig type t [@@immediate64] end) ->
+    sig val f : local_ M.t -> M.t end
+|}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -559,7 +559,7 @@ let mode_cross env (ty : type_expr) mode =
   if is_principal ty then begin
     match immediacy env ty with
     | Type_immediacy.Always -> Value_mode.newvar ()
-    | Type_immediacy.Always_on_64bits when !Clflags.native_code && Sys.word_size = 64 ->
+    | Type_immediacy.Always_on_64bits when Sys.word_size = 64 ->
         Value_mode.newvar ()  (* floating and relaxed *)
     | _ -> mode
   end


### PR DESCRIPTION
This is only safe if we're sure we don't run bytecode on 64-bit platforms.