### PR TITLE
fix several issues when removing exp_mode

### DIFF
--- a/.depend
+++ b/.depend
@@ -403,6 +403,7 @@ parsing/docstrings.cmi : \
     parsing/location.cmi
 parsing/extensions.cmo : \
     parsing/parsetree.cmi \
+    utils/misc.cmi \
     parsing/location.cmi \
     utils/clflags.cmi \
     parsing/asttypes.cmi \
@@ -410,6 +411,7 @@ parsing/extensions.cmo : \
     parsing/extensions.cmi
 parsing/extensions.cmx : \
     parsing/parsetree.cmi \
+    utils/misc.cmx \
     parsing/location.cmx \
     utils/clflags.cmx \
     parsing/asttypes.cmi \
@@ -1547,9 +1549,7 @@ typing/typecore.cmi : \
     typing/ident.cmi \
     typing/errortrace.cmi \
     typing/env.cmi \
-    typing/ctype.cmi \
     utils/clflags.cmi \
-    typing/btype.cmi \
     parsing/asttypes.cmi
 typing/typedecl.cmo : \
     utils/warnings.cmi \
@@ -3823,14 +3823,17 @@ lambda/transl_array_comprehension.cmi : \
 lambda/transl_comprehension_utils.cmo : \
     typing/primitive.cmi \
     lambda/lambda.cmi \
+    typing/ident.cmi \
     lambda/transl_comprehension_utils.cmi
 lambda/transl_comprehension_utils.cmx : \
     typing/primitive.cmx \
     lambda/lambda.cmx \
+    typing/ident.cmx \
     lambda/transl_comprehension_utils.cmi
 lambda/transl_comprehension_utils.cmi : \
     parsing/location.cmi \
-    lambda/lambda.cmi
+    lambda/lambda.cmi \
+    typing/ident.cmi
 lambda/transl_list_comprehension.cmo : \
     typing/typeopt.cmi \
     typing/typedtree.cmi \
@@ -3929,6 +3932,7 @@ lambda/translcore.cmo : \
     typing/typecore.cmi \
     lambda/translprim.cmi \
     lambda/translobj.cmi \
+    lambda/translmode.cmi \
     lambda/translattribute.cmi \
     lambda/transl_list_comprehension.cmi \
     lambda/transl_array_comprehension.cmi \
@@ -3961,6 +3965,7 @@ lambda/translcore.cmx : \
     typing/typecore.cmx \
     lambda/translprim.cmx \
     lambda/translobj.cmx \
+    lambda/translmode.cmx \
     lambda/translattribute.cmx \
     lambda/transl_list_comprehension.cmx \
     lambda/transl_array_comprehension.cmx \
@@ -3986,7 +3991,6 @@ lambda/translcore.cmx : \
     parsing/asttypes.cmi \
     lambda/translcore.cmi
 lambda/translcore.cmi : \
-    typing/types.cmi \
     typing/typedtree.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
@@ -4050,6 +4054,17 @@ lambda/translmod.cmi : \
     lambda/lambda.cmi \
     typing/ident.cmi \
     utils/compilation_unit.cmi
+lambda/translmode.cmo : \
+    typing/types.cmi \
+    lambda/lambda.cmi \
+    lambda/translmode.cmi
+lambda/translmode.cmx : \
+    typing/types.cmx \
+    lambda/lambda.cmx \
+    lambda/translmode.cmi
+lambda/translmode.cmi : \
+    typing/types.cmi \
+    lambda/lambda.cmi
 lambda/translobj.cmo : \
     typing/primitive.cmi \
     utils/misc.cmi \
@@ -4083,6 +4098,7 @@ lambda/translprim.cmo : \
     typing/types.cmi \
     typing/typeopt.cmi \
     typing/typedtree.cmi \
+    lambda/translmode.cmi \
     typing/primitive.cmi \
     typing/predef.cmi \
     typing/path.cmi \
@@ -4101,6 +4117,7 @@ lambda/translprim.cmx : \
     typing/types.cmx \
     typing/typeopt.cmx \
     typing/typedtree.cmx \
+    lambda/translmode.cmx \
     typing/primitive.cmx \
     typing/predef.cmx \
     typing/path.cmx \

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -2347,8 +2347,8 @@ let assignment_kind
     (ptr: Lambda.immediate_or_pointer)
     (init: Lambda.initialization_or_assignment) =
   match init, ptr with
