### PR TITLE
remove exp_mode from typedtree

### DIFF
--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -884,8 +884,8 @@ let transl_primitive_application loc p env ty mode path exp args arg_exps pos =
   in
   let has_constant_constructor =
     match arg_exps with
-    | [_; {exp_desc = Texp_construct(_, {cstr_tag = Cstr_constant _}, _)}]
-    | [{exp_desc = Texp_construct(_, {cstr_tag = Cstr_constant _}, _)}; _]
+    | [_; {exp_desc = Texp_construct(_, {cstr_tag = Cstr_constant _}, _, _)}]
+    | [{exp_desc = Texp_construct(_, {cstr_tag = Cstr_constant _}, _, _)}; _]
     | [_; {exp_desc = Texp_variant(_, None)}]
     | [{exp_desc = Texp_variant(_, None)}; _] -> true
     | _ -> false

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -87,9 +87,9 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
         pattern (test_locations.ml[17,534+8]..test_locations.ml[17,534+11])
           Tpat_var "fib"
         expression (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
-          value_mode global
           Texp_function
           region true
+          alloc_mode global
           Nolabel
           [
             <case>
@@ -100,80 +100,70 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                 pattern (test_locations.ml[18,557+8]..test_locations.ml[18,557+9])
                   Tpat_constant Const_int 1
               expression (test_locations.ml[18,557+13]..test_locations.ml[18,557+14])
-                value_mode global
                 Texp_constant Const_int 1
             <case>
               pattern (test_locations.ml[19,572+4]..test_locations.ml[19,572+5])
                 Tpat_var "n"
               expression (test_locations.ml[19,572+9]..test_locations.ml[19,572+34])
-                value_mode global
                 Texp_apply
                 apply_mode Tail
+                alloc_mode global
                 expression (test_locations.ml[19,572+21]..test_locations.ml[19,572+22])
-                  value_mode <modevar>
                   Texp_ident "Stdlib!.+"
                 [
                   <arg>
                     Nolabel
                     expression (test_locations.ml[19,572+9]..test_locations.ml[19,572+20])
-                      value_mode <modevar>
                       Texp_apply
                       apply_mode Default
+                      alloc_mode <modevar>
                       expression (test_locations.ml[19,572+9]..test_locations.ml[19,572+12])
-                        value_mode <modevar>
                         Texp_ident "fib"
                       [
                         <arg>
                           Nolabel
                           expression (test_locations.ml[19,572+13]..test_locations.ml[19,572+20])
-                            value_mode <modevar>
                             Texp_apply
                             apply_mode Default
+                            alloc_mode <modevar>
                             expression (test_locations.ml[19,572+16]..test_locations.ml[19,572+17])
-                              value_mode <modevar>
                               Texp_ident "Stdlib!.-"
                             [
                               <arg>
                                 Nolabel
                                 expression (test_locations.ml[19,572+14]..test_locations.ml[19,572+15])
-                                  value_mode <modevar>
                                   Texp_ident "n"
                               <arg>
                                 Nolabel
                                 expression (test_locations.ml[19,572+18]..test_locations.ml[19,572+19])
-                                  value_mode <modevar>
                                   Texp_constant Const_int 1
                             ]
                       ]
                   <arg>
                     Nolabel
                     expression (test_locations.ml[19,572+23]..test_locations.ml[19,572+34])
-                      value_mode <modevar>
                       Texp_apply
                       apply_mode Default
+                      alloc_mode <modevar>
                       expression (test_locations.ml[19,572+23]..test_locations.ml[19,572+26])
-                        value_mode <modevar>
                         Texp_ident "fib"
                       [
                         <arg>
                           Nolabel
                           expression (test_locations.ml[19,572+27]..test_locations.ml[19,572+34])
-                            value_mode <modevar>
                             Texp_apply
                             apply_mode Default
+                            alloc_mode <modevar>
                             expression (test_locations.ml[19,572+30]..test_locations.ml[19,572+31])
-                              value_mode <modevar>
                               Texp_ident "Stdlib!.-"
                             [
                               <arg>
                                 Nolabel
                                 expression (test_locations.ml[19,572+28]..test_locations.ml[19,572+29])
-                                  value_mode <modevar>
                                   Texp_ident "n"
                               <arg>
                                 Nolabel
                                 expression (test_locations.ml[19,572+32]..test_locations.ml[19,572+33])
-                                  value_mode <modevar>
                                   Texp_constant Const_int 2
                             ]
                       ]

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -87,9 +87,9 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
         pattern 
           Tpat_var "fib"
         expression 
-          value_mode global
           Texp_function
           region true
+          alloc_mode global
           Nolabel
           [
             <case>
@@ -100,80 +100,70 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                 pattern 
                   Tpat_constant Const_int 1
               expression 
-                value_mode global
                 Texp_constant Const_int 1
             <case>
               pattern 
                 Tpat_var "n"
               expression 
-                value_mode global
                 Texp_apply
                 apply_mode Tail
+                alloc_mode global
                 expression 
-                  value_mode <modevar>
                   Texp_ident "Stdlib!.+"
                 [
                   <arg>
                     Nolabel
                     expression 
-                      value_mode <modevar>
                       Texp_apply
                       apply_mode Default
+                      alloc_mode <modevar>
                       expression 
-                        value_mode <modevar>
                         Texp_ident "fib"
                       [
                         <arg>
                           Nolabel
                           expression 
-                            value_mode <modevar>
                             Texp_apply
                             apply_mode Default
+                            alloc_mode <modevar>
                             expression 
-                              value_mode <modevar>
                               Texp_ident "Stdlib!.-"
                             [
                               <arg>
                                 Nolabel
                                 expression 
-                                  value_mode <modevar>
                                   Texp_ident "n"
                               <arg>
                                 Nolabel
                                 expression 
-                                  value_mode <modevar>
                                   Texp_constant Const_int 1
                             ]
                       ]
                   <arg>
                     Nolabel
                     expression 
-                      value_mode <modevar>
                       Texp_apply
                       apply_mode Default
+                      alloc_mode <modevar>
                       expression 
-                        value_mode <modevar>
                         Texp_ident "fib"
                       [
                         <arg>
                           Nolabel
                           expression 
-                            value_mode <modevar>
                             Texp_apply
                             apply_mode Default
+                            alloc_mode <modevar>
                             expression 
-                              value_mode <modevar>
                               Texp_ident "Stdlib!.-"
                             [
                               <arg>
                                 Nolabel
                                 expression 
-                                  value_mode <modevar>
                                   Texp_ident "n"
                               <arg>
                                 Nolabel
                                 expression 
-                                  value_mode <modevar>
                                   Texp_constant Const_int 2
                             ]
                       ]

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -1904,7 +1904,7 @@ val primloc : int32 -> int = <fun>
 |}]
 
 (* (&&) and (||) tail call on the right *)
-let testbool1 f = let local_ r = ref 42 in (f r || false) && true 
+let testbool1 f = let local_ r = ref 42 in (f r || false) && true
 
 let testbool2 f = let local_ r = ref 42 in true && (false || f r)
 [%%expect{|
@@ -2577,7 +2577,7 @@ Error: This value escapes its region
 
 (* on construction of array, we ensure elements are global *)
 
-let f (local_ x : string) = 
+let f (local_ x : string) =
   [|x; "foo"|]
 [%%expect{|
 Line 2, characters 4-5:
@@ -2586,21 +2586,21 @@ Line 2, characters 4-5:
 Error: This value escapes its region
 |}]
 
-let f (x : string) = 
+let f (x : string) =
   [|x; "foo"|]
 [%%expect{|
 val f : string -> string array = <fun>
-|}]  
+|}]
 
 
-(* on pattern matching of array, 
-   elements are strengthened to global 
+(* on pattern matching of array,
+   elements are strengthened to global
   even if array itself is local *)
-let f (local_ a : string array) = 
+let f (local_ a : string array) =
   match a with
   | [| x; _ |] -> ref x
   | _ -> ref "foo"
 
 [%%expect{|
 val f : local_ string array -> string ref = <fun>
-|}]  
+|}]

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -333,6 +333,18 @@ and comprehension i ppf comp_types=
     Option.iter (expression i ppf) guard
   ) comp_types
 
+and alloc_mode i ppf m =
+  line i ppf "alloc_mode %s\n"
+  (match Types.Alloc_mode.check_const m with
+  | Some Global ->  "global"
+  | Some Local ->  "local"
+  | None -> "<modevar>"
+  )
+
+and expression_alloc_mode i ppf (expr, am) =
+  alloc_mode i ppf am;
+  expression i ppf expr
+
 and expression i ppf x =
   line i ppf "expression %a\n" fmt_location x.exp_loc;
   attributes i ppf x.exp_attributes;
@@ -343,11 +355,6 @@ and expression i ppf x =
     line i ppf "extra\n";
     List.iter (expression_extra (i+1) ppf) extra;
   end;
-  (match Types.Value_mode.check_const x.exp_mode with
-  | Some Global -> line i ppf "value_mode global\n"
-  | Some Regional -> line i ppf "value_mode regional\n"
-  | Some Local -> line i ppf "value_mode local\n"
-  | None -> line i ppf "value_mode <modevar>\n");
   match x.exp_desc with
   | Texp_ident (li,_,_,_) -> line i ppf "Texp_ident %a\n" fmt_path li;
   | Texp_instvar (_, li,_) -> line i ppf "Texp_instvar %a\n" fmt_path li;
@@ -356,18 +363,20 @@ and expression i ppf x =
       line i ppf "Texp_let %a\n" fmt_rec_flag rf;
       list i value_binding ppf l;
       expression i ppf e;
-  | Texp_function { arg_label = p; param = _; cases; partial = _; region } ->
+  | Texp_function { arg_label = p; param = _; cases; partial = _; region; alloc_mode = am } ->
       line i ppf "Texp_function\n";
       line i ppf "region %b\n" region;
+      alloc_mode i ppf am;
       arg_label i ppf p;
       list i case ppf cases;
-  | Texp_apply (e, l, m) ->
+  | Texp_apply (e, l, m, am) ->
       line i ppf "Texp_apply\n";
       line i ppf "apply_mode %s\n"
         (match m with
          | Tail -> "Tail"
          | Nontail -> "Nontail"
          | Default -> "Default");
+      alloc_mode i ppf am;
       expression i ppf e;
       list i label_x_apply_arg ppf l;
   | Texp_match (e, l, _partial) ->
@@ -378,35 +387,41 @@ and expression i ppf x =
       line i ppf "Texp_try\n";
       expression i ppf e;
       list i case ppf l;
-  | Texp_tuple (l) ->
+  | Texp_tuple (l, am) ->
       line i ppf "Texp_tuple\n";
+      alloc_mode i ppf am;
       list i expression ppf l;
-  | Texp_construct (li, _, eo) ->
+  | Texp_construct (li, _, eo, am) ->
       line i ppf "Texp_construct %a\n" fmt_longident li;
+      alloc_mode i ppf am;
       list i expression ppf eo;
   | Texp_variant (l, eo) ->
       line i ppf "Texp_variant \"%s\"\n" l;
-      option i expression ppf eo;
-  | Texp_record { fields; representation; extended_expression } ->
+      option i expression_alloc_mode ppf eo;
+  | Texp_record { fields; representation; extended_expression; alloc_mode = am} ->
       line i ppf "Texp_record\n";
       let i = i+1 in
+      alloc_mode i ppf am;
       line i ppf "fields =\n";
       array (i+1) record_field ppf fields;
       line i ppf "representation =\n";
       record_representation (i+1) ppf representation;
       line i ppf "extended_expression =\n";
       option (i+1) expression ppf extended_expression;
-  | Texp_field (e, li, _) ->
+  | Texp_field (e, li, _, am) ->
       line i ppf "Texp_field\n";
+      alloc_mode i ppf am;
       expression i ppf e;
       longident i ppf li;
-  | Texp_setfield (e1, li, _, e2) ->
+  | Texp_setfield (e1, am, li, _, e2) ->
       line i ppf "Texp_setfield\n";
+      alloc_mode i ppf am;
       expression i ppf e1;
       longident i ppf li;
       expression i ppf e2;
-  | Texp_array (l) ->
+  | Texp_array (l, am) ->
       line i ppf "Texp_array\n";
+      alloc_mode i ppf am;
       list i expression ppf l;
   | Texp_ifthenelse (e1, e2, eo) ->
       line i ppf "Texp_ifthenelse\n";
@@ -438,14 +453,17 @@ and expression i ppf x =
       expression i ppf for_to;
       line i ppf "region %b\n" for_region;
       expression i ppf for_body
-  | Texp_send (e, Tmeth_name s, _) ->
+  | Texp_send (e, Tmeth_name s, _, am) ->
       line i ppf "Texp_send \"%s\"\n" s;
+      alloc_mode i ppf am;
       expression i ppf e
-  | Texp_send (e, Tmeth_val s, _) ->
+  | Texp_send (e, Tmeth_val s, _, am) ->
       line i ppf "Texp_send \"%a\"\n" fmt_ident s;
+      alloc_mode i ppf am;
       expression i ppf e
-  | Texp_send (e, Tmeth_ancestor(s, _), _) ->
+  | Texp_send (e, Tmeth_ancestor(s, _), _, am) ->
       line i ppf "Texp_send \"%a\"\n" fmt_ident s;
+      alloc_mode i ppf am;
       expression i ppf e
   | Texp_new (li, _, _, _) -> line i ppf "Texp_new %a\n" fmt_path li;
   | Texp_setinstvar (_, s, _, e) ->

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -208,7 +208,7 @@ let expr sub {exp_extra; exp_desc; exp_env; _} =
       sub.expr sub exp
   | Texp_function {cases; _} ->
      List.iter (sub.case sub) cases
-  | Texp_apply (exp, list, _) ->
+  | Texp_apply (exp, list, _, _) ->
       sub.expr sub exp;
       List.iter (function
         | (_, Arg exp) -> sub.expr sub exp
@@ -220,20 +220,20 @@ let expr sub {exp_extra; exp_desc; exp_env; _} =
   | Texp_try (exp, cases) ->
       sub.expr sub exp;
       List.iter (sub.case sub) cases
-  | Texp_tuple list -> List.iter (sub.expr sub) list
-  | Texp_construct (_, _, args) -> List.iter (sub.expr sub) args
-  | Texp_variant (_, expo) -> Option.iter (sub.expr sub) expo
+  | Texp_tuple (list, _) -> List.iter (sub.expr sub) list
+  | Texp_construct (_, _, args, _) -> List.iter (sub.expr sub) args
+  | Texp_variant (_, expo) -> Option.iter (fun (expr, _) -> sub.expr sub expr) expo
   | Texp_record { fields; extended_expression; _} ->
       Array.iter (function
         | _, Kept _ -> ()
         | _, Overridden (_, exp) -> sub.expr sub exp)
         fields;
       Option.iter (sub.expr sub) extended_expression;
-  | Texp_field (exp, _, _) -> sub.expr sub exp
-  | Texp_setfield (exp1, _, _, exp2) ->
+  | Texp_field (exp, _, _, _) -> sub.expr sub exp
+  | Texp_setfield (exp1, _,  _, _, exp2) ->
       sub.expr sub exp1;
       sub.expr sub exp2
-  | Texp_array list -> List.iter (sub.expr sub) list
+  | Texp_array (list, _) -> List.iter (sub.expr sub) list
   | Texp_ifthenelse (exp1, exp2, expo) ->
       sub.expr sub exp1;
       sub.expr sub exp2;
@@ -259,7 +259,7 @@ let expr sub {exp_extra; exp_desc; exp_env; _} =
       sub.expr sub for_from;
       sub.expr sub for_to;
       sub.expr sub for_body
-  | Texp_send (exp, _, _) ->
+  | Texp_send (exp, _, _, _) ->
       sub.expr sub exp
   | Texp_new _ -> ()
   | Texp_instvar _ -> ()

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1178,7 +1178,6 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
                          Id_value);
               exp_loc = Location.none; exp_extra = [];
               exp_type = Ctype.instance vd.val_type;
-              exp_mode = Value_mode.global;
               exp_attributes = []; (* check *)
               exp_env = val_env'})
           end
@@ -1342,7 +1341,6 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
                            Id_value);
                 exp_loc = Location.none; exp_extra = [];
                 exp_type = Ctype.instance vd.val_type;
