### PR TITLE
Constrain curry modes to increase along applications

### DIFF
--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -326,12 +326,12 @@ val apply2 : int -> local_ 'a -> int -> int = <fun>
 |}]
 let apply3 x = g x x x
 [%%expect{|
-Line 1, characters 19-20:
+Line 1, characters 15-20:
 1 | let apply3 x = g x x x
-                       ^
-Error: This application involving locals is complete after this argument,
-       but extra arguments were provided
-  Hint: Try wrapping the application in parentheses up to this argument
+                   ^^^^^
+Error: This application is complete, but further arguments were provided afterwards.
+       With local arguments or closures, these are not allowed in the same application.
+  Hint: Try wrapping the marked application in parentheses.
 |}]
 let apply3_wrapped x = (g x x) x
 [%%expect{|
@@ -345,12 +345,12 @@ Error: This local value escapes its region
 |}]
 let apply4 x = g x x x x
 [%%expect{|
-Line 1, characters 19-20:
+Line 1, characters 15-20:
 1 | let apply4 x = g x x x x
-                       ^
-Error: This application involving locals is complete after this argument,
-       but extra arguments were provided
-  Hint: Try wrapping the application in parentheses up to this argument
+                   ^^^^^
+Error: This application is complete, but further arguments were provided afterwards.
+       With local arguments or closures, these are not allowed in the same application.
+  Hint: Try wrapping the marked application in parentheses.
 |}]
 let apply4_wrapped x = (g x x) x x
 [%%expect{|
@@ -420,12 +420,12 @@ Error: This local value escapes its region
 let app42 (f : a:local_ int ref -> (int -> b:local_ int ref -> c:int -> unit)) =
   f ~a:(local_ ref 1) 2 ~c:4
 [%%expect{|
-Line 2, characters 7-21:
+Line 2, characters 2-21:
 2 |   f ~a:(local_ ref 1) 2 ~c:4
-           ^^^^^^^^^^^^^^
-Error: This application involving locals is complete after this argument,
-       but extra arguments were provided
-  Hint: Try wrapping the application in parentheses up to this argument
+      ^^^^^^^^^^^^^^^^^^^
+Error: This application is complete, but further arguments were provided afterwards.
+       With local arguments or closures, these are not allowed in the same application.
+  Hint: Try wrapping the marked application in parentheses.
 |}]
 let app42_wrapped (f : a:local_ int ref -> (int -> b:local_ int ref -> c:int -> unit)) =
   (f ~a:(local_ ref 1)) 2 ~c:4
@@ -483,12 +483,12 @@ Error: This local value escapes its region
 let app42' (f : a:local_ int ref -> (int -> b:local_ int ref -> c:int -> unit)) =
   f ~a:(ref 1) 2 ~c:4
 [%%expect{|
-Line 2, characters 7-14:
+Line 2, characters 2-14:
 2 |   f ~a:(ref 1) 2 ~c:4
-           ^^^^^^^
-Error: This application involving locals is complete after this argument,
-       but extra arguments were provided
-  Hint: Try wrapping the application in parentheses up to this argument
+      ^^^^^^^^^^^^
+Error: This application is complete, but further arguments were provided afterwards.
+       With local arguments or closures, these are not allowed in the same application.
+  Hint: Try wrapping the marked application in parentheses.
 |}]
 let app42'_wrapped (f : a:local_ int ref -> (int -> b:local_ int ref -> c:int -> unit)) =
   (f ~a:(ref 1)) 2 ~c:4
@@ -500,12 +500,12 @@ val app42'_wrapped :
 let app43' (f : a:local_ int ref -> (int -> b:local_ int ref -> c:int -> unit)) =
   f ~a:(ref 1) 2
 [%%expect{|
-Line 2, characters 7-14:
+Line 2, characters 2-14:
 2 |   f ~a:(ref 1) 2
-           ^^^^^^^
-Error: This application involving locals is complete after this argument,
-       but extra arguments were provided
-  Hint: Try wrapping the application in parentheses up to this argument
+      ^^^^^^^^^^^^
+Error: This application is complete, but further arguments were provided afterwards.
+       With local arguments or closures, these are not allowed in the same application.
+  Hint: Try wrapping the marked application in parentheses.
 |}]
 let app43'_wrapped (f : a:local_ int ref -> (int -> b:local_ int ref -> c:int -> unit)) =
   (f ~a:(ref 1)) 2

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -556,7 +556,13 @@ let bug2 () =
   let res = bar ~a:"world" in
   res
 [%%expect{|
-val bug2 : unit -> c:int -> unit = <fun>
+Line 5, characters 19-33:
+5 |   let bar = local_ foo ~b:"hello" in
+                       ^^^^^^^^^^^^^^
+Error: This application is complete, but surplus arguments were provided afterwards.
+       When passing or calling a local value, extra arguments are passed in a separate application.
+  Hint: Try splitting the application in two, first applying the arguments
+  up to a (in the function's type), and then the rest.
 |}]
 let bug3 () =
   let foo : a:local_ string -> (b:local_ string -> (c:int -> unit)) =
@@ -604,6 +610,17 @@ Error: This application is complete, but surplus arguments were provided afterwa
        When passing or calling a local value, extra arguments are passed in a separate application.
   Hint: Try splitting the application in two, first applying the arguments
   up to the marked one (in the function's type), and then the rest.
+|}]
+
+let () = overapp ~d:1 ~a:2
+[%%expect{|
+Line 1, characters 9-26:
+1 | let () = overapp ~d:1 ~a:2
+             ^^^^^^^^^^^^^^^^^
+Error: This application is complete, but surplus arguments were provided afterwards.
+       When passing or calling a local value, extra arguments are passed in a separate application.
+  Hint: Try splitting the application in two, first applying the arguments
+  up to b (in the function's type), and then the rest.
 |}]
 
 

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -561,8 +561,8 @@ Line 5, characters 19-33:
                        ^^^^^^^^^^^^^^
 Error: This application is complete, but surplus arguments were provided afterwards.
        When passing or calling a local value, extra arguments are passed in a separate application.
-  Hint: Try splitting the application in two, first applying the arguments
-  up to a (in the function's type), and then the rest.
+  Hint: Try splitting the application in two. The arguments that come
+  after a in the function's type should be applied separately.
 |}]
 let bug3 () =
   let foo : a:local_ string -> (b:local_ string -> (c:int -> unit)) =
@@ -597,8 +597,8 @@ Line 1, characters 20-21:
                         ^
 Error: This application is complete, but surplus arguments were provided afterwards.
        When passing or calling a local value, extra arguments are passed in a separate application.
-  Hint: Try splitting the application in two, first applying the arguments
-  up to the marked one (in the function's type), and then the rest.
+  Hint: Try splitting the application in two. The arguments that come
+  after this one in the function's type should be applied separately.
 |}]
 
 let () = overapp ~c:1 ~b:2
@@ -608,8 +608,8 @@ Line 1, characters 25-26:
                              ^
 Error: This application is complete, but surplus arguments were provided afterwards.
        When passing or calling a local value, extra arguments are passed in a separate application.
-  Hint: Try splitting the application in two, first applying the arguments
-  up to the marked one (in the function's type), and then the rest.
+  Hint: Try splitting the application in two. The arguments that come
+  after this one in the function's type should be applied separately.
 |}]
 
 let () = overapp ~d:1 ~a:2