-  | Assignment Alloc_heap, Pointer -> Caml_modify
-  | Assignment Alloc_local, Pointer ->
+  | Assignment Modify_heap, Pointer -> Caml_modify
+  | Assignment Modify_maybe_stack, Pointer ->
     assert Config.stack_allocation;
     Caml_modify_local
   | Heap_initialization, _ ->

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -132,6 +132,7 @@ LAMBDA = \
   lambda/printlambda.cmo \
   lambda/switch.cmo \
   lambda/matching.cmo \
+  lambda/translmode.cmo \
   lambda/transl_comprehension_utils.cmo \
   lambda/transl_array_comprehension.cmo \
   lambda/transl_list_comprehension.cmo \

--- a/dune
+++ b/dune
@@ -87,6 +87,7 @@
 
    ;; lambda/
    debuginfo lambda matching printlambda runtimedef tmc simplif switch
+   translmode
    transl_comprehension_utils
    transl_array_comprehension transl_list_comprehension
    translattribute translclass translcore translmod translobj translprim
@@ -317,6 +318,7 @@
     (runtimedef.mli as compiler-libs/runtimedef.mli)
     (simplif.mli as compiler-libs/simplif.mli)
     (switch.mli as compiler-libs/switch.mli)
+    (translmode.mli as compiler-libs/translmode.mli)
     (translattribute.mli as compiler-libs/translattribute.mli)
     (translclass.mli as compiler-libs/translclass.mli)
     (translcore.mli as compiler-libs/translcore.mli)

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -38,15 +38,23 @@ type alloc_mode = private
   | Alloc_heap
   | Alloc_local
 
+type modify_mode = private
+  | Modify_heap
+  | Modify_maybe_stack
+
 val alloc_heap : alloc_mode
 
 (* Actually [Alloc_heap] if [Config.stack_allocation] is [false] *)
 val alloc_local : alloc_mode
 
+val modify_heap : modify_mode
+
+val modify_maybe_stack : modify_mode
+
 type initialization_or_assignment =
   (* [Assignment Alloc_local] is a mutation of a block that may be heap or local.
      [Assignment Alloc_heap] is a mutation of a block that's definitely heap. *)
-  | Assignment of alloc_mode
+  | Assignment of modify_mode
   (* Initialization of in heap values, like [caml_initialize] C primitive.  The
      field should not have been read before and initialization should happen
      only once. *)

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -252,8 +252,8 @@ let primitive ppf = function
         match init with
         | Heap_initialization -> "(heap-init)"
         | Root_initialization -> "(root-init)"
-        | Assignment Alloc_heap -> ""
-        | Assignment Alloc_local -> "(local)"
+        | Assignment Modify_heap -> ""
+        | Assignment Modify_maybe_stack -> "(maybe-stack)"
       in
       fprintf ppf "setfield_%s%s %i" instr init n
   | Psetfield_computed (ptr, init) ->
@@ -266,8 +266,8 @@ let primitive ppf = function
         match init with
         | Heap_initialization -> "(heap-init)"
         | Root_initialization -> "(root-init)"
-        | Assignment Alloc_heap -> ""
-        | Assignment Alloc_local -> "(local)"
+        | Assignment Modify_heap -> ""
+        | Assignment Modify_maybe_stack -> "(maybe-stack)"
       in
       fprintf ppf "setfield_%s%s_computed" instr init
   | Pfloatfield (n, sem, mode) ->
@@ -278,8 +278,8 @@ let primitive ppf = function
         match init with
         | Heap_initialization -> "(heap-init)"
         | Root_initialization -> "(root-init)"
-        | Assignment Alloc_heap -> ""
-        | Assignment Alloc_local -> "(local)"
+        | Assignment Modify_heap -> ""
+        | Assignment Modify_maybe_stack -> "(maybe-stack)"
       in
       fprintf ppf "setfloatfield%s %i" init n
   | Pduprecord (rep, size) -> fprintf ppf "duprecord %a %i" record_rep rep size

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -86,7 +86,7 @@ let transl_meth_list lst =
             (0, List.map (fun lab -> Const_immstring lab) lst))
 
 let set_inst_var ~scopes obj id expr =
