### PR TITLE
Refactoring and fixes around module lookup

### DIFF
--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1089,7 +1089,7 @@ and find_functor_components path env =
   | Functor_comps f -> f
   | Structure_comps _ -> raise Not_found
 
-let find_module ?(alias=false) path env =
+let find_module path env =
   match path with
   | Pident id ->
       let data = find_ident_module id env in
@@ -1100,10 +1100,9 @@ let find_module ?(alias=false) path env =
       Subst.Lazy.force_module_decl data.mda_declaration
   | Papply(p1, p2) ->
       let fc = find_functor_components p1 env in
-      if alias then md (fc.fcomp_res)
-      else md (modtype_of_functor_appl fc p1 p2)
+      md (modtype_of_functor_appl fc p1 p2)
 
-let find_module_lazy ?(alias=false) path env =
+let find_module_lazy ~alias path env =
   match path with
   | Pident id ->
       let data = find_ident_module id env in
@@ -1446,6 +1445,9 @@ and expand_modtype_path env path =
   match (find_modtype_lazy path env).mtdl_type with
   | Some (MtyL_ident path) -> normalize_modtype_path env path
   | _ | exception Not_found -> path
+
+let find_module_lazy path env =
+  find_module_lazy ~alias:false path env
 
 (* Find the manifest type associated to a type when appropriate:
    - the type should be public or should have a private row,

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -799,11 +799,11 @@ let check_functor_application =
        f0_path:Path.t -> args:(Path.t * Types.module_type) list ->
        arg_path:Path.t -> arg_mty:module_type -> param_mty:module_type ->
        t -> unit)