@@ -619,8 +619,8 @@ Line 1, characters 9-26:
              ^^^^^^^^^^^^^^^^^
 Error: This application is complete, but surplus arguments were provided afterwards.
        When passing or calling a local value, extra arguments are passed in a separate application.
-  Hint: Try splitting the application in two, first applying the arguments
-  up to b (in the function's type), and then the rest.
+  Hint: Try splitting the application in two. The arguments that come
+  after b in the function's type should be applied separately.
 |}]
 
 

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -329,8 +329,8 @@ let apply3 x = g x x x
 Line 1, characters 15-20:
 1 | let apply3 x = g x x x
                    ^^^^^
-Error: This application is complete, but further arguments were provided afterwards.
-       With local arguments or closures, these are not allowed in the same application.
+Error: This application is complete, but surplus arguments were provided afterwards.
+       When passing or calling a local value, extra arguments are passed in a separate application.
   Hint: Try wrapping the marked application in parentheses.
 |}]
 let apply3_wrapped x = (g x x) x
@@ -348,8 +348,8 @@ let apply4 x = g x x x x
 Line 1, characters 15-20:
 1 | let apply4 x = g x x x x
                    ^^^^^
-Error: This application is complete, but further arguments were provided afterwards.
-       With local arguments or closures, these are not allowed in the same application.
+Error: This application is complete, but surplus arguments were provided afterwards.
+       When passing or calling a local value, extra arguments are passed in a separate application.
   Hint: Try wrapping the marked application in parentheses.
 |}]
 let apply4_wrapped x = (g x x) x x