-  Lprim(Psetfield_computed (Typeopt.maybe_pointer expr, Assignment alloc_heap),
+  Lprim(Psetfield_computed (Typeopt.maybe_pointer expr, Assignment modify_heap),
     [Lvar obj; Lvar id; transl_exp ~scopes expr], Loc_unknown)
 
 let transl_val tbl create name =
@@ -770,7 +770,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
   let env1 = Ident.create_local "env" and env1' = Ident.create_local "env'" in
   let copy_env self =
     if top then lambda_unit else
-    Lifused(env2, Lprim(Psetfield_computed (Pointer, Assignment alloc_heap),
+    Lifused(env2, Lprim(Psetfield_computed (Pointer, Assignment modify_heap),
                         [Lvar self; Lvar env2; Lvar env1'],
                         Loc_unknown))
   and subst_env envs l lam =
@@ -921,7 +921,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
                                     inh_keys, Loc_unknown)]),
          lam)
   and lset cached i lam =
-    Lprim(Psetfield(i, Pointer, Assignment alloc_heap),
+    Lprim(Psetfield(i, Pointer, Assignment modify_heap),
           [Lvar cached; lam], Loc_unknown)
   in
   let ldirect () =

--- a/lambda/translcore.mli
+++ b/lambda/translcore.mli
@@ -43,8 +43,6 @@ val transl_extension_constructor: scopes:scopes ->
 
 val transl_scoped_exp : scopes:scopes -> expression -> lambda
 
-val transl_alloc_mode : Types.alloc_mode -> Lambda.alloc_mode
-
 type error =
     Free_super_var
   | Unreachable_reached

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -110,8 +110,7 @@ let rec apply_coercion loc strict restr arg =
       let carg = apply_coercion loc Alias cc_arg (Lvar param) in
       apply_coercion_result loc strict arg [param, Pgenval] [carg] cc_res
   | Tcoerce_primitive { pc_desc; pc_env; pc_type; pc_poly_mode } ->
-      let poly_mode = Option.map Translcore.transl_alloc_mode pc_poly_mode in
-      Translprim.transl_primitive loc pc_desc pc_env pc_type ~poly_mode None
+      Translprim.transl_primitive loc pc_desc pc_env pc_type ~poly_mode:pc_poly_mode None
   | Tcoerce_alias (env, path, cc) ->
       let lam = transl_module_path loc env path in
       name_lambda strict arg
@@ -625,12 +624,8 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
                       match cc with
                       | Tcoerce_primitive p ->
                           let loc = of_location ~scopes p.pc_loc in
-                          let poly_mode =
-                            Option.map
-                              Translcore.transl_alloc_mode p.pc_poly_mode
-                          in
                           Translprim.transl_primitive
-                            loc p.pc_desc p.pc_env p.pc_type ~poly_mode None
+                            loc p.pc_desc p.pc_env p.pc_type ~poly_mode:p.pc_poly_mode None
                       | _ -> apply_coercion loc Strict cc (get_field pos))
                     pos_cc_list, loc)
             and id_pos_list =
@@ -1085,8 +1080,7 @@ let field_of_str loc str =
   fun (pos, cc) ->
     match cc with
     | Tcoerce_primitive { pc_desc; pc_env; pc_type; pc_poly_mode } ->
-        let poly_mode = Option.map Translcore.transl_alloc_mode pc_poly_mode in
-        Translprim.transl_primitive loc pc_desc pc_env pc_type ~poly_mode None
+        Translprim.transl_primitive loc pc_desc pc_env pc_type ~poly_mode:pc_poly_mode None
     | Tcoerce_alias (env, path, cc) ->
         let lam = transl_module_path loc env path in
         apply_coercion loc Alias cc lam
@@ -1417,13 +1411,10 @@ let transl_store_structure ~scopes glob map prims aliases str =
     List.fold_right (add_ident may_coerce) idlist subst
 
   and store_primitive (pos, prim) cont =
-    let poly_mode =
-      Option.map Translcore.transl_alloc_mode prim.pc_poly_mode
-    in
     Lsequence(Lprim(mod_setfield pos,
                     [Lprim(Pgetglobal glob, [], Loc_unknown);
                      Translprim.transl_primitive Loc_unknown
-                       prim.pc_desc prim.pc_env prim.pc_type ~poly_mode None],
+                       prim.pc_desc prim.pc_env prim.pc_type ~poly_mode:prim.pc_poly_mode None],
                     Loc_unknown),
               cont)
 

--- a/lambda/translmode.ml
+++ b/lambda/translmode.ml
@@ -1,0 +1,11 @@
+open Types
+open Lambda
+let transl_alloc_mode alloc_mode =
+  match Alloc_mode.constrain_lower alloc_mode with
+  | Global -> alloc_heap
+  | Local -> alloc_local
+
+let transl_modify_mode alloc_mode =
+  match Alloc_mode.constrain_lower alloc_mode with
+  | Global -> modify_heap
+  | Local -> modify_maybe_stack

