### PR TITLE
Consistently use Lmutvar or Lvar in comprehensions

### DIFF
--- a/lambda/transl_comprehension_utils.ml
+++ b/lambda/transl_comprehension_utils.ml
@@ -11,22 +11,16 @@ module Let_binding = struct
     { let_kind   : Let_kind.t
     ; value_kind : value_kind
     ; id         : Ident.t
-    ; init       : lambda }
+    ; init       : lambda
+    ; var        : lambda }
 
-  let make_id let_kind value_kind name init =
+  let make (let_kind : Let_kind.t) value_kind name init =
     let id = Ident.create_local name in
-    id, {let_kind; value_kind; id; init}
-
-  let make_id_binding let_kind value_kind name init =
-    snd @@ make_id let_kind value_kind name init
-
-  let make_id_var let_kind value_kind name init =
-    let id, binding = make_id let_kind value_kind name init in
-    id, Lvar id, binding
-
-  let make_var let_kind value_kind name init =
-    let _id, var, binding = make_id_var let_kind value_kind name init in
-    var, binding
+    let var = match let_kind with
+      | Mutable -> Lmutvar id
+      | Immutable _ -> Lvar id
+    in
+    {let_kind; value_kind; id; init; var}
 
   let let_one {let_kind; value_kind; id; init} body =
     match let_kind with

--- a/lambda/transl_comprehension_utils.mli
+++ b/lambda/transl_comprehension_utils.mli
@@ -25,29 +25,17 @@ module Let_binding : sig
   end
 
   (** The first-class (in OCaml) type of let bindings. *)
-  type t =
+  type t = private
     { let_kind   : Let_kind.t
     ; value_kind : value_kind
     ; id         : Ident.t
-    ; init       : lambda }
+    ; init       : lambda   (* initial value *)
+    ; var        : lambda   (* occurrence of this variable *)
+    }
 
-  (** Create a fresh local identifier to bind (from a string), and return that
-      it along with the Lambda variable (with [Lvar]) for it and the
-      corresponding let binding. *)
-  val make_id_var :
-    Let_kind.t -> value_kind -> string -> lambda -> Ident.t * lambda * t
-
-  (** Create a fresh local identifier to bind (from a string), and return it
-      along with the corresponding let binding. *)
-  val make_id : Let_kind.t -> value_kind -> string -> lambda -> Ident.t * t
-
-  (** Create a fresh local identifier to bind (from a string), and return its
-      corresponding Lambda variable (with [Lvar]) and let binding. *)
-  val make_var : Let_kind.t -> value_kind -> string -> lambda -> lambda * t
-
-  (** Create a fresh local identifier to bind (from a string), and return the
-      corresponding let binding. *)
-  val make_id_binding : Let_kind.t -> value_kind -> string -> lambda -> t
+  (** Create a fresh local identifier (with name as given by the string
+      argument) to bind to an initial value given by the lambda argument. *)
+  val make : Let_kind.t -> value_kind -> string -> lambda -> t
 
   (** Create a Lambda let-binding (with [Llet]) from a first-class let
       binding, providing the body. *)

--- a/lambda/transl_list_comprehension.ml
+++ b/lambda/transl_list_comprehension.ml
@@ -168,7 +168,7 @@ let iterator ~transl_exp ~scopes = function
       (* We have to let-bind [start] and [stop] so that they're evaluated in the
          correct (i.e., left-to-right) order *)
       let transl_bound var bound =
-        Let_binding.make_id_binding
+        Let_binding.make
           (Immutable Strict) Pintval
           var (transl_exp ~scopes bound)
       in
@@ -184,7 +184,7 @@ let iterator ~transl_exp ~scopes = function
       }
   | Texp_comp_in { pattern; sequence } ->
       let iter_list =
-        Let_binding.make_id_binding (Immutable Strict) Pgenval
+        Let_binding.make (Immutable Strict) Pgenval
           "iter_list" (transl_exp ~scopes sequence)
       in
       (* Create a fresh variable to use as the function argument *)

--- a/testsuite/tests/comprehensions/array_comprehensions_side_effects.ml
+++ b/testsuite/tests/comprehensions/array_comprehensions_side_effects.ml
@@ -1,6 +1,5 @@
 (* TEST
   flags = "-extension comprehensions_experimental"
-   * skip
 *)
 
 (******************************************************************************


### PR DESCRIPTION
This commit adds an `occur` field to `Let_binding` so that it can correctly use `Lvar` or `Lmutvar`. Tiny bonus: fewer allocations from Lvar nodes, because now we just create one.