@@ -423,8 +423,8 @@ let app42 (f : a:local_ int ref -> (int -> b:local_ int ref -> c:int -> unit)) =
 Line 2, characters 2-21:
 2 |   f ~a:(local_ ref 1) 2 ~c:4
       ^^^^^^^^^^^^^^^^^^^
-Error: This application is complete, but further arguments were provided afterwards.
-       With local arguments or closures, these are not allowed in the same application.
+Error: This application is complete, but surplus arguments were provided afterwards.
+       When passing or calling a local value, extra arguments are passed in a separate application.
   Hint: Try wrapping the marked application in parentheses.
 |}]
 let app42_wrapped (f : a:local_ int ref -> (int -> b:local_ int ref -> c:int -> unit)) =
@@ -486,8 +486,8 @@ let app42' (f : a:local_ int ref -> (int -> b:local_ int ref -> c:int -> unit)) 
 Line 2, characters 2-14:
 2 |   f ~a:(ref 1) 2 ~c:4
       ^^^^^^^^^^^^
-Error: This application is complete, but further arguments were provided afterwards.
-       With local arguments or closures, these are not allowed in the same application.
+Error: This application is complete, but surplus arguments were provided afterwards.
+       When passing or calling a local value, extra arguments are passed in a separate application.
   Hint: Try wrapping the marked application in parentheses.
 |}]
 let app42'_wrapped (f : a:local_ int ref -> (int -> b:local_ int ref -> c:int -> unit)) =
@@ -503,8 +503,8 @@ let app43' (f : a:local_ int ref -> (int -> b:local_ int ref -> c:int -> unit)) 
 Line 2, characters 2-14:
 2 |   f ~a:(ref 1) 2
       ^^^^^^^^^^^^
-Error: This application is complete, but further arguments were provided afterwards.
-       With local arguments or closures, these are not allowed in the same application.
+Error: This application is complete, but surplus arguments were provided afterwards.
+       When passing or calling a local value, extra arguments are passed in a separate application.
   Hint: Try wrapping the marked application in parentheses.
 |}]
 let app43'_wrapped (f : a:local_ int ref -> (int -> b:local_ int ref -> c:int -> unit)) =
@@ -571,6 +571,41 @@ Line 3, characters 63-64:
                                                                    ^
 Error: The value a is local, so cannot be used inside a closure that might escape
 |}]