-let strengthen =
-  (* to be filled with Mtype.strengthen *)
-  ref ((fun ~aliasable:_ _env _mty _path -> assert false) :
-         aliasable:bool -> t -> Subst.Lazy.modtype ->
-         Path.t -> Subst.Lazy.modtype)
+
+let scrape_alias =
+  (* to be filled with Mtype.scrape_alias *)
+  ref ((fun _env _mty -> assert false) :
+        t -> Subst.Lazy.modtype -> Subst.Lazy.modtype)
 
 let md md_type =
   {md_type; md_attributes=[]; md_loc=Location.none
@@ -1089,7 +1089,7 @@ and find_functor_components path env =
   | Functor_comps f -> f
   | Structure_comps _ -> raise Not_found
 
-let find_module ~alias path env =
+let find_module ?(alias=false) path env =
   match path with
   | Pident id ->
       let data = find_ident_module id env in
@@ -1103,7 +1103,7 @@ let find_module ~alias path env =
       if alias then md (fc.fcomp_res)
       else md (modtype_of_functor_appl fc p1 p2)
 
-let find_module_lazy ~alias path env =
+let find_module_lazy ?(alias=false) path env =
   match path with
   | Pident id ->
       let data = find_ident_module id env in
@@ -1119,11 +1119,6 @@ let find_module_lazy ~alias path env =
         else md (modtype_of_functor_appl fc p1 p2)
       in
       Subst.Lazy.of_module_decl md
-
-let find_strengthened_module ~aliasable path env =
-  let md = find_module_lazy ~alias:true path env in
-  let mty = !strengthen ~aliasable env md.mdl_type path in
-  Subst.Lazy.force_modtype mty
 
 let find_value_full path env =
   match path with
@@ -1452,12 +1447,6 @@ and expand_modtype_path env path =
   | Some (MtyL_ident path) -> normalize_modtype_path env path
   | _ | exception Not_found -> path
 
-let find_module path env =
-  find_module ~alias:false path env
-
-let find_module_lazy path env =
-  find_module_lazy ~alias:false path env
-
 (* Find the manifest type associated to a type when appropriate:
    - the type should be public or should have a private row,
    - the type should have an associated manifest type. *)
@@ -1653,29 +1642,6 @@ let find_shadowed_types path env =
     (find_shadowed wrap_identity
        (fun env -> env.types) (fun comps -> comps.comp_types) path env)
 
-(* Expand manifest module type names at the top of the given module type *)
-
-let rec scrape_alias env ?path mty =
-  let open Subst.Lazy in
-  match mty, path with
-    MtyL_ident p, _ ->
-      begin try
-        scrape_alias env (find_modtype_expansion_lazy p env) ?path
-      with Not_found ->
-        mty
-      end
-  | MtyL_alias path, _ ->
-      begin try
-        scrape_alias env ((find_module_lazy path env).mdl_type) ~path
-      with Not_found ->
-        (*Location.prerr_warning Location.none
-          (Warnings.No_cmi_file (Path.name path));*)
-        mty
-      end
-  | mty, Some path ->
-      !strengthen ~aliasable:true env mty path
-  | _ -> mty
-
 (* Given a signature and a root path, prefix all idents in the signature
    by the root path and build the corresponding substitution. *)
 
@@ -1774,7 +1740,7 @@ let is_identchar c =
 let rec components_of_module_maker
           {cm_env; cm_prefixing_subst;
            cm_path; cm_addr; cm_mty; cm_shape} : _ result =
-  match scrape_alias cm_env cm_mty with
+  match !scrape_alias cm_env cm_mty with
     MtyL_signature sg ->
       let c =
         { comp_values = NameMap.empty;
@@ -2209,8 +2175,6 @@ and store_cltype id desc shape env =
     cltypes = IdTbl.add id cltda env.cltypes;
     summary = Env_cltype(env.summary, id, desc) }
 
-let scrape_alias env mty = scrape_alias env mty
-
 (* Compute the components of a functor application in a path. *)
 
 let components_of_functor_appl ~loc ~f_path ~f_comp ~arg env =
@@ -2325,10 +2289,6 @@ let add_module ?arg ?shape id presence mty env =
 let add_local_type path info env =
   { env with
     local_constraints = Path.Map.add path info env.local_constraints }
-
-(* Non-lazy version of scrape_alias *)
-let scrape_alias t mty =
-  mty |> Subst.Lazy.of_modtype |> scrape_alias t |> Subst.Lazy.force_modtype
 
 (* Insertion of bindings by name *)
 

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -86,13 +86,11 @@ val without_cmis: ('a -> 'b) -> 'a -> 'b
 val find_value: Path.t -> t -> value_description
 val find_type: Path.t -> t -> type_declaration
 val find_type_descrs: Path.t -> t -> type_descriptions
-val find_module: Path.t -> t -> module_declaration
+val find_module_lazy: ?alias:bool -> Path.t -> t -> Subst.Lazy.module_decl
+val find_module: ?alias:bool -> Path.t -> t -> module_declaration
 val find_modtype: Path.t -> t -> modtype_declaration
 val find_class: Path.t -> t -> class_declaration
 val find_cltype: Path.t -> t -> class_type_declaration
-
-val find_strengthened_module:
-  aliasable:bool -> Path.t -> t -> module_type
 
 val find_ident_constructor: Ident.t -> t -> constructor_description
 val find_ident_label: Ident.t -> t -> label_description
@@ -481,9 +479,8 @@ val check_well_formed_module:
 (* Forward declaration to break mutual recursion with Typecore. *)
 val add_delayed_check_forward: ((unit -> unit) -> unit) ref
 (* Forward declaration to break mutual recursion with Mtype. *)
-val strengthen:
-    (aliasable:bool -> t -> Subst.Lazy.modtype ->
-     Path.t -> Subst.Lazy.modtype) ref
+val scrape_alias:
+    (t -> Subst.Lazy.modtype -> Subst.Lazy.modtype) ref
 (* Forward declaration to break mutual recursion with Ctype. *)
 val same_constr: (t -> type_expr -> type_expr -> bool) ref
 (* Forward declaration to break mutual recursion with Printtyp. *)
@@ -524,7 +521,6 @@ val fold_cltypes:
 
 
 (** Utilities *)
-val scrape_alias: t -> module_type -> module_type
 val check_value_name: string -> Location.t -> unit
 
 val print_address : Format.formatter -> address -> unit

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -86,8 +86,8 @@ val without_cmis: ('a -> 'b) -> 'a -> 'b
 val find_value: Path.t -> t -> value_description
 val find_type: Path.t -> t -> type_declaration
 val find_type_descrs: Path.t -> t -> type_descriptions
-val find_module_lazy: ?alias:bool -> Path.t -> t -> Subst.Lazy.module_decl
-val find_module: ?alias:bool -> Path.t -> t -> module_declaration
+val find_module_lazy: Path.t -> t -> Subst.Lazy.module_decl
+val find_module: Path.t -> t -> module_declaration
 val find_modtype: Path.t -> t -> modtype_declaration
 val find_class: Path.t -> t -> class_declaration
 val find_cltype: Path.t -> t -> class_type_declaration

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -190,10 +190,7 @@ let expand_modtype_path env path =
      | x -> Some x
 
 let expand_module_alias ~strengthen env path =
-  match
-    if strengthen then Env.find_strengthened_module ~aliasable:true path env
-    else (Env.find_module path env).md_type
-  with
+  match Mtype.find_type_of_module ~strengthen ~aliasable:true env path with
   | x -> Ok x
   | exception Not_found -> Error (Error.Unbound_module_path path)
 
@@ -1230,8 +1227,7 @@ let strengthened_module_decl ~loc ~aliasable env ~mark md1 path1 md2 =
 let expand_module_alias ~strengthen env path =
   match expand_module_alias ~strengthen env path with
   | Ok x -> x
-  | Result.Error _ ->
-      raise (Error(env,In_Expansion(Error.Unbound_module_path path)))
+  | Result.Error e -> raise (Error(env,In_Expansion e))
 
 let check_modtype_equiv ~loc env id mty1 mty2 =
   match check_modtype_equiv ~in_eq:false ~loc env ~mark:Mark_both mty1 mty2 with

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -140,12 +140,8 @@ module Illegal_permutation = struct
 
   (* Find module type at position [path] and convert the [coerce_pos] path to
      a [pos] path *)
-  let rec find env ctx path (mt:Types.module_type) = match mt, path with
-    | (Mty_ident p | Mty_alias p), _ ->
-        begin match (Env.find_modtype p env).mtd_type with
-        | None -> raise Not_found
-        | Some mt -> find env ctx path mt
-        end
+  let rec find env ctx path (mt:Types.module_type) =
+    match Mtype.scrape_alias env mt, path with
     | Mty_signature s , [] -> List.rev ctx, s
     | Mty_signature s, Item k :: q ->
         begin match runtime_item k s with

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -242,7 +242,7 @@ let () = Env.scrape_alias := fun env mty -> scrape_alias_lazy env mty
 
 let find_type_of_module ~strengthen ~aliasable env path =
   if strengthen then
-    let md = Env.find_module_lazy ~alias:true path env in
+    let md = Env.find_module_lazy path env in
     let mty = strengthen_lazy ~aliasable env md.mdl_type path in
     Subst.Lazy.force_modtype mty
   else

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -446,13 +446,9 @@ let no_code_needed env mty = no_code_needed_mod env Mp_present mty
 
 (* Check whether a module type may return types *)
 
-let rec contains_type env = function
-    Mty_ident path ->
-      begin try match (Env.find_modtype path env).mtd_type with
-      | None -> raise Exit (* PR#6427 *)
-      | Some mty -> contains_type env mty
-      with Not_found -> raise Exit
-      end
+let rec contains_type env mty =
+  match scrape env mty with
+    Mty_ident _ -> raise Exit (* PR#6427 *)
   | Mty_signature sg ->
       contains_type_sig env sg
   | Mty_functor (_, body) ->

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -126,8 +126,6 @@ and strengthen_lazy_decl ~aliasable env md p =
   | _ when aliasable -> {md with mdl_type = MtyL_alias p}
   | mty -> {md with mdl_type = strengthen_lazy ~aliasable env mty p}
 
-let () = Env.strengthen := strengthen_lazy
-
 let strengthen ~aliasable env mty p =
   let mty = strengthen_lazy ~aliasable env (Subst.Lazy.of_modtype mty) p in
   Subst.Lazy.force_modtype mty
@@ -210,6 +208,45 @@ let scrape_for_type_of env pres mty =
     | _ -> mty
   in
   make_aliases_absent pres (loop env None mty)
+
+(* Expand manifest module type names at the top of the given module type *)
+
+let rec scrape_alias_lazy env ?path mty =
+  let open Subst.Lazy in
+  match mty, path with
+    MtyL_ident p, _ ->
+      begin try
+        scrape_alias_lazy env (Env.find_modtype_expansion_lazy p env) ?path
+      with Not_found ->
+        mty
+      end
+  | MtyL_alias path, _ ->
+      begin try
+        scrape_alias_lazy env ((Env.find_module_lazy path env).mdl_type) ~path
+      with Not_found ->
+        (*Location.prerr_warning Location.none
+          (Warnings.No_cmi_file (Path.name path));*)
+        mty
+      end
+  | mty, Some path ->
+      strengthen_lazy ~aliasable:true env mty path
+  | _ -> mty
+
+(* Non-lazy version of scrape_alias *)
+let scrape_alias env mty =
+  Subst.Lazy.of_modtype mty
+  |> scrape_alias_lazy env
+  |> Subst.Lazy.force_modtype
+
+let () = Env.scrape_alias := fun env mty -> scrape_alias_lazy env mty
+
+let find_type_of_module ~strengthen ~aliasable env path =
+  if strengthen then
+    let md = Env.find_module_lazy ~alias:true path env in
+    let mty = strengthen_lazy ~aliasable env md.mdl_type path in
+    Subst.Lazy.force_modtype mty
+  else
+    (Env.find_module path env).md_type
 
 (* In nondep_supertype, env is only used for the type it assigns to id.
    Hence there is no need to keep env up-to-date by adding the bindings
@@ -524,7 +561,7 @@ let rec remove_aliases_mty env args pres mty =
       Mty_signature sg ->
         Mp_present, Mty_signature (remove_aliases_sig env args' sg)
     | Mty_alias _ ->
-        let mty' = Env.scrape_alias env mty in
+        let mty' = scrape_alias env mty in
         if mty' = mty then begin
           pres, mty
         end else begin

--- a/typing/mtype.mli
+++ b/typing/mtype.mli
@@ -21,6 +21,10 @@ val scrape: Env.t -> module_type -> module_type
         (* Expand toplevel module type abbreviations
            till hitting a "hard" module type (signature, functor,
            or abstract module type ident. *)
+val scrape_alias: Env.t -> module_type -> module_type
+        (* Expand toplevel module type abbreviations and aliases
+           till hitting a "hard" module type (signature, functor,
+           or abstract module type ident. *)
 val scrape_for_functor_arg: Env.t -> module_type -> module_type
         (* Remove aliases in a functor argument type *)
 val scrape_for_type_of:
@@ -34,6 +38,10 @@ val strengthen: aliasable:bool -> Env.t -> module_type -> Path.t -> module_type
            given path. *)
 val strengthen_decl:
   aliasable:bool -> Env.t -> module_declaration -> Path.t -> module_declaration
+
+val find_type_of_module:
+  strengthen:bool -> aliasable:bool -> Env.t -> Path.t -> module_type
+        (* Get the type of a module, strengthening if necessary. *)
 
 val sig_make_manifest : signature -> signature
         (* Make abstract types manifest.  Similar to strengthening, but rather


### PR DESCRIPTION
This PR contains refactoring and fixes which improve the code around module type lookup and strengthening. While (hopefully) sensible in their own right, the main driver for this work is improving the performance of module type checking in upcoming PRs which rely on the changes in this PR.