-                exp_mode = Value_mode.global;
                 exp_attributes = [];
                 exp_env = val_env;
                }

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -87,7 +87,6 @@ and expression =
     exp_loc: Location.t;
     exp_extra: (exp_extra * Location.t * attribute list) list;
     exp_type: type_expr;
-    exp_mode: value_mode;
     exp_env: Env.t;
     exp_attributes: attribute list;
    }
@@ -111,23 +110,24 @@ and expression_desc =
   | Texp_function of { arg_label : arg_label; param : Ident.t;
       cases : value case list; partial : partial;
       region : bool; curry : fun_curry_state;
-      warnings : Warnings.state; }
-  | Texp_apply of expression * (arg_label * apply_arg) list * apply_position
+      warnings : Warnings.state; alloc_mode : Types.alloc_mode }
+  | Texp_apply of expression * (arg_label * apply_arg) list * apply_position * Types.alloc_mode
   | Texp_match of expression * computation case list * partial
   | Texp_try of expression * value case list
-  | Texp_tuple of expression list
+  | Texp_tuple of expression list * Types.alloc_mode
   | Texp_construct of
-      Longident.t loc * constructor_description * expression list
-  | Texp_variant of label * expression option
+      Longident.t loc * constructor_description * expression list * Types.alloc_mode
+  | Texp_variant of label * (expression * Types.alloc_mode) option
   | Texp_record of {
       fields : ( Types.label_description * record_label_definition ) array;
       representation : Types.record_representation;
       extended_expression : expression option;
+      alloc_mode : Types.alloc_mode
     }