--- a/lambda/translmode.mli
+++ b/lambda/translmode.mli
@@ -1,0 +1,3 @@
+val transl_alloc_mode : Types.alloc_mode -> Lambda.alloc_mode
+
+val transl_modify_mode : Types.alloc_mode -> Lambda.modify_mode

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -22,6 +22,7 @@ open Typedtree
 open Typeopt
 open Lambda
 open Debuginfo.Scoped_location
+open Translmode
 
 type error =
   | Unknown_builtin_primitive of string
@@ -122,11 +123,19 @@ let to_alloc_mode ~poly = function
   | Prim_poly, _ ->
     match poly with
     | None -> assert false
-    | Some mode -> mode
+    | Some mode -> transl_alloc_mode mode
+
+let to_modify_mode ~poly = function
+  | Prim_global, _ -> modify_heap
+  | Prim_local, _ -> modify_maybe_stack
+  | Prim_poly, _ ->
+    match poly with
+    | None -> assert false
+    | Some mode -> transl_modify_mode mode
 
 let lookup_primitive loc poly pos p =
   let mode = to_alloc_mode ~poly p.prim_native_repr_res in
-  let arg_modes = List.map (to_alloc_mode ~poly) p.prim_native_repr_args in
+  let arg_modes = List.map (to_modify_mode ~poly) p.prim_native_repr_args in
   let prim = match p.prim_name with
     | "%identity" -> Identity
     | "%bytes_to_string" -> Primitive (Pbytes_to_string, 1)
@@ -759,8 +768,8 @@ let lambda_of_prim prim_name prim loc args arg_exps =
 let check_primitive_arity loc p =
   let mode =
     match p.prim_native_repr_res with
-    | Prim_global, _ | Prim_poly, _ -> Some alloc_heap
-    | Prim_local, _ -> Some alloc_local
+    | Prim_global, _ | Prim_poly, _ -> Some Alloc_mode.global
+    | Prim_local, _ -> Some Alloc_mode.local
   in
   let prim = lookup_primitive loc mode Rc_normal p in
   let ok =

--- a/lambda/translprim.mli
+++ b/lambda/translprim.mli
@@ -35,13 +35,13 @@ val check_primitive_arity :
 val transl_primitive :
   Lambda.scoped_location -> Primitive.description -> Env.t ->
   Types.type_expr ->
-  poly_mode:Lambda.alloc_mode option ->
+  poly_mode:Types.alloc_mode option ->
   Path.t option ->
   Lambda.lambda
 
 val transl_primitive_application :
   Lambda.scoped_location -> Primitive.description -> Env.t ->
-  Types.type_expr -> Lambda.alloc_mode option -> Path.t ->
+  Types.type_expr -> Types.alloc_mode option -> Path.t ->
   Typedtree.expression option ->
   Lambda.lambda list -> Typedtree.expression list ->
   Lambda.region_close -> Lambda.lambda

--- a/middle_end/printclambda_primitives.ml
+++ b/middle_end/printclambda_primitives.ml
@@ -84,8 +84,8 @@ let primitive ppf (prim:Clambda_primitives.primitive) =
         match init with
         | Heap_initialization -> "(heap-init)"
         | Root_initialization -> "(root-init)"
-        | Assignment Alloc_heap -> ""
-        | Assignment Alloc_local -> "(local)"
+        | Assignment Modify_heap -> ""
+        | Assignment Modify_maybe_stack -> "(maybe-stack)"
       in
       fprintf ppf "setfield_%s%s %i" instr init n
   | Psetfield_computed (ptr, init) ->
@@ -98,8 +98,8 @@ let primitive ppf (prim:Clambda_primitives.primitive) =
         match init with
         | Heap_initialization -> "(heap-init)"
         | Root_initialization -> "(root-init)"
-        | Assignment Alloc_heap -> ""
-        | Assignment Alloc_local -> "(local)"
+        | Assignment Modify_heap -> ""
+        | Assignment Modify_maybe_stack -> "(maybe-stack)"
       in
       fprintf ppf "setfield_%s%s_computed" instr init
   | Pfloatfield (n, Alloc_heap) -> fprintf ppf "floatfield %i" n
@@ -109,8 +109,8 @@ let primitive ppf (prim:Clambda_primitives.primitive) =
         match init with
         | Heap_initialization -> "(heap-init)"
         | Root_initialization -> "(root-init)"
