### PR TITLE
Add `-dgc-timings` to collect timing information about major / minor collections

### DIFF
--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -558,6 +558,10 @@ let mk_dtimings f =
   "-dtimings", Arg.Unit f, " Print timings information for each pass";
 ;;
 
+let mk_dgc_timings f =
+  "-dgc-timings", Arg.Unit f, " Print GC timings information for each pass";
+;;
+
 let mk_dtimings_precision f =
   "-dtimings-precision", Arg.Int f,
     Printf.sprintf "<n>  Specify precision for timings information (default %d)"
@@ -1053,6 +1057,7 @@ module type Compiler_options = sig
 
   val _match_context_rows : int -> unit
   val _dtimings : unit -> unit
+  val _dgc_timings : unit -> unit
   val _dtimings_precision : int -> unit
   val _dprofile : unit -> unit
   val _dump_into_file : unit -> unit
@@ -1309,6 +1314,7 @@ struct
     mk_dinstr F._dinstr;
     mk_dcamlprimc F._dcamlprimc;
     mk_dtimings F._dtimings;
+    mk_dgc_timings F._dgc_timings;
     mk_dtimings_precision F._dtimings_precision;
     mk_dprofile F._dprofile;
     mk_dump_into_file F._dump_into_file;
@@ -1540,6 +1546,7 @@ struct
     mk_dinterval F._dinterval;
     mk_dstartup F._dstartup;
     mk_dtimings F._dtimings;
+    mk_dgc_timings F._dgc_timings;
     mk_dtimings_precision F._dtimings_precision;
     mk_dprofile F._dprofile;
     mk_dump_into_file F._dump_into_file;
