### PR TITLE
Fix misplaced attribute warning when using external parser (and some cleanup)

### DIFF
--- a/parsing/ast_invariants.ml
+++ b/parsing/ast_invariants.ml
@@ -170,6 +170,10 @@ let iterator =
           "In object types, attaching attributes to inherited \
            subtypes is not allowed."
   in
+  let attribute self attr =
+    super.attribute self attr;
+    Builtin_attributes.register_attr attr.attr_name
+  in
   { super with
     type_declaration
   ; typ
@@ -185,6 +189,7 @@ let iterator =
   ; signature_item
   ; row_field
   ; object_field
+  ; attribute
   }
 
 let structure st = iterator.structure iterator st

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -92,9 +92,12 @@ let builtin_attrs =
 
 let is_builtin_attr s = Hashtbl.mem builtin_attrs s
 
-let mk_internal ?(loc= !default_loc) name payload =
+let register_attr name =
   if is_builtin_attr name.txt
-  then Attribute_table.add unused_attrs name ();
+  then Attribute_table.replace unused_attrs name ()
+
+let mk_internal ?(loc= !default_loc) name payload =
+  register_attr name;
   Attr.mk ~loc name payload
 
 

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -46,6 +46,10 @@ val mk_internal:
   ?loc:Location.t -> string Location.loc -> Parsetree.payload ->
   Parsetree.attribute
 
+(** Used to record attributes that should be tracked for the purpose of
+    misplaced attribute warnings.  *)
+val register_attr: string Location.loc -> unit
+
 (** Marks alert attributes used for the purposes of misplaced attribute
     warnings.  Call this when moving things with alert attributes into the
     environment. *)

--- a/testsuite/tests/warnings/w53.compilers.reference
+++ b/testsuite/tests/warnings/w53.compilers.reference
@@ -6,10 +6,6 @@ File "w53.ml", line 12, characters 4-5:
 12 | let h x = x [@inline] (* rejected *)
          ^
 Warning 32 [unused-value-declaration]: unused value h.
-File "w53.ml", line 334, characters 2-33:
-334 |   let x : int64 = 42L [@@noalloc] (* rejected *)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 File "w53.ml", line 12, characters 14-20:
 12 | let h x = x [@inline] (* rejected *)
                    ^^^^^^
@@ -558,6 +554,10 @@ File "w53.ml", line 333, characters 19-26:
 333 |   type s1 = Foo1 [@noalloc] (* rejected *)
                          ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
+File "w53.ml", line 334, characters 25-32:
+334 |   let x : int64 = 42L [@@noalloc] (* rejected *)
+                               ^^^^^^^
+Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 File "w53.ml", line 336, characters 24-31:
 336 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
                               ^^^^^^^
@@ -590,3 +590,51 @@ File "w53.ml", line 352, characters 22-30:
 352 |   let x : int = 42 [@@untagged] (* rejected *)
                             ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
+File "w53.ml", line 359, characters 21-25:
+359 |   type 'a t1 = 'a [@@poll error] (* rejected *)
+                           ^^^^
+Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+File "w53.ml", line 360, characters 19-23:
+360 |   type s1 = Foo1 [@poll error] (* rejected *)
+                         ^^^^
+Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+File "w53.ml", line 361, characters 19-23:
+361 |   val x : int64 [@@poll error] (* rejected *)
+                         ^^^^
+Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+File "w53.ml", line 363, characters 24-28:
+363 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) = (* rejected *)
+                              ^^^^
+Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+File "w53.ml", line 363, characters 49-53:
+363 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) = (* rejected *)
+                                                       ^^^^
+Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+File "w53.ml", line 365, characters 39-43:
+365 |   external z : int64 -> int64 = "x" [@@poll error] (* rejected *)
+                                             ^^^^
+Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+File "w53.ml", line 369, characters 21-25:
+369 |   type 'a t1 = 'a [@@poll error] (* rejected *)
+                           ^^^^
+Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+File "w53.ml", line 370, characters 19-23:
+370 |   type s1 = Foo1 [@poll error] (* rejected *)
+                         ^^^^
+Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+File "w53.ml", line 371, characters 25-29:
+371 |   let x : int64 = 42L [@@poll error] (* rejected *)
+                               ^^^^
+Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+File "w53.ml", line 374, characters 24-28:
+374 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) =  (* rejected *)
+                              ^^^^
+Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+File "w53.ml", line 374, characters 49-53:
+374 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) =  (* rejected *)
+                                                       ^^^^
+Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
+File "w53.ml", line 376, characters 39-43:
+376 |   external z : int64 -> int64 = "x" [@@poll error] (* rejected *)
+                                             ^^^^
+Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context