+let overapp ~(local_ a) ~b = (); fun ~c ~d -> ()
+
+let () = overapp ~a:1 ~b:2 ~c:3 ~d:4
+[%%expect{|
+val overapp : a:local_ 'a -> b:'b -> (c:'c -> d:'d -> unit) = <fun>
+Line 3, characters 9-26:
+3 | let () = overapp ~a:1 ~b:2 ~c:3 ~d:4
+             ^^^^^^^^^^^^^^^^^
+Error: This application is complete, but surplus arguments were provided afterwards.
+       When passing or calling a local value, extra arguments are passed in a separate application.
+  Hint: Try wrapping the marked application in parentheses.
+|}]
+
+let () = overapp ~b:2 ~a:1 ~c:3 ~d:4
+[%%expect{|
+Line 1, characters 20-21:
+1 | let () = overapp ~b:2 ~a:1 ~c:3 ~d:4
+                        ^
+Error: This application is complete, but surplus arguments were provided afterwards.
+       When passing or calling a local value, extra arguments are passed in a separate application.
+  Hint: Try splitting the application in two, first applying the arguments
+  up to the marked one (in the function's type), and then the rest.
+|}]
+
+let () = overapp ~c:1 ~b:2
+[%%expect{|
+Line 1, characters 25-26:
+1 | let () = overapp ~c:1 ~b:2
+                             ^
+Error: This application is complete, but surplus arguments were provided afterwards.
+       When passing or calling a local value, extra arguments are passed in a separate application.
+  Hint: Try splitting the application in two, first applying the arguments
+  up to the marked one (in the function's type), and then the rest.
+|}]
+
 
 (* Regression test for bug with mishandled regional function modes *)
 let bug4 : local_ (string -> foo:string -> unit) -> (string -> unit) =

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -326,9 +326,18 @@ val apply2 : int -> local_ 'a -> int -> int = <fun>
 |}]
 let apply3 x = g x x x
 [%%expect{|
-Line 1, characters 15-22:
+Line 1, characters 19-20:
 1 | let apply3 x = g x x x
-                   ^^^^^^^
+                       ^
+Error: This application involving locals is complete after this argument,
+       but extra arguments were provided
+  Hint: Try wrapping the application in parentheses up to this argument
+|}]
+let apply3_wrapped x = (g x x) x
+[%%expect{|
+Line 1, characters 23-32:
+1 | let apply3_wrapped x = (g x x) x
+                           ^^^^^^^^^
 Error: This local value escapes its region
   Hint: Cannot return local value without an explicit "local_" annotation
   Hint: This is a partial application
@@ -336,7 +345,40 @@ Error: This local value escapes its region
 |}]
 let apply4 x = g x x x x
 [%%expect{|
-val apply4 : int -> int = <fun>
+Line 1, characters 19-20:
+1 | let apply4 x = g x x x x
+                       ^
+Error: This application involving locals is complete after this argument,
+       but extra arguments were provided
+  Hint: Try wrapping the application in parentheses up to this argument
+|}]
+let apply4_wrapped x = (g x x) x x
+[%%expect{|
+val apply4_wrapped : int -> int = <fun>
+|}]
+let ill_typed () = g 1 2 3 4 5
+[%%expect{|
+Line 1, characters 19-20:
+1 | let ill_typed () = g 1 2 3 4 5
+                       ^
+Error: This function has type local_ 'a -> int -> (local_ 'b -> int -> int)
+       It is applied to too many arguments; maybe you forgot a `;'.
+|}]
+
+(*
+ * Defaulting of modes in module type of (like mli-less files)
+ *)
+
+let f g = g (local_ (1, 2)) 1 2 3 [@nontail]
+[%%expect{|
+val f : (local_ int * int -> int -> int -> int -> 'a) -> 'a = <fun>
+|}]
+module type F = module type of struct
+  let f g = g (local_ (1, 2)) 1 2 3 [@nontail]
+end
+[%%expect{|
+module type F =
+  sig val f : (local_ int * int -> int -> int -> int -> 'a) -> 'a end
 |}]
 
 (*
@@ -378,7 +420,17 @@ Error: This local value escapes its region
 let app42 (f : a:local_ int ref -> (int -> b:local_ int ref -> c:int -> unit)) =
   f ~a:(local_ ref 1) 2 ~c:4
 [%%expect{|
-val app42 :
+Line 2, characters 7-21:
+2 |   f ~a:(local_ ref 1) 2 ~c:4
+           ^^^^^^^^^^^^^^
+Error: This application involving locals is complete after this argument,
+       but extra arguments were provided
+  Hint: Try wrapping the application in parentheses up to this argument
+|}]
+let app42_wrapped (f : a:local_ int ref -> (int -> b:local_ int ref -> c:int -> unit)) =
+  (f ~a:(local_ ref 1)) 2 ~c:4
+[%%expect{|
+val app42_wrapped :
   (a:local_ int ref -> (int -> b:local_ int ref -> c:int -> unit)) ->
   b:local_ int ref -> unit = <fun>
 |}]
@@ -431,14 +483,34 @@ Error: This local value escapes its region
 let app42' (f : a:local_ int ref -> (int -> b:local_ int ref -> c:int -> unit)) =
   f ~a:(ref 1) 2 ~c:4
 [%%expect{|
-val app42' :
+Line 2, characters 7-14:
+2 |   f ~a:(ref 1) 2 ~c:4
+           ^^^^^^^
+Error: This application involving locals is complete after this argument,
+       but extra arguments were provided
+  Hint: Try wrapping the application in parentheses up to this argument
+|}]
+let app42'_wrapped (f : a:local_ int ref -> (int -> b:local_ int ref -> c:int -> unit)) =
+  (f ~a:(ref 1)) 2 ~c:4
+[%%expect{|
+val app42'_wrapped :
   (a:local_ int ref -> (int -> b:local_ int ref -> c:int -> unit)) ->
   b:local_ int ref -> unit = <fun>
 |}]
 let app43' (f : a:local_ int ref -> (int -> b:local_ int ref -> c:int -> unit)) =
   f ~a:(ref 1) 2
 [%%expect{|
-val app43' :
+Line 2, characters 7-14:
+2 |   f ~a:(ref 1) 2
+           ^^^^^^^
+Error: This application involving locals is complete after this argument,
+       but extra arguments were provided
+  Hint: Try wrapping the application in parentheses up to this argument
+|}]
+let app43'_wrapped (f : a:local_ int ref -> (int -> b:local_ int ref -> c:int -> unit)) =
+  (f ~a:(ref 1)) 2
+[%%expect{|
+val app43'_wrapped :
   (a:local_ int ref -> (int -> b:local_ int ref -> c:int -> unit)) ->
   b:local_ int ref -> c:int -> unit = <fun>
 |}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -7812,8 +7812,8 @@ let report_error ~loc env = function
              "@[Hint: Try wrapping the marked application in parentheses.@]"]
         | `Single_arg ->
           [Location.msg
-             "@[Hint: Try splitting the application in two, first applying the arguments@ \
-              up to the marked one (in the function's type), and then the rest.@]"]
+             "@[Hint: Try splitting the application in two. The arguments that come@ \
+              after this one in the function's type should be applied separately.@]"]
         | `Entire_apply ->
           let lbl =
             match lbl with
@@ -7821,8 +7821,8 @@ let report_error ~loc env = function
             | Labelled s | Optional s -> s
           in
           [Location.msg
-             "@[Hint: Try splitting the application in two, first applying the arguments@ \
-             up to %s (in the function's type), and then the rest.@]" lbl]
+             "@[Hint: Try splitting the application in two. The arguments that come@ \
+              after %s in the function's type should be applied separately.@]" lbl]
       in
       Location.errorf ~loc ~sub
         "@[This application is complete, but surplus arguments were provided afterwards.@ \

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2814,6 +2814,14 @@ let remaining_function_type ty_ret mode_ret rev_args =
   in
   ty_ret
 
+(* Check that within a single application, the return modes of curried arrows
+   increase along the application. That is, check that this is not an
+   unparenthesized over-application of a local function that returns a global
+   function.
+
+   This check is not required for soundness, but including it simplifies the
+   principal types of applications, making the inferred types more sensible
+   in ml files that lack an mli. *)
 let rec check_local_application_complete ~env ~app_loc args =
   match args with
   | [] | [_] -> ()
@@ -7777,8 +7785,8 @@ let report_error ~loc env = function
       Location.errorf ~loc ~sub "This %svalue escapes its region" mode
   | Local_application_complete ->
       Location.errorf ~loc
-        "@[This application is complete, but further arguments were provided afterwards.@ \
-         With local arguments or closures, these are not allowed in the same application.@]"
+        "@[This application is complete, but surplus arguments were provided afterwards.@ \
+         When passing or calling a local value, extra arguments are passed in a separate application.@]"
         ~sub:[Location.msg
             "@[Hint: Try wrapping the marked application in parentheses.@]"]
   | Param_mode_mismatch ty ->

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -253,7 +253,7 @@ type error =
   | Wrong_expected_kind of wrong_kind_sort * wrong_kind_context * type_expr
   | Expr_not_a_record_type of type_expr
   | Local_value_escapes of Value_mode.error * submode_reason * Env.escaping_context option
-  | Local_application_complete
+  | Local_application_complete of [`Prefix|`Single_arg]
   | Param_mode_mismatch of type_expr
   | Uncurried_function_escapes
   | Local_return_annotation_mismatch of Location.t

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -253,7 +253,7 @@ type error =
   | Wrong_expected_kind of wrong_kind_sort * wrong_kind_context * type_expr
   | Expr_not_a_record_type of type_expr
   | Local_value_escapes of Value_mode.error * submode_reason * Env.escaping_context option
-  | Local_application_complete of [`Prefix|`Single_arg]
+  | Local_application_complete of Asttypes.arg_label * [`Prefix|`Single_arg|`Entire_apply]
   | Param_mode_mismatch of type_expr
   | Uncurried_function_escapes
   | Local_return_annotation_mismatch of Location.t

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -253,6 +253,7 @@ type error =
   | Wrong_expected_kind of wrong_kind_sort * wrong_kind_context * type_expr
   | Expr_not_a_record_type of type_expr
   | Local_value_escapes of Value_mode.error * submode_reason * Env.escaping_context option
