### PR TITLE
Further tidying around type variables

### DIFF
--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1376,11 +1376,11 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
          }
   | Pcl_constraint (scl', scty) ->
       Ctype.begin_class_def ();
-      let cl = Typetexp.TyVarEnv.narrow_in (fun () ->
+      let cl = Typetexp.TyVarEnv.with_local_scope (fun () ->
         let cl = class_expr cl_num val_env met_env virt self_scope scl' in
         complete_class_type cl.cl_loc val_env virt Class_type cl.cl_type;
         cl) in
-      let clty = Typetexp.TyVarEnv.narrow_in (fun () ->
+      let clty = Typetexp.TyVarEnv.with_local_scope (fun () ->
         let clty = class_type val_env virt self_scope scty in
         complete_class_type clty.cltyp_loc val_env virt Class clty.cltyp_type;
         clty) in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4674,7 +4674,7 @@ and type_expect_
       let ty = newvar() in
       (* remember original level *)
       begin_def ();
-      let modl, pres, id, new_env = Typetexp.TyVarEnv.narrow_in begin fun () ->
+      let modl, pres, id, new_env = Typetexp.TyVarEnv.with_local_scope begin fun () ->
         let modl, md_shape = !type_module env smodl in
         Mtype.lower_nongen (get_level ty) modl.mod_type;
         let pres =
@@ -6076,7 +6076,7 @@ and type_unpacks ?(in_function : (Location.t * type_expr * bool) option)
   let extended_env, tunpacks =
     List.fold_left (fun (env, tunpacks) unpack ->
       begin_def ();
-      Typetexp.TyVarEnv.narrow_in begin fun () ->
+      Typetexp.TyVarEnv.with_local_scope begin fun () ->
         let modl, md_shape =
           !type_module env
             Ast_helper.(

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -331,7 +331,7 @@ let make_constructor env loc type_path type_params svars sargs sret_type =
          Ctype.end_def();
          Btype.iter_type_expr_cstr_args Ctype.generalize args;
          Ctype.generalize ret_type;
-         let _vars = instance_poly_univars env loc univars in
+         let _vars = TyVarEnv.instance_poly_univars env loc univars in
          let set_level t = Ctype.unify_var env (Ctype.newvar()) t in
          Btype.iter_type_expr_cstr_args set_level args;
          set_level ret_type;

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -293,7 +293,7 @@ let make_constructor env loc type_path type_params svars sargs sret_type =
         transl_constructor_arguments env None true sargs
       in
         targs, None, args, None
-  | Some sret_type -> TyVarEnv.narrow_in begin fun () ->
+  | Some sret_type -> TyVarEnv.with_local_scope begin fun () ->
       (* if it's a generalized constructor we must work in a narrowed
          context so as to not introduce any new constraints *)
       TyVarEnv.reset ();

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3037,7 +3037,7 @@ let type_package env m p fl =
   (* Same as Pexp_letmodule *)
   (* remember original level *)
   Ctype.begin_def ();
-  let modl, scope = Typetexp.TyVarEnv.narrow_in begin fun () ->
+  let modl, scope = Typetexp.TyVarEnv.with_local_scope begin fun () ->
     let modl, _mod_shape = type_module env m in
     let scope = Ctype.create_scope () in
     modl, scope

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -112,10 +112,42 @@ end = struct
   (** Map indexed by type variable names. *)
   module TyVarMap = Misc.Stdlib.String.Map
 
+  let not_generic v = get_level v <> Btype.generic_level
+
+  (* These are the "global" type variables: they were in scope before
+     we started processing the current type.
+
+     INVARIANT: No types at generic_level.
+  *)
   let type_variables = ref (TyVarMap.empty : type_expr TyVarMap.t)
-  let univars        = ref ([] : (string * type_expr) list)
-  let pre_univars    = ref ([] : type_expr list)
-  let used_variables = ref (TyVarMap.empty : (type_expr * Location.t) TyVarMap.t)
+
+  (* These are variables that have been used in the currently-being-checked
+     type.
+
+     INVARIANT: No types at generic_level.
+  *)
+  let used_variables =
+    ref (TyVarMap.empty : (type_expr * Location.t) TyVarMap.t)
+
+  (* These are variables we expect to become univars (they were introduced with
+     e.g. ['a .]), but we need to make sure they don't unify first.  Why not
+     just birth them as univars? Because they might successfully unify with a
+     row variable in the ['a. < m : ty; .. > as 'a] idiom.  They are like the
+     [used_variables], but will not be globalized in [globalize_used_variables].
+
+     INVARIANT: No types at generic_level.
+  *)
+  let univars = ref ([] : (string * type_expr) list)
+  let assert_univars uvs =
+    assert (List.for_all (fun (_name, v) -> not_generic v) uvs)
+
+  (* These are variables that will become univars when we're done with the
+     current type. Used to force free variables in method types to become
+     univars.
+
+     INVARIANT: No types at generic_level.
+  *)
+  let pre_univars = ref ([] : type_expr list)
 
   let reset () =
     reset_global_level ();
@@ -126,6 +158,7 @@ end = struct
     TyVarMap.mem name !type_variables
 
   let add name v =
+    assert (not_generic v);
     type_variables := TyVarMap.add name v !type_variables
 
   let with_local_scope f =
@@ -149,6 +182,7 @@ end = struct
   type poly_univars = (string * type_expr) list
 
   let with_univars new_ones f =
+    assert_univars new_ones;
     let old_univars = !univars in
     univars := new_ones @ !univars;
     Fun.protect
@@ -172,20 +206,19 @@ end = struct
 
   (*****)
   let reset_locals ?univars:(uvs=[]) () =
+    assert_univars uvs;
     univars := uvs;
     used_variables := TyVarMap.empty
 
   (* throws Not_found if the variable is not in scope *)
   let lookup_local name =
-    let v =
-      try
-        List.assoc name !univars
-      with Not_found ->
-        fst (TyVarMap.find name !used_variables)
-    in
-    instance v
+    try
+      List.assoc name !univars
+    with Not_found ->
+      fst (TyVarMap.find name !used_variables)
 
   let remember_used name v loc =
+    assert (not_generic v);
     used_variables := TyVarMap.add name (v, loc) !used_variables
 
   type flavor = Unification | Universal
@@ -197,7 +230,9 @@ end = struct
   let univars_policy = { flavor = Universal; extensibility = Extensible }
 
   let add_pre_univar tv = function
-    | { flavor = Universal } -> pre_univars := tv :: !pre_univars
+    | { flavor = Universal } ->
+      assert (not_generic tv);
+      pre_univars := tv :: !pre_univars
     | _ -> ()
 
   let collect_pre_univars f =

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -62,7 +62,7 @@ module TyVarEnv : sig
   val add : string -> type_expr -> unit
   (* add a global type variable to the environment *)
 
-  val narrow_in : (unit -> 'a) -> 'a
+  val with_local_scope : (unit -> 'a) -> 'a
   (* see mli file *)
 
   type poly_univars
@@ -128,7 +128,7 @@ end = struct
   let add name v =
     type_variables := TyVarMap.add name v !type_variables
 
-  let narrow_in f =
+  let with_local_scope f =
     let old_gl = increase_global_level () in
     let old_tv = !type_variables in
     Fun.protect
@@ -187,7 +187,6 @@ end = struct
 
   let remember_used name v loc =
     used_variables := TyVarMap.add name (v, loc) !used_variables
-
 
   type flavor = Unification | Universal
   type extensibility = Extensible | Fixed
@@ -683,7 +682,7 @@ and transl_type_aux env policy mode styp =
       ctyp (Ttyp_poly (vars, cty)) ty'
   | Ptyp_package (p, l) ->
       let l, mty = create_package_mty true styp.ptyp_loc env (p, l) in
-      let mty = TyVarEnv.narrow_in (fun () -> !transl_modtype env mty) in
+      let mty = TyVarEnv.with_local_scope (fun () -> !transl_modtype env mty) in
       let ptys = List.map (fun (s, pty) ->
                              s, transl_type env policy Alloc_mode.Global pty
                           ) l in

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -37,14 +37,15 @@ module TyVarEnv : sig
     (** Verify that the given univars are universally quantified,
        and return the list of variables. The type in which the
        univars are used must be generalised *)
+
+  val instance_poly_univars :
+     Env.t -> Location.t -> poly_univars -> type_expr list
+    (** Same as [check_poly_univars], but instantiates the resulting
+       type scheme (i.e. variables become Tvar rather than Tunivar) *)
+
 end
 
 val valid_tyvar_name : string -> bool
-
-val instance_poly_univars :
-   Env.t -> Location.t -> TyVarEnv.poly_univars -> type_expr list
-  (* Same as [check_poly_univars], but instantiates the resulting
-     type scheme (i.e. variables become Tvar rather than Tunivar) *)
 
 val transl_simple_type:
         Env.t -> ?univars:TyVarEnv.poly_univars -> fixed:bool -> alloc_mode_const

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -24,7 +24,7 @@ module TyVarEnv : sig
   val reset : unit -> unit
   (** removes all type variables from scope *)
 
-  val narrow_in: (unit -> 'a) -> 'a
+  val with_local_scope : (unit -> 'a) -> 'a
   (** Evaluate in a narrowed type-variable scope *)
 
   type poly_univars


### PR DESCRIPTION
In responding to Gabriel's [comment](https://github.com/ocaml/ocaml/pull/11912#discussion_r1080943382) on the upstream PR, I realized that there was an unnecessary call to [instance]. But instead of just removing the call, I added comments and checks to make sure my intuition was correct.

This PR also includes a renaming of `narrow_in` to become `with_local_scope`, which is what upstream uses. (Or will, once my PR there is merged.)