--- a/testsuite/tests/warnings/w53.ml
+++ b/testsuite/tests/warnings/w53.ml
@@ -355,3 +355,23 @@ module TestUntaggedStruct = struct
   external z : int -> int = "x" "y" [@@untagged] (* accepted *)
 end
 
+module type TestPollSig = sig
+  type 'a t1 = 'a [@@poll error] (* rejected *)
+  type s1 = Foo1 [@poll error] (* rejected *)
+  val x : int64 [@@poll error] (* rejected *)
+
+  external y : (int64 [@poll error]) -> (int64 [@poll error]) = (* rejected *)
+    "x"
+  external z : int64 -> int64 = "x" [@@poll error] (* rejected *)
+end
+
+module TestPollStruct = struct
+  type 'a t1 = 'a [@@poll error] (* rejected *)
+  type s1 = Foo1 [@poll error] (* rejected *)
+  let x : int64 = 42L [@@poll error] (* rejected *)
+  let [@poll error] f x = x (* accepted *)
+
+  external y : (int64 [@poll error]) -> (int64 [@poll error]) =  (* rejected *)
+    "x"
+  external z : int64 -> int64 = "x" [@@poll error] (* rejected *)
+end

--- a/testsuite/tests/warnings/w53_ppx.ml
+++ b/testsuite/tests/warnings/w53_ppx.ml
@@ -1,0 +1,13 @@
+open Ast_mapper
+
+let replace_attr ({ Parsetree.attr_name; _} as attr) =
+  { attr with
+    attr_name =
+      if String.equal attr.attr_name.txt "test" then
+        { attr_name with txt = "immediate" }
+      else attr_name
+  }
+
+let () =
+  register "test" (fun _ ->
+    { default_mapper with attribute = fun _ attr -> replace_attr attr })

--- a/testsuite/tests/warnings/w53_with_ppx.compilers.reference
+++ b/testsuite/tests/warnings/w53_with_ppx.compilers.reference
@@ -1,0 +1,4 @@
+File "w53_with_ppx.ml", line 18, characters 13-17:
+18 | let x = 3 [@@test]
+                  ^^^^
+Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context

--- a/testsuite/tests/warnings/w53_with_ppx.ml
+++ b/testsuite/tests/warnings/w53_with_ppx.ml
@@ -1,0 +1,20 @@
+(* TEST
+readonly_files = "w53_ppx.ml"
+include ocamlcommon
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+program = "${test_build_directory}/w53_ppx.exe"
+all_modules = "w53_ppx.ml"
+*** ocamlc.byte
+module = "w53_with_ppx.ml"
+flags = "-ppx ${program}"
+**** check-ocamlc.byte-output
+*)
+
+(* This test checks that compiler-builtin attributes inserted by a ppx still
+   trigger the misplaced attribute warning if they are unused (and not if
+   they are used). *)
+
+let x = 3 [@@test]
+
+type t = int [@@test]


### PR DESCRIPTION
(This replaces #98)

Not all parse trees are created by the parser in the compiler.  There are at least two other possibilities (see [driver/pparse.ml]): 1) the compiler accepts serialized parse trees constructed by other tools, and 2) the compiler can apply rewriters that modify parse trees.  The previous rework of the misplaced attributes check (#44) missed all attributes in case 1 and rewriter-created attributes in case 2.

The first commit in this PR fixes this situation, using the ast invariant checker used by the compiler in cases 1 and 2 to also insert attributes into the table to be tracked for warning 53.  Compared with #98, we don't attempt to give different warnings for rewriter-inserted attributes - this is slightly trickier than I thought because of case 1, and I'd like to get this out quickly, but we can come back later.

The second commit is some minor related cleanup.