+  | Local_application_complete
   | Param_mode_mismatch of type_expr
   | Uncurried_function_escapes
   | Local_return_annotation_mismatch of Location.t


### PR DESCRIPTION
In short, this patch rejects certain sound-but-weird typings of applications, so that the principal type of an application is less weird. This matters because in certain contexts (particularly, files with no `mli`), the user actually sees the principal type of expressions, so making it not be weird is good.

Specifically, this patch enforces that in a multiple argument application `f a b c d`, then if any of the intermediate partial applications `f`, `f a`, `f a b` and `f a b c` are local, then all subsequent ones must be also.

This does mean that typing can reject more programs than before. In particular, overapplications of functions with local arguments now yield an error:
```
let f (g : local_ string -> int -> (int -> int -> unit)) = g (local_ "a") 2 3 4 [@nontail]
```
yields:
```
Error: This application involving locals is complete after this argument,
       but extra arguments were provided
  Hint: Try wrapping the application in parentheses up to this argument
```
pointing to the second argument `2`.

As the hint suggests, replacing the body with `(g (local_ "a") 2) 3 4` (splitting the overapplication into two applications) resolves the issue.

The benefit is that if the user writes the same function without a type annotation, as:
```
let f g = g (local_ "a") 2 3 4 [@nontail]
```
then in a file with no mli, this patch changes the inferred type to:
```
val f : (g : local_ string -> int -> int -> int -> 'a) -> 'a
```
which is probably what the user intended.