-        | Assignment Alloc_heap -> ""
-        | Assignment Alloc_local -> "(local)"
+        | Assignment Modify_heap -> ""
+        | Assignment Modify_maybe_stack -> "(maybe-stack)"
       in
       fprintf ppf "setfloatfield%s %i" init n
   | Pduprecord (rep, size) ->

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -325,6 +325,8 @@ and alloc_mode i ppf m =
   | None -> "<modevar>"
   )
 
+and alloc_mode_option i ppf m = Option.iter (alloc_mode i ppf) m
+
 and expression_alloc_mode i ppf (expr, am) =
   alloc_mode i ppf am;
   expression i ppf expr
@@ -377,7 +379,7 @@ and expression i ppf x =
       list i expression ppf l;
   | Texp_construct (li, _, eo, am) ->
       line i ppf "Texp_construct %a\n" fmt_longident li;
-      alloc_mode i ppf am;
+      alloc_mode_option i ppf am;
       list i expression ppf eo;
   | Texp_variant (l, eo) ->
       line i ppf "Texp_variant \"%s\"\n" l;
@@ -385,7 +387,7 @@ and expression i ppf x =
   | Texp_record { fields; representation; extended_expression; alloc_mode = am} ->
       line i ppf "Texp_record\n";
       let i = i+1 in
-      alloc_mode i ppf am;
+      alloc_mode_option i ppf am;
       line i ppf "fields =\n";
       array (i+1) record_field ppf fields;
       line i ppf "representation =\n";
@@ -394,7 +396,7 @@ and expression i ppf x =
       option (i+1) expression ppf extended_expression;
   | Texp_field (e, li, _, am) ->
       line i ppf "Texp_field\n";
-      alloc_mode i ppf am;
+      alloc_mode_option i ppf am;
       expression i ppf e;
       longident i ppf li;
   | Texp_setfield (e1, am, li, _, e2) ->

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1255,7 +1255,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
               )
             in
             let eliminate_optional_arg () =
-              Arg (option_none val_env ty0 Value_mode.global Location.none)
+              Arg (option_none val_env ty0 Location.none)
             in
             let remaining_sargs, arg =
               if ignore_labels then begin

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -501,7 +501,7 @@ let option_some env texp mode =
   let alloc_mode  = register_allocation_value_mode mode in
   let lid = Longident.Lident "Some" in
   let csome = Env.find_ident_constructor Predef.ident_some env in
-  mkexp ( Texp_construct(mknoloc lid , csome, [texp], Some alloc_mode) )
+  mkexp (Texp_construct(mknoloc lid , csome, [texp], Some alloc_mode))
     (type_option texp.exp_type) texp.exp_loc texp.exp_env
 
 let extract_option_type env ty =
@@ -2459,7 +2459,7 @@ and type_pat_aux
       let path, new_env =
         !type_open Asttypes.Fresh !env sp.ppat_loc lid in
       env := new_env;