@@ -1923,6 +1930,9 @@ module Default = struct
     let _config_var = Misc.show_config_variable_and_exit
     let _dprofile () = profile_columns := Profile.all_columns
     let _dtimings () = profile_columns := [`Time]
+    let _dgc_timings () =
+      Gc.collect_timing ();
+      profile_columns := [`Gc_time_minor; `Gc_time_major]
     let _dtimings_precision n = timings_precision := n
     let _dump_into_file = set dump_into_file
     let _dump_dir s = dump_dir := Some s

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -121,6 +121,7 @@ module type Compiler_options = sig
 
   val _match_context_rows : int -> unit
   val _dtimings : unit -> unit
+  val _dgc_timings : unit -> unit
   val _dtimings_precision : int -> unit
   val _dprofile : unit -> unit
   val _dump_into_file : unit -> unit

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -88,6 +88,8 @@ DOMAIN_STATE(intnat, stat_top_heap_wsz)
 DOMAIN_STATE(intnat, stat_compactions)
 DOMAIN_STATE(intnat, stat_forced_major_collections)
 DOMAIN_STATE(intnat, stat_heap_chunks)
+DOMAIN_STATE(intnat, stat_minor_collections_ns)
+DOMAIN_STATE(intnat, stat_major_collections_ns)
 /* See gc_ctrl.c */
 
 DOMAIN_STATE(uintnat, eventlog_startup_timestamp)

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -195,6 +195,10 @@ extern caml_timing_hook caml_major_slice_begin_hook, caml_major_slice_end_hook;
 extern caml_timing_hook caml_minor_gc_begin_hook, caml_minor_gc_end_hook;
 extern caml_timing_hook caml_finalise_begin_hook, caml_finalise_end_hook;
 
+
+extern int caml_gc_collect_timing;
+
+
 #define CAML_STATIC_ASSERT_3(b, l) \
   CAMLunused_start \
     CAMLextern char static_assertion_failure_line_##l[(b) ? 1 : -1] \
@@ -415,6 +419,8 @@ extern void caml_ext_table_clear(struct ext_table * tbl, int free_entries);
    Return 0 on success, -1 on error; set errno in the case of error. */
 CAMLextern int caml_read_directory(char_os * dirname,
                                    struct ext_table * contents);
+
+int64_t time_counter(void);
 
 /* Deprecated aliases */
 #define caml_aligned_malloc \

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -77,6 +77,8 @@ void caml_init_domain ()
   Caml_state->stat_compactions = 0;
   Caml_state->stat_forced_major_collections = 0;
   Caml_state->stat_heap_chunks = 0;
+  Caml_state->stat_minor_collections_ns = 0;
+  Caml_state->stat_major_collections_ns = 0;
 
   Caml_state->raising_async_exn = 0;
   Caml_state->backtrace_active = 0;

--- a/runtime/eventlog.c
+++ b/runtime/eventlog.c
@@ -23,20 +23,6 @@
 #include "caml/memory.h"
 #include "caml/osdeps.h"
 
-
-#ifdef _WIN32
-#include <wtypes.h>
-#include <process.h>
-#elif defined(HAS_UNISTD)
-#include <unistd.h>
-#endif
-
-#ifdef HAS_MACH_ABSOLUTE_TIME
-#include <mach/mach_time.h>
-#elif HAS_POSIX_MONOTONIC_CLOCK
-#include <time.h>
-#endif
-
 #ifdef CAML_INSTR
 
 #define CTF_MAGIC 0xc1fc1fc1
@@ -76,49 +62,6 @@ struct event_buffer {
 };
 
 static struct event_buffer* evbuf;
-
-static int64_t time_counter(void)
-{
-#ifdef _WIN32
-  static double clock_freq = 0;
-  static LARGE_INTEGER now;
-
-  if (clock_freq == 0) {
-    LARGE_INTEGER f;
-    if (!QueryPerformanceFrequency(&f))
-      return 0;
-    clock_freq = (1000000000.0 / f.QuadPart);
-  };
-
-  if (!QueryPerformanceCounter(&now))
-    return 0;
-  return (int64_t)(now.QuadPart * clock_freq);
-
-#elif defined(HAS_MACH_ABSOLUTE_TIME)
-  static mach_timebase_info_data_t time_base = {0};
-  uint64_t now;
-
-  if (time_base.denom == 0) {
-    if (mach_timebase_info (&time_base) != KERN_SUCCESS)
-      return 0;
-
-    if (time_base.denom == 0)
-      return 0;
-  }
-
-  now = mach_absolute_time ();
-  return (int64_t)((now * time_base.numer) / time_base.denom);
-
-#elif defined(HAS_POSIX_MONOTONIC_CLOCK)
-  struct timespec t;
-  clock_gettime(CLOCK_MONOTONIC, &t);
-  return
-    (int64_t)t.tv_sec  * (int64_t)1000000000 +
-    (int64_t)t.tv_nsec;
-
-
-#endif
-}
 
 static void setup_evbuf()
 {

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -130,6 +130,8 @@ CAMLexport void caml_do_exit(int retcode)
     intnat top_heap_words = Caml_state->stat_top_heap_wsz;
     intnat cpct = Caml_state->stat_compactions;
     intnat forcmajcoll = Caml_state->stat_forced_major_collections;
+    intnat mincollns = Caml_state->stat_minor_collections_ns;
+    intnat majcollns = Caml_state->stat_major_collections_ns;
     caml_gc_message(0x400, "allocated_words: %.0f\n", allocated_words);
     caml_gc_message(0x400, "minor_words: %.0f\n", minwords);
     caml_gc_message(0x400, "promoted_words: %.0f\n", prowords);
@@ -149,6 +151,10 @@ CAMLexport void caml_do_exit(int retcode)
     caml_gc_message(0x400,
                     "forced_major_collections: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
                     forcmajcoll);
+    caml_gc_message(0x400, "minor_collections_ns: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
+                    mincollns);
+    caml_gc_message(0x400, "major_collections_ns: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
+                    majcollns);
   }
 
 #ifndef NATIVE_CODE

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -37,6 +37,8 @@ type stat = {
   top_heap_words : int;
   stack_size : int;
   forced_major_collections: int;
+  time_spend_in_minor_collections_ns: float;
+  time_spend_in_major_collections_ns: float;
 }
 
 type control = {
@@ -71,6 +73,7 @@ external get_credit : unit -> int = "caml_get_major_credit" [@@noalloc]
 external huge_fallback_count : unit -> int = "caml_gc_huge_fallback_count"
 external eventlog_pause : unit -> unit = "caml_eventlog_pause"
 external eventlog_resume : unit -> unit = "caml_eventlog_resume"
+external collect_timing : unit -> unit = "caml_gc_toggle_collect_timing" [@@noalloc]
 
 open Printf
 
@@ -96,7 +99,11 @@ let print_stat c =
   fprintf c "\n";
   fprintf c "live_blocks: %d\n" st.live_blocks;
   fprintf c "free_blocks: %d\n" st.free_blocks;
-  fprintf c "heap_chunks: %d\n" st.heap_chunks
+  fprintf c "heap_chunks: %d\n" st.heap_chunks;
+  fprintf c "\n";
+  let l3 = String.length (sprintf "%.0f" st.time_spend_in_minor_collections_ns) in
+  fprintf c "minor_collections (ns):      %*.0f\n" l3 st.time_spend_in_minor_collections_ns;
+  fprintf c "major_collections (ns):      %*.0f\n" l3 st.time_spend_in_major_collections_ns
 
 
 let allocated_bytes () =

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -95,6 +95,12 @@ type stat =
     (** Number of forced full major collections completed since the program
         was started.
         @since 4.12.0 *)
+
+    time_spend_in_minor_collections_ns: float;
+    (** Time spend in minor collections, expressed in milliseconds. *)
+
+    time_spend_in_major_collections_ns: float;
+    (** Time spend in major collections, expressed in milliseconds. *)
 }
 (** The memory management counters are returned in a [stat] record.
 
@@ -461,6 +467,10 @@ external eventlog_resume : unit -> unit = "caml_eventlog_resume"
 
    @since 4.11
   *)
+
+external collect_timing : unit -> unit = "caml_gc_toggle_collect_timing" [@@noalloc]
+(** [collect_timing ()] will start collecting timing information from
+   gc cycles.*)
 
 
 (** [Memprof] is a sampling engine for allocated memory words. Every

--- a/utils/profile.mli
+++ b/utils/profile.mli
@@ -31,7 +31,7 @@ val record_call : ?accumulate:bool -> string -> (unit -> 'a) -> 'a
 val record : ?accumulate:bool -> string -> ('a -> 'b) -> 'a -> 'b
 (** [record pass f arg] records the profile information of [f arg] *)
 
-type column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap ]
+type column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap | `Gc_time_minor | `Gc_time_major ]
 
 val print : Format.formatter -> column list -> timings_precision:int -> unit
 (** Prints the selected recorded profiling information to the formatter. *)


### PR DESCRIPTION
This PR adds a new flag, `-dgc-timings` that will collect timing information about major / minor collections.

By default no timing collection is collected and no calls to `clock_gettime` is made.