-  | Texp_field of expression * Longident.t loc * label_description
+  | Texp_field of expression * Longident.t loc * label_description * Types.alloc_mode
   | Texp_setfield of
-      expression * Longident.t loc * label_description * expression
-  | Texp_array of expression list
+      expression * Types.alloc_mode * Longident.t loc * label_description * expression
+  | Texp_array of expression list * Types.alloc_mode
   | Texp_ifthenelse of expression * expression * expression option
   | Texp_sequence of expression * expression
   | Texp_while of {
@@ -149,7 +149,7 @@ and expression_desc =
       for_body : expression;
       for_region : bool;
     }
-  | Texp_send of expression * meth * apply_position
+  | Texp_send of expression * meth * apply_position * Types.alloc_mode
   | Texp_new of
       Path.t * Longident.t loc * Types.class_declaration * apply_position
   | Texp_instvar of Path.t * Path.t * string loc

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -385,7 +385,7 @@ let classify_lazy_argument : Typedtree.expression ->
         ( Const_int _ | Const_char _ | Const_string _
         | Const_int32 _ | Const_int64 _ | Const_nativeint _ )
     | Texp_function _
-    | Texp_construct (_, {cstr_arity = 0}, _) ->
+    | Texp_construct (_, {cstr_arity = 0}, _, _) ->
        `Constant_or_function
     | Texp_constant(Const_float _) ->
        if Config.flat_float_array

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -437,7 +437,7 @@ let expression sub exp =
         Pexp_fun (label, None, Pat.var ~loc {loc;txt = name },
           Exp.match_ ~loc (Exp.ident ~loc {loc;txt= Lident name})
                           (List.map (sub.case sub) cases))
-    | Texp_apply (exp, list, _) ->
+    | Texp_apply (exp, list, _, _) ->
         Pexp_apply (sub.expr sub exp,
           List.fold_right (fun (label, arg) list ->
               match arg with
@@ -448,9 +448,9 @@ let expression sub exp =
       Pexp_match (sub.expr sub exp, List.map (sub.case sub) cases)
     | Texp_try (exp, cases) ->
         Pexp_try (sub.expr sub exp, List.map (sub.case sub) cases)
-    | Texp_tuple list ->
+    | Texp_tuple (list, _) ->
         Pexp_tuple (List.map (sub.expr sub) list)
-    | Texp_construct (lid, _, args) ->
+    | Texp_construct (lid, _, args, _) ->
         Pexp_construct (map_loc sub lid,
           (match args with
               [] -> None
@@ -460,7 +460,7 @@ let expression sub exp =
                 (Exp.tuple ~loc (List.map (sub.expr sub) args))
           ))
     | Texp_variant (label, expo) ->
-        Pexp_variant (label, Option.map (sub.expr sub) expo)
+        Pexp_variant (label, Option.map (fun (e, _) -> sub.expr sub e) expo)
     | Texp_record { fields; extended_expression; _ } ->
         let list = Array.fold_left (fun l -> function
             | _, Kept _ -> l
@@ -468,12 +468,12 @@ let expression sub exp =
             [] fields
         in
         Pexp_record (list, Option.map (sub.expr sub) extended_expression)
-    | Texp_field (exp, lid, _label) ->
+    | Texp_field (exp, lid, _label, _) ->
         Pexp_field (sub.expr sub exp, map_loc sub lid)
-    | Texp_setfield (exp1, lid, _label, exp2) ->
+    | Texp_setfield (exp1, _, lid, _label, exp2) ->
         Pexp_setfield (sub.expr sub exp1, map_loc sub lid,
           sub.expr sub exp2)
-    | Texp_array list ->
+    | Texp_array (list, _) ->
         Pexp_array (List.map (sub.expr sub) list)
     | Texp_ifthenelse (exp1, exp2, expo) ->
         Pexp_ifthenelse (sub.expr sub exp1,
@@ -497,7 +497,7 @@ let expression sub exp =
         Pexp_for (for_pat,
           sub.expr sub for_from, sub.expr sub for_to,
           for_dir, sub.expr sub for_body)
-    | Texp_send (exp, meth, _) ->
+    | Texp_send (exp, meth, _, _) ->
         Pexp_send (sub.expr sub exp, match meth with
             Tmeth_name name -> mkloc name loc
           | Tmeth_val id -> mkloc (Ident.name id) loc


### PR DESCRIPTION
This patch tries to remove `exp_mode` from `typedtree`, which is hotbed for subtle mode bugs. Instead, we only keep `alloc_mode` in some typed expressions where allocations happen. 