-      type_pat category ~env p expected_ty ( fun p ->
+      type_pat category ~env p expected_ty (fun p ->
         let new_env = !env in
         begin match Env.remove_last_open path new_env with
         | None -> assert false
@@ -2978,7 +2978,7 @@ let rec is_nonexpansive exp =
   | Texp_probe {handler} -> is_nonexpansive handler
   | Texp_tuple (el, _) ->
       List.for_all is_nonexpansive el
-  | Texp_construct( _, _, el, _) ->
+  | Texp_construct(_, _, el, _) ->
       List.for_all is_nonexpansive el
   | Texp_variant(_, arg) -> is_nonexpansive_opt (Option.map fst arg)
   | Texp_record { fields; extended_expression } ->
@@ -4099,7 +4099,7 @@ and type_expect_
         | Some sarg ->
             let arg = type_exp env argument_mode sarg in
             let alloc_mode = register_allocation expected_mode in
-            Some ( arg, alloc_mode )
+            Some (arg, alloc_mode)
         in
         let arg_type = Option.map (fun (arg, _) -> arg.exp_type) arg in
         let row =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -492,17 +492,16 @@ let mkexp exp_desc exp_type exp_loc exp_env =
   { exp_desc; exp_type;
     exp_loc; exp_env; exp_extra = []; exp_attributes = [] }
 
-let option_none env ty mode loc =
-  let alloc_mode = Value_mode.regional_to_global_alloc mode in
+let option_none env ty loc =
   let lid = Longident.Lident "None" in
   let cnone = Env.find_ident_constructor Predef.ident_none env in
-  mkexp (Texp_construct(mknoloc lid, cnone, [], alloc_mode)) ty loc env
+  mkexp (Texp_construct(mknoloc lid, cnone, [], None)) ty loc env
 
 let option_some env texp mode =
   let alloc_mode  = register_allocation_value_mode mode in
   let lid = Longident.Lident "Some" in
   let csome = Env.find_ident_constructor Predef.ident_some env in
-  mkexp ( Texp_construct(mknoloc lid , csome, [texp], alloc_mode) )
+  mkexp ( Texp_construct(mknoloc lid , csome, [texp], Some alloc_mode) )
     (type_option texp.exp_type) texp.exp_loc texp.exp_env
 
 let extract_option_type env ty =
@@ -511,14 +510,14 @@ let extract_option_type env ty =
   | _ -> assert false
 
 type record_extraction_result =
-  | Record_type of Path.t * Path.t * Types.label_declaration list
+  | Record_type of Path.t * Path.t * Types.label_declaration list * record_representation
   | Not_a_record_type
   | Maybe_a_record_type
 
 let extract_concrete_record env ty =
   match extract_concrete_typedecl env ty with
-  | Typedecl(p0, p, {type_kind=Type_record (fields, _)}) ->
-    Record_type (p0, p, fields)
+  | Typedecl(p0, p, {type_kind=Type_record (fields, repres)}) ->
+    Record_type (p0, p, fields, repres)
   | Has_no_typedecl | Typedecl(_, _, _) -> Not_a_record_type
   | May_have_typedecl -> Maybe_a_record_type
 
@@ -538,7 +537,7 @@ let extract_concrete_variant env ty =
 
 let extract_label_names env ty =
   match extract_concrete_record env ty with
-  | Record_type (_, _,fields) -> List.map (fun l -> l.Types.ld_id) fields
+  | Record_type (_, _,fields, _) -> List.map (fun l -> l.Types.ld_id) fields
   | Not_a_record_type | Maybe_a_record_type -> assert false
 
 let is_principal ty =
@@ -2278,7 +2277,7 @@ and type_pat_aux
       assert (lid_sp_list <> []);
       let expected_type, record_ty =
         match extract_concrete_record !env expected_ty with
-        | Record_type(p0, p, _) ->
+        | Record_type(p0, p, _, _) ->
             let ty = generic_instance expected_ty in
             Some (p0, p, is_principal expected_ty), ty
         | Maybe_a_record_type -> None, newvar ()
@@ -2937,7 +2936,7 @@ let type_omitted_parameters expected_mode env ty_ret mode_ret args =
              let closed_args = new_closed_args @ closed_args in
              let open_args = [] in
              let mode_closure = Alloc_mode.join (mode_fun :: closed_args) in
-             ignore (register_allocation_mode mode_closure);
+             register_allocation_mode mode_closure;
              let arg = Omitted { mode_closure; mode_arg; mode_ret } in
              let args = (lbl, arg) :: args in
              (ty_ret, mode_closure, open_args, closed_args, args))
@@ -3758,7 +3757,6 @@ and type_expect_
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
   | Pexp_constant(Pconst_string (str, _, _) as cst) ->
-      ignore (register_allocation expected_mode);
       let cst = constant_or_raise env loc cst in
       (* Terrible hack for format strings *)
       let ty_exp = expand_head env ty_expected in
@@ -4098,8 +4096,10 @@ and type_expect_
       with Exit ->
         let arg = match sarg with
         | None -> None
-        | Some sarg -> Some (type_exp env argument_mode sarg,
-                        register_allocation expected_mode)
+        | Some sarg ->
+            let arg = type_exp env argument_mode sarg in
+            let alloc_mode = register_allocation expected_mode in
+            Some ( arg, alloc_mode )
         in
         let arg_type = Option.map (fun (arg, _) -> arg.exp_type) arg in
         let row =
@@ -4135,7 +4135,7 @@ and type_expect_
       let ty_record, expected_type =
         let expected_opath =
           match extract_concrete_record env ty_expected with
-          | Record_type (p0, p, _) -> Some (p0, p, is_principal ty_expected)
+          | Record_type (p0, p, _, _) -> Some (p0, p, is_principal ty_expected)
           | Maybe_a_record_type -> None
           | Not_a_record_type ->
             let error =
@@ -4148,7 +4148,7 @@ and type_expect_
           | None -> None
           | Some exp ->
             match extract_concrete_record env exp.exp_type with
-            | Record_type (p0, p, _) -> Some (p0, p, is_principal exp.exp_type)
+            | Record_type (p0, p, _, _) -> Some (p0, p, is_principal exp.exp_type)
             | Maybe_a_record_type -> None
             | Not_a_record_type ->
               let error = Expr_not_a_record_type exp.exp_type in
@@ -4177,12 +4177,16 @@ and type_expect_
       in
       with_explanation (fun () ->
         unify_exp_types loc env (instance ty_record) (instance ty_expected));
-      if List.exists
-           (function
-            | _, { lbl_repres = Record_unboxed _; _ }, _ -> false
-            | _ -> true)
-           lbl_exp_list then
-        ignore (register_allocation expected_mode);
+      let alloc_mode =
+        if List.exists
+            (function
+              | _, { lbl_repres = Record_unboxed _; _ }, _ -> false
+              | _ -> true)
+            lbl_exp_list then
+          Some (register_allocation expected_mode)
+        else
+          None
+      in
       (* type_label_a_list returns a list of labels sorted by lbl_pos *)
       (* note: check_duplicates would better be implemented in
          type_label_a_list directly *)
@@ -4262,7 +4266,7 @@ and type_expect_
         exp_desc = Texp_record {
             fields; representation;
             extended_expression = opt_exp;
-            alloc_mode = Value_mode.regional_to_global_alloc expected_mode.mode
+            alloc_mode
           };
         exp_loc = loc; exp_extra = [];
         exp_type = instance ty_expected;
@@ -4271,6 +4275,11 @@ and type_expect_
   | Pexp_field(srecord, lid) ->
       let (record, rmode, label, _) =
         type_label_access env srecord Env.Projection lid
+      in
+      let alloc_mode = match label.lbl_repres with
+      (* projecting out of packed-float-record needs allocation *)
+        | Record_float -> Some (register_allocation expected_mode)
+        | _ -> None
       in
       let mode =
         match label.lbl_global with
@@ -4297,9 +4306,7 @@ and type_expect_
         end;
       let mode = mode_cross env ty_arg mode in
       ruem ~mode ~expected_mode {
-        exp_desc = Texp_field(record, lid, label,
-            Value_mode.regional_to_global_alloc expected_mode.mode
-          );
+        exp_desc = Texp_field(record, lid, label, alloc_mode);
         exp_loc = loc; exp_extra = [];
         exp_type = ty_arg;
         exp_attributes = sexp.pexp_attributes;
@@ -4317,7 +4324,7 @@ and type_expect_
         raise(Error(loc, env, Label_not_mutable lid.txt));
       rue {
         exp_desc = Texp_setfield(record,
-          Value_mode.regional_to_global_alloc rmode,
+          Value_mode.regional_to_local_alloc rmode,
           label_loc, label, newval);
         exp_loc = loc; exp_extra = [];
         exp_type = instance Predef.type_unit;
@@ -4644,7 +4651,7 @@ and type_expect_
       in
       rue {
         exp_desc = Texp_send(obj, meth, ap_pos,
-          Value_mode.regional_to_global_alloc expected_mode.mode
+          register_allocation expected_mode
         );
         exp_loc = loc; exp_extra = [];
         exp_type = typ;
@@ -5323,7 +5330,7 @@ and type_label_access env srecord usage lid =
   let ty_exp = record.exp_type in
   let expected_type =
     match extract_concrete_record env ty_exp with
-    | Record_type(p0, p, _) ->
+    | Record_type(p0, p, _, _) ->
         Some(p0, p, is_principal ty_exp)
     | Maybe_a_record_type -> None
     | Not_a_record_type ->
@@ -5728,11 +5735,10 @@ and type_argument ?explanation ?recarg env (mode : expected_mode) sarg
       end;
       let rec make_args args ty_fun =
         match get_desc (expand_head env ty_fun) with
-        | Tarrow ((l,marg,_mret),ty_arg,ty_fun,_) when is_optional l ->
-            let marg = Value_mode.of_alloc marg in
+        | Tarrow ((l,_marg,_mret),ty_arg,ty_fun,_) when is_optional l ->
             let ty =
               option_none env (instance (tpoly_get_mono ty_arg))
-                marg sarg.pexp_loc
+                sarg.pexp_loc
             in
             make_args ((l, Arg ty) :: args) ty_fun
         | Tarrow ((l,_,_),_,ty_res',_) when l = Nolabel || !Clflags.classic ->
@@ -5898,10 +5904,7 @@ and type_apply_arg env ~app_loc ~funct ~index ~position ~partial_app (lbl, arg) 
       in
       (lbl, Arg (arg, expected_mode.mode))
   | Arg (Eliminated_optional_arg { ty_arg; _ }) ->
-      let arg =
-        option_none env (instance ty_arg)
-          Value_mode.global Location.none
-      in
+      let arg = option_none env (instance ty_arg) Location.none in
       (lbl, Arg (arg, Value_mode.global))
   | Omitted _ as arg -> (lbl, arg)
 
@@ -6011,9 +6014,7 @@ and type_construct env (expected_mode : expected_mode) loc lid sarg
   let (ty_args, ty_res, _) = instance_constructor constr in
   let texp =
     re {
-      exp_desc = Texp_construct(lid, constr, [],
-        Value_mode.regional_to_global_alloc expected_mode.mode
-      );
+      exp_desc = Texp_construct(lid, constr, [], None);
       exp_loc = loc; exp_extra = [];
       exp_type = ty_res;
       exp_attributes = attrs;
@@ -6048,15 +6049,15 @@ and type_construct env (expected_mode : expected_mode) loc lid sarg
         raise (Error(loc, env, Inlined_record_expected))
       end
   in
-  let argument_mode =
+  let (argument_mode, alloc_mode) =
     match constr.cstr_tag with
-    | Cstr_unboxed -> expected_mode
+    | Cstr_unboxed -> expected_mode, None
     | Cstr_constant _ ->
        assert (sargs = []);
-       expected_mode
+       expected_mode, None
     | Cstr_block _ | Cstr_extension _ ->
-       ignore (register_allocation expected_mode);
-       mode_subcomponent expected_mode
+       mode_subcomponent expected_mode,
+       Some (register_allocation expected_mode)
   in
   let args =
     List.map2
@@ -6082,8 +6083,7 @@ and type_construct env (expected_mode : expected_mode) loc lid sarg
     end;
   (* NOTE: shouldn't we call "re" on this final expression? -- AF *)
   { texp with
-    exp_desc = Texp_construct(lid, constr, args,
-      Value_mode.regional_to_global_alloc expected_mode.mode) }
+    exp_desc = Texp_construct(lid, constr, args, alloc_mode) }
 
 (* Typing of statements (expressions whose values are discarded) *)
 

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -144,7 +144,7 @@ val type_argument:
 val option_some:
   Env.t -> Typedtree.expression -> value_mode -> Typedtree.expression
 val option_none:
-  Env.t -> type_expr -> value_mode -> Location.t -> Typedtree.expression
+  Env.t -> type_expr -> Location.t -> Typedtree.expression
 val extract_option_type: Env.t -> type_expr -> type_expr
 val generalizable: int -> type_expr -> bool
 val reset_delayed_checks: unit -> unit

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -116,15 +116,15 @@ and expression_desc =
   | Texp_try of expression * value case list
   | Texp_tuple of expression list * Types.alloc_mode
   | Texp_construct of
-      Longident.t loc * constructor_description * expression list * Types.alloc_mode
+      Longident.t loc * constructor_description * expression list * Types.alloc_mode option
   | Texp_variant of label * (expression * Types.alloc_mode) option
   | Texp_record of {
       fields : ( Types.label_description * record_label_definition ) array;
       representation : Types.record_representation;
       extended_expression : expression option;
-      alloc_mode : Types.alloc_mode
+      alloc_mode : Types.alloc_mode option
     }
-  | Texp_field of expression * Longident.t loc * label_description * Types.alloc_mode
+  | Texp_field of expression * Longident.t loc * label_description * Types.alloc_mode option
   | Texp_setfield of
       expression * Types.alloc_mode * Longident.t loc * label_description * expression
   | Texp_array of expression list * Types.alloc_mode


### PR DESCRIPTION
This commit fixes several issues introduced by https://github.com/ocaml-flambda/ocaml-jst/pull/100 

- There is a BUG as pointed out below. 
- Related to the BUG, in `lambda.mli` we replace the `alloc_mode` in `Assignment` with `modify_mode`, because this bit is not about where to allocate a new thing, but about whether the block being modified is on heap or potentially on stack. 
- The remaining names for the mode types (`Value_mode`, `alloc_mode`) are still confusing - we have decided a better naming scheme, and I think it's easier to carry that out in the uniqueness PR.
- In `Texp_field`, `Texp_construct` and `Texp_record` we put `alloc_mode` inside `option` - they will be `Some` only when they actually allocate.
- Minor performance improvements: 
  - register allocation for `Texp_send` and `Texp_field`(when projecting out of `Record_float`), so that these allocations will try to be on stack. 
  - remove registering allocation for constant string because there is no allocation. 


