### PR TITLE
Print `nlocal` in the `-d(raw)lambda` output

### DIFF
--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -644,7 +644,8 @@ let rec lam ppf = function
   | Lfunction{kind; params; return; body; attr; mode; region} ->
       let pr_params ppf params =
         match kind with
-        | Curried _ ->
+        | Curried {nlocal} ->
+            fprintf ppf "@ {nlocal = %d}" nlocal;
             List.iter (fun (param, k) ->
                 fprintf ppf "@ %a%a" Ident.print param value_kind k) params
         | Tupled ->

--- a/testsuite/tests/basic-modules/anonymous.ocamlc.reference
+++ b/testsuite/tests/basic-modules/anonymous.ocamlc.reference
@@ -20,12 +20,13 @@
           (module-defn(B) Anonymous anonymous.ml(33):703-773
             (let (x =[(consts ()) (non_consts ([0: *, *]))] [0: "foo" "bar"])
               (makeblock 0))))
-        (let (f = (function param : int 0) s = (makemutable 0 ""))
+        (let
+          (f = (function {nlocal = 0} param : int 0) s = (makemutable 0 ""))
           (seq
             (ignore
               (let (*match* = (setfield_ptr 0 s "Hello World!"))
                 (makeblock 0)))
             (let
-              (drop = (function param : int 0)
+              (drop = (function {nlocal = 0} param : int 0)
                *match* = (apply drop (field_mut 0 s)))
               (makeblock 0 A B f s drop))))))))

--- a/testsuite/tests/basic-modules/anonymous.ocamlopt.flambda.reference
+++ b/testsuite/tests/basic-modules/anonymous.ocamlopt.flambda.reference
@@ -19,11 +19,11 @@
         (module-defn(B) Anonymous anonymous.ml(33):703-773
           (let (x =[(consts ()) (non_consts ([0: *, *]))] [0: "foo" "bar"])
             (makeblock 0))))
-      (let (f = (function param : int 0) s = (makemutable 0 ""))
+      (let (f = (function {nlocal = 0} param : int 0) s = (makemutable 0 ""))
         (seq
           (ignore
             (let (*match* = (setfield_ptr 0 s "Hello World!")) (makeblock 0)))
           (let
-            (drop = (function param : int 0)
+            (drop = (function {nlocal = 0} param : int 0)
              *match* = (apply drop (field_mut 0 s)))
             (makeblock 0 A B f s drop)))))))

--- a/testsuite/tests/basic-modules/anonymous.ocamlopt.reference
+++ b/testsuite/tests/basic-modules/anonymous.ocamlopt.reference
@@ -19,7 +19,7 @@
           (makeblock 0)))
       (setfield_ptr(root-init) 0 (global Anonymous!) A)
       (setfield_ptr(root-init) 1 (global Anonymous!) B)
-      (let (f = (function param : int 0))
+      (let (f = (function {nlocal = 0} param : int 0))
         (setfield_ptr(root-init) 2 (global Anonymous!) f))
       (let (s = (makemutable 0 ""))
         (setfield_ptr(root-init) 3 (global Anonymous!) s))
@@ -28,7 +28,7 @@
           (*match* =
              (setfield_ptr 0 (field 3 (global Anonymous!)) "Hello World!"))
           (makeblock 0)))
-      (let (drop = (function param : int 0))
+      (let (drop = (function {nlocal = 0} param : int 0))
         (setfield_ptr(root-init) 4 (global Anonymous!) drop))
       (let
         (*match* =

--- a/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -82,8 +82,8 @@ let _ = fun a b ->
   | ((true, _) as _g)
   | ((false, _) as _g) -> ()
 [%%expect{|
-(function a/287[int] b/288 : int 0)
-(function a/287[int] b/288 : int 0)
+(function {nlocal = 0} a/287[int] b/288 : int 0)
+(function {nlocal = 0} a/287[int] b/288 : int 0)
 - : bool -> 'a -> unit = <fun>
 |}];;
 
@@ -102,14 +102,14 @@ let _ = fun a b -> match a, b with
 | (false, _) as p -> p
 (* outside, trivial *)
 [%%expect {|
-(function a/291[int] b/292
+(function {nlocal = 0} a/291[int] b/292
   [(consts ()) (non_consts ([0: [int], *]))](let
                                               (p/293 =a[(consts ())
                                                         (non_consts (
                                                         [0: [int], *]))]
                                                  (makeblock 0 a/291 b/292))
                                               p/293))
-(function a/291[int] b/292
+(function {nlocal = 0} a/291[int] b/292
   [(consts ()) (non_consts ([0: [int], *]))](makeblock 0 a/291 b/292))
 - : bool -> 'a -> bool * 'a = <fun>
 |}]
@@ -119,14 +119,14 @@ let _ = fun a b -> match a, b with
 | ((false, _) as p) -> p
 (* inside, trivial *)
 [%%expect{|
-(function a/295[int] b/296
+(function {nlocal = 0} a/295[int] b/296
   [(consts ()) (non_consts ([0: [int], *]))](let
                                               (p/297 =a[(consts ())
                                                         (non_consts (
                                                         [0: [int], *]))]
                                                  (makeblock 0 a/295 b/296))
                                               p/297))
-(function a/295[int] b/296
+(function {nlocal = 0} a/295[int] b/296
   [(consts ()) (non_consts ([0: [int], *]))](makeblock 0 a/295 b/296))
 - : bool -> 'a -> bool * 'a = <fun>
 |}];;
@@ -136,7 +136,7 @@ let _ = fun a b -> match a, b with
 | (false as x, _) as p -> x, p
 (* outside, simple *)
 [%%expect {|
-(function a/301[int] b/302
+(function {nlocal = 0} a/301[int] b/302
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
   (let
@@ -145,7 +145,7 @@ let _ = fun a b -> match a, b with
        (makeblock 0 a/301 b/302))
     (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/303
       p/304)))
-(function a/301[int] b/302
+(function {nlocal = 0} a/301[int] b/302
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
   (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) a/301
@@ -158,7 +158,7 @@ let _ = fun a b -> match a, b with
 | ((false as x, _) as p) -> x, p
 (* inside, simple *)
 [%%expect {|
-(function a/307[int] b/308
+(function {nlocal = 0} a/307[int] b/308
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
   (let
@@ -167,7 +167,7 @@ let _ = fun a b -> match a, b with
        (makeblock 0 a/307 b/308))
     (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/309
       p/310)))
-(function a/307[int] b/308
+(function {nlocal = 0} a/307[int] b/308
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
   (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) a/307
@@ -180,7 +180,7 @@ let _ = fun a b -> match a, b with
 | (false, x) as p -> x, p
 (* outside, complex *)
 [%%expect{|
-(function a/317[int] b/318[int]
+(function {nlocal = 0} a/317[int] b/318[int]
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
   (if a/317
@@ -196,7 +196,7 @@ let _ = fun a b -> match a, b with
          (makeblock 0 a/317 b/318))
       (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/321
         p/322))))
-(function a/317[int] b/318[int]
+(function {nlocal = 0} a/317[int] b/318[int]
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
   (if a/317
@@ -213,7 +213,7 @@ let _ = fun a b -> match a, b with
   -> x, p
 (* inside, complex *)
 [%%expect{|
-(function a/323[int] b/324[int]
+(function {nlocal = 0} a/323[int] b/324[int]
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
   (catch
@@ -231,7 +231,7 @@ let _ = fun a b -> match a, b with
    with (10 x/325[int] p/326[(consts ()) (non_consts ([0: [int], [int]]))])
     (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/325
       p/326)))
-(function a/323[int] b/324[int]
+(function {nlocal = 0} a/323[int] b/324[int]
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
   (catch
@@ -252,7 +252,7 @@ let _ = fun a b -> match a, b with
 | (false as x, _) as p -> x, p
 (* outside, onecase *)
 [%%expect {|
-(function a/333[int] b/334[int]
+(function {nlocal = 0} a/333[int] b/334[int]
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
   (if a/333
@@ -268,7 +268,7 @@ let _ = fun a b -> match a, b with
          (makeblock 0 a/333 b/334))
       (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/337
         p/338))))
-(function a/333[int] b/334[int]
+(function {nlocal = 0} a/333[int] b/334[int]
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
   (if a/333
@@ -284,7 +284,7 @@ let _ = fun a b -> match a, b with
 | ((false as x, _) as p) -> x, p
 (* inside, onecase *)
 [%%expect{|
-(function a/339[int] b/340
+(function {nlocal = 0} a/339[int] b/340
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
   (let
@@ -293,7 +293,7 @@ let _ = fun a b -> match a, b with
        (makeblock 0 a/339 b/340))
     (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/341
       p/342)))
-(function a/339[int] b/340
+(function {nlocal = 0} a/339[int] b/340
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
   (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) a/339
@@ -314,7 +314,7 @@ let _ =fun a b -> match a, b with
 | (_, _) as p -> p
 (* outside, tuplist *)
 [%%expect {|
-(function a/352[int]
+(function {nlocal = 0} a/352[int]
   b/353[(consts (0))
         (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))]]))]
   [(consts ())
@@ -342,7 +342,7 @@ let _ =fun a b -> match a, b with
                                                                     a/352
                                                                     b/353))
                                                                     p/355)))
-(function a/352[int]
+(function {nlocal = 0} a/352[int]
   b/353[(consts (0))
         (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))]]))]
   [(consts ())
@@ -365,7 +365,7 @@ let _ = fun a b -> match a, b with
 | ((_, _) as p) -> p
 (* inside, tuplist *)
 [%%expect{|
-(function a/356[int]
+(function {nlocal = 0} a/356[int]
   b/357[(consts (0))
         (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))]]))]
   [(consts ())
@@ -405,7 +405,7 @@ let _ = fun a b -> match a, b with
                                                                     (non_consts (
                                                                     [0: *]))]]))])
                                                                     p/358))
-(function a/356[int]
+(function {nlocal = 0} a/356[int]
   b/357[(consts (0))
         (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))]]))]
   [(consts ())

--- a/testsuite/tests/basic/patmatch_split_no_or.ml
+++ b/testsuite/tests/basic/patmatch_split_no_or.ml
@@ -16,7 +16,8 @@ let last_is_anys = function
 [%%expect{|
 (let
   (last_is_anys/11 =
-     (function param/13[(consts ()) (non_consts ([0: [int], [int]]))] : int
+     (function {nlocal = 0}
+       param/13[(consts ()) (non_consts ([0: [int], [int]]))] : int
        (catch
          (if (field 0 param/13) (if (field 1 param/13) (exit 1) 1)
            (if (field 1 param/13) (exit 1) 2))
@@ -33,7 +34,8 @@ let last_is_vars = function
 [%%expect{|
 (let
   (last_is_vars/18 =
-     (function param/22[(consts ()) (non_consts ([0: [int], [int]]))] : int
+     (function {nlocal = 0}
+       param/22[(consts ()) (non_consts ([0: [int], [int]]))] : int
        (catch
          (if (field 0 param/22) (if (field 1 param/22) (exit 3) 1)
            (if (field 1 param/22) (exit 3) 2))
@@ -75,8 +77,8 @@ let f = function
    B/27 = (apply (field 0 (global Toploop!)) "B/27")
    A/26 = (apply (field 0 (global Toploop!)) "A/26")
    f/29 =
-     (function param/31[(consts ()) (non_consts ([0: *, [int], [int]]))]
-       : int
+     (function {nlocal = 0}
+       param/31[(consts ()) (non_consts ([0: *, [int], [int]]))] : int
        (let (*match*/32 =a (field 0 param/31))
          (catch
            (if (== *match*/32 A/26) (if (field 1 param/31) 1 (exit 8))

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -175,7 +175,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
 (setglobal Test_locations!
   (letrec
     (fib
-       (function n[int] : int
+       (function {nlocal = 0} n[int] : int
          (funct-body Test_locations.fib test_locations.ml(17):548-606
            (if (isout 1 n)
              (before Test_locations.fib test_locations.ml(19):581-606

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -175,6 +175,6 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
 (setglobal Test_locations!
   (letrec
     (fib
-       (function n[int] : int
+       (function {nlocal = 0} n[int] : int
          (if (isout 1 n) (+ (apply fib (- n 1)) (apply fib (- n 2))) 1)))
     (makeblock 0 fib)))

--- a/testsuite/tests/functors/functors.compilers.reference
+++ b/testsuite/tests/functors/functors.compilers.reference
@@ -2,54 +2,62 @@
   (let
     (O =
        (module-defn(O) Functors functors.ml(12):184-279
-         (function X is_a_functor always_inline never_loop
+         (function {nlocal = 0} X is_a_functor always_inline never_loop
            (let
-             (cow = (function x[int] : int (apply (field 0 X) x))
-              sheep = (function x[int] : int (+ 1 (apply cow x))))
+             (cow =
+                (function {nlocal = 0} x[int] : int (apply (field 0 X) x))
+              sheep =
+                (function {nlocal = 0} x[int] : int (+ 1 (apply cow x))))
              (makeblock 0 cow sheep))))
      F =
        (module-defn(F) Functors functors.ml(17):281-392
-         (function X Y is_a_functor always_inline never_loop
+         (function {nlocal = 0} X Y is_a_functor always_inline never_loop
            (let
              (cow =
-                (function x[int] : int
+                (function {nlocal = 0} x[int] : int
                   (apply (field 0 Y) (apply (field 0 X) x)))
-              sheep = (function x[int] : int (+ 1 (apply cow x))))
+              sheep =
+                (function {nlocal = 0} x[int] : int (+ 1 (apply cow x))))
              (makeblock 0 cow sheep))))
      F1 =
        (module-defn(F1) Functors functors.ml(31):516-632
-         (function X Y is_a_functor always_inline never_loop
+         (function {nlocal = 0} X Y is_a_functor always_inline never_loop
            (let
              (cow =
-                (function x[int] : int
+                (function {nlocal = 0} x[int] : int
                   (apply (field 0 Y) (apply (field 0 X) x)))
-              sheep = (function x[int] : int (+ 1 (apply cow x))))
+              sheep =
+                (function {nlocal = 0} x[int] : int (+ 1 (apply cow x))))
              (makeblock 0 sheep))))
      F2 =
        (module-defn(F2) Functors functors.ml(36):634-784
-         (function X Y is_a_functor always_inline never_loop
+         (function {nlocal = 0} X Y is_a_functor always_inline never_loop
            (let
              (X =a (makeblock 0 (field 1 X))
               Y =a (makeblock 0 (field 1 Y))
               cow =
-                (function x[int] : int
+                (function {nlocal = 0} x[int] : int
                   (apply (field 0 Y) (apply (field 0 X) x)))
-              sheep = (function x[int] : int (+ 1 (apply cow x))))
+              sheep =
+                (function {nlocal = 0} x[int] : int (+ 1 (apply cow x))))
              (makeblock 0 sheep))))
      M =
        (module-defn(M) Functors functors.ml(41):786-970
          (let
            (F =
               (module-defn(F) Functors.M functors.ml(44):849-966
-                (function X Y is_a_functor always_inline never_loop
+                (function {nlocal = 0} X Y is_a_functor always_inline
+                  never_loop
                   (let
                     (cow =
-                       (function x[int] : int
+                       (function {nlocal = 0} x[int] : int
                          (apply (field 0 Y) (apply (field 0 X) x)))
-                     sheep = (function x[int] : int (+ 1 (apply cow x))))
+                     sheep =
+                       (function {nlocal = 0} x[int] : int
+                         (+ 1 (apply cow x))))
                     (makeblock 0 cow sheep)))))
            (makeblock 0
-             (function funarg funarg is_a_functor stub
+             (function {nlocal = 0} funarg funarg is_a_functor stub
                (let
                  (let =
                     (apply F (makeblock 0 (field 1 funarg))

--- a/testsuite/tests/tmc/readable_output.ml
+++ b/testsuite/tests/tmc/readable_output.ml
@@ -10,7 +10,7 @@ let[@tail_mod_cons] rec map f = function
 [%%expect{|
 (letrec
   (map
-     (function f
+     (function {nlocal = 0} f
        param[(consts (0))
              (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
        tail_mod_cons
@@ -27,7 +27,7 @@ let[@tail_mod_cons] rec map f = function
            (seq (apply map_dps block 1 f (field 1 param)) block))
          0))
     map_dps
-      (function dst offset[int] f
+      (function {nlocal = 0} dst offset[int] f
         param[(consts (0))
               (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
         tail_mod_cons
@@ -65,7 +65,8 @@ let[@tail_mod_cons] rec rec_map f = function
 [%%expect{|
 (letrec
   (rec_map
-     (function f param[(consts (0)) (non_consts ([0: *]))] tail_mod_cons
+     (function {nlocal = 0} f param[(consts (0)) (non_consts ([0: *]))]
+       tail_mod_cons
        [(consts (0)) (non_consts ([0: *]))](if param
                                              (let
                                                (*match* =a (field 0 param))
@@ -90,8 +91,8 @@ let[@tail_mod_cons] rec rec_map f = function
                                                      block))))
                                              0))
     rec_map_dps
-      (function dst offset[int] f param[(consts (0)) (non_consts ([0: *]))]
-        tail_mod_cons
+      (function {nlocal = 0} dst offset[int] f
+        param[(consts (0)) (non_consts ([0: *]))] tail_mod_cons
         [(consts (0)) (non_consts ([0: *]))](if param
                                               (let
                                                 (*match* =a (field 0 param)
@@ -132,7 +133,7 @@ let[@tail_mod_cons] rec trip = function
 [%%expect{|
 (letrec
   (trip
-     (function
+     (function {nlocal = 0}
        param[(consts (0))
              (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
        tail_mod_cons
@@ -164,7 +165,7 @@ let[@tail_mod_cons] rec trip = function
                  (seq (apply trip_dps block 1 (field 1 param)) block)))))
          0))
     trip_dps
-      (function dst offset[int]
+      (function {nlocal = 0} dst offset[int]
         param[(consts (0))
               (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
         tail_mod_cons
@@ -210,7 +211,7 @@ let[@tail_mod_cons] rec effects f = function
 [%%expect{|
 (letrec
   (effects
-     (function f
+     (function {nlocal = 0} f
        param[(consts (0))
              (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
        tail_mod_cons
@@ -233,7 +234,7 @@ let[@tail_mod_cons] rec effects f = function
                (seq (apply effects_dps block 1 f (field 1 param)) block))))
          0))
     effects_dps
-      (function dst offset[int] f
+      (function {nlocal = 0} dst offset[int] f
         param[(consts (0))
               (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
         tail_mod_cons
@@ -276,7 +277,7 @@ let[@tail_mod_cons] rec map_stutter f xs =
 [%%expect{|
 (letrec
   (map_stutter
-     (function f
+     (function {nlocal = 0} f
        xs[(consts (0))
           (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
        tail_mod_cons
@@ -297,7 +298,7 @@ let[@tail_mod_cons] rec map_stutter f xs =
              (seq (apply map_stutter_dps block 1 f (field 1 xs)) block))
            0)))
     map_stutter_dps
-      (function dst offset[int] f
+      (function {nlocal = 0} dst offset[int] f
         xs[(consts (0))
            (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
         tail_mod_cons
@@ -346,7 +347,7 @@ let[@tail_mod_cons] rec smap_stutter f xs n =
 type 'a stream = { hd : 'a; tl : unit -> 'a stream; }
 (letrec
   (smap_stutter
-     (function f xs[(consts ()) (non_consts ([0: *, *]))] n[int]
+     (function {nlocal = 0} f xs[(consts ()) (non_consts ([0: *, *]))] n[int]
        tail_mod_cons
        [(consts (0))
         (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
@@ -369,8 +370,8 @@ type 'a stream = { hd : 'a; tl : unit -> 'a stream; }
                  (- n 1))
                block)))))
     smap_stutter_dps
-      (function dst offset[int] f xs[(consts ()) (non_consts ([0: *, *]))]
-        n[int] tail_mod_cons
+      (function {nlocal = 0} dst offset[int] f
+        xs[(consts ()) (non_consts ([0: *, *]))] n[int] tail_mod_cons
         [(consts (0))
          (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
         (if (== n 0) (setfield_ptr(heap-init)_computed dst offset 0)

--- a/testsuite/tests/translprim/array_spec.compilers.flat.reference
+++ b/testsuite/tests/translprim/array_spec.compilers.flat.reference
@@ -5,59 +5,74 @@
      addr_a =[addrarray] (makearray[addr] "a" "b" "c"))
     (seq (array.length[int] int_a) (array.length[float] float_a)
       (array.length[addr] addr_a)
-      (function a[genarray] : int (array.length[gen] a))
+      (function {nlocal = 0} a[genarray] : int (array.length[gen] a))
       (array.get[int] int_a 0) (array.get[float] float_a 0)
-      (array.get[addr] addr_a 0) (function a[genarray] (array.get[gen] a 0))
+      (array.get[addr] addr_a 0)
+      (function {nlocal = 0} a[genarray] (array.get[gen] a 0))
       (array.unsafe_get[int] int_a 0) (array.unsafe_get[float] float_a 0)
       (array.unsafe_get[addr] addr_a 0)
-      (function a[genarray] (array.unsafe_get[gen] a 0))
+      (function {nlocal = 0} a[genarray] (array.unsafe_get[gen] a 0))
       (array.set[int] int_a 0 1) (array.set[float] float_a 0 1.)
       (array.set[addr] addr_a 0 "a")
-      (function a[genarray] x : int (array.set[gen] a 0 x))
+      (function {nlocal = 2} a[genarray] x : int (array.set[gen] a 0 x))
       (array.unsafe_set[int] int_a 0 1)
       (array.unsafe_set[float] float_a 0 1.)
       (array.unsafe_set[addr] addr_a 0 "a")
-      (function a[genarray] x : int (array.unsafe_set[gen] a 0 x))
+      (function {nlocal = 2} a[genarray] x : int
+        (array.unsafe_set[gen] a 0 x))
       (let
-        (eta_gen_len = (function prim stub (array.length[gen] prim))
+        (eta_gen_len =
+           (function {nlocal = 0} prim stub (array.length[gen] prim))
          eta_gen_safe_get =
-           (function prim prim stub (array.get[gen] prim prim))
+           (function {nlocal = 0} prim prim stub (array.get[gen] prim prim))
          eta_gen_unsafe_get =
-           (function prim prim stub (array.unsafe_get[gen] prim prim))
+           (function {nlocal = 0} prim prim stub
+             (array.unsafe_get[gen] prim prim))
          eta_gen_safe_set =
-           (function prim prim prim stub (array.set[gen] prim prim prim))
+           (function {nlocal = 0} prim prim prim stub
+             (array.set[gen] prim prim prim))
          eta_gen_unsafe_set =
-           (function prim prim prim stub
+           (function {nlocal = 0} prim prim prim stub
              (array.unsafe_set[gen] prim prim prim))
-         eta_int_len = (function prim stub (array.length[int] prim))
+         eta_int_len =
+           (function {nlocal = 0} prim stub (array.length[int] prim))
          eta_int_safe_get =
-           (function prim prim stub (array.get[int] prim prim))
+           (function {nlocal = 0} prim prim stub (array.get[int] prim prim))
          eta_int_unsafe_get =
-           (function prim prim stub (array.unsafe_get[int] prim prim))
+           (function {nlocal = 0} prim prim stub
+             (array.unsafe_get[int] prim prim))
          eta_int_safe_set =
-           (function prim prim prim stub (array.set[int] prim prim prim))
+           (function {nlocal = 0} prim prim prim stub
+             (array.set[int] prim prim prim))
          eta_int_unsafe_set =
-           (function prim prim prim stub
+           (function {nlocal = 0} prim prim prim stub
              (array.unsafe_set[int] prim prim prim))
-         eta_float_len = (function prim stub (array.length[float] prim))
+         eta_float_len =
+           (function {nlocal = 0} prim stub (array.length[float] prim))
          eta_float_safe_get =
-           (function prim prim stub (array.get[float] prim prim))
+           (function {nlocal = 0} prim prim stub
+             (array.get[float] prim prim))
          eta_float_unsafe_get =
-           (function prim prim stub (array.unsafe_get[float] prim prim))
+           (function {nlocal = 0} prim prim stub
+             (array.unsafe_get[float] prim prim))
          eta_float_safe_set =
-           (function prim prim prim stub (array.set[float] prim prim prim))
+           (function {nlocal = 0} prim prim prim stub
+             (array.set[float] prim prim prim))
          eta_float_unsafe_set =
-           (function prim prim prim stub
+           (function {nlocal = 0} prim prim prim stub
              (array.unsafe_set[float] prim prim prim))
-         eta_addr_len = (function prim stub (array.length[addr] prim))
+         eta_addr_len =
+           (function {nlocal = 0} prim stub (array.length[addr] prim))
          eta_addr_safe_get =
-           (function prim prim stub (array.get[addr] prim prim))
+           (function {nlocal = 0} prim prim stub (array.get[addr] prim prim))
          eta_addr_unsafe_get =
-           (function prim prim stub (array.unsafe_get[addr] prim prim))
+           (function {nlocal = 0} prim prim stub
+             (array.unsafe_get[addr] prim prim))
          eta_addr_safe_set =
-           (function prim prim prim stub (array.set[addr] prim prim prim))
+           (function {nlocal = 0} prim prim prim stub
+             (array.set[addr] prim prim prim))
          eta_addr_unsafe_set =
-           (function prim prim prim stub
+           (function {nlocal = 0} prim prim prim stub
              (array.unsafe_set[addr] prim prim prim)))
         (makeblock 0 int_a float_a addr_a eta_gen_len eta_gen_safe_get
           eta_gen_unsafe_get eta_gen_safe_set eta_gen_unsafe_set eta_int_len

--- a/testsuite/tests/translprim/comparison_table.compilers.reference
+++ b/testsuite/tests/translprim/comparison_table.compilers.reference
@@ -1,148 +1,208 @@
 (setglobal Comparison_table!
   (let
-    (gen_cmp = (function x y : int (caml_compare x y))
-     int_cmp = (function x[int] y[int] : int (compare_ints x y))
-     bool_cmp = (function x[int] y[int] : int (compare_ints x y))
-     intlike_cmp = (function x[int] y[int] : int (compare_ints x y))
-     float_cmp = (function x[float] y[float] : int (compare_floats x y))
-     string_cmp = (function x y : int (caml_string_compare x y))
-     int32_cmp = (function x[int32] y[int32] : int (compare_bints int32 x y))
-     int64_cmp = (function x[int64] y[int64] : int (compare_bints int64 x y))
+    (gen_cmp = (function {nlocal = 0} x y : int (caml_compare x y))
+     int_cmp = (function {nlocal = 0} x[int] y[int] : int (compare_ints x y))
+     bool_cmp =
+       (function {nlocal = 0} x[int] y[int] : int (compare_ints x y))
+     intlike_cmp =
+       (function {nlocal = 0} x[int] y[int] : int (compare_ints x y))
+     float_cmp =
+       (function {nlocal = 0} x[float] y[float] : int (compare_floats x y))
+     string_cmp = (function {nlocal = 0} x y : int (caml_string_compare x y))
+     int32_cmp =
+       (function {nlocal = 0} x[int32] y[int32] : int
+         (compare_bints int32 x y))
+     int64_cmp =
+       (function {nlocal = 0} x[int64] y[int64] : int
+         (compare_bints int64 x y))
      nativeint_cmp =
-       (function x[nativeint] y[nativeint] : int
+       (function {nlocal = 0} x[nativeint] y[nativeint] : int
          (compare_bints nativeint x y))
-     gen_eq = (function x y : int (caml_equal x y))
-     int_eq = (function x[int] y[int] : int (== x y))
-     bool_eq = (function x[int] y[int] : int (== x y))
-     intlike_eq = (function x[int] y[int] : int (== x y))
-     float_eq = (function x[float] y[float] : int (==. x y))
-     string_eq = (function x y : int (caml_string_equal x y))
-     int32_eq = (function x[int32] y[int32] : int (Int32.== x y))
-     int64_eq = (function x[int64] y[int64] : int (Int64.== x y))
+     gen_eq = (function {nlocal = 0} x y : int (caml_equal x y))
+     int_eq = (function {nlocal = 0} x[int] y[int] : int (== x y))
+     bool_eq = (function {nlocal = 0} x[int] y[int] : int (== x y))
+     intlike_eq = (function {nlocal = 0} x[int] y[int] : int (== x y))
+     float_eq = (function {nlocal = 0} x[float] y[float] : int (==. x y))
+     string_eq = (function {nlocal = 0} x y : int (caml_string_equal x y))
+     int32_eq =
+       (function {nlocal = 0} x[int32] y[int32] : int (Int32.== x y))
+     int64_eq =
+       (function {nlocal = 0} x[int64] y[int64] : int (Int64.== x y))
      nativeint_eq =
-       (function x[nativeint] y[nativeint] : int (Nativeint.== x y))
-     gen_ne = (function x y : int (caml_notequal x y))
-     int_ne = (function x[int] y[int] : int (!= x y))
-     bool_ne = (function x[int] y[int] : int (!= x y))
-     intlike_ne = (function x[int] y[int] : int (!= x y))
-     float_ne = (function x[float] y[float] : int (!=. x y))
-     string_ne = (function x y : int (caml_string_notequal x y))
-     int32_ne = (function x[int32] y[int32] : int (Int32.!= x y))
-     int64_ne = (function x[int64] y[int64] : int (Int64.!= x y))
+       (function {nlocal = 0} x[nativeint] y[nativeint] : int
+         (Nativeint.== x y))
+     gen_ne = (function {nlocal = 0} x y : int (caml_notequal x y))
+     int_ne = (function {nlocal = 0} x[int] y[int] : int (!= x y))
+     bool_ne = (function {nlocal = 0} x[int] y[int] : int (!= x y))
+     intlike_ne = (function {nlocal = 0} x[int] y[int] : int (!= x y))
+     float_ne = (function {nlocal = 0} x[float] y[float] : int (!=. x y))
+     string_ne = (function {nlocal = 0} x y : int (caml_string_notequal x y))
+     int32_ne =
+       (function {nlocal = 0} x[int32] y[int32] : int (Int32.!= x y))
+     int64_ne =
+       (function {nlocal = 0} x[int64] y[int64] : int (Int64.!= x y))
      nativeint_ne =
-       (function x[nativeint] y[nativeint] : int (Nativeint.!= x y))
-     gen_lt = (function x y : int (caml_lessthan x y))
-     int_lt = (function x[int] y[int] : int (< x y))
-     bool_lt = (function x[int] y[int] : int (< x y))
-     intlike_lt = (function x[int] y[int] : int (< x y))
-     float_lt = (function x[float] y[float] : int (<. x y))
-     string_lt = (function x y : int (caml_string_lessthan x y))
-     int32_lt = (function x[int32] y[int32] : int (Int32.< x y))
-     int64_lt = (function x[int64] y[int64] : int (Int64.< x y))
+       (function {nlocal = 0} x[nativeint] y[nativeint] : int
+         (Nativeint.!= x y))
+     gen_lt = (function {nlocal = 0} x y : int (caml_lessthan x y))
+     int_lt = (function {nlocal = 0} x[int] y[int] : int (< x y))
+     bool_lt = (function {nlocal = 0} x[int] y[int] : int (< x y))
+     intlike_lt = (function {nlocal = 0} x[int] y[int] : int (< x y))
+     float_lt = (function {nlocal = 0} x[float] y[float] : int (<. x y))
+     string_lt = (function {nlocal = 0} x y : int (caml_string_lessthan x y))
+     int32_lt = (function {nlocal = 0} x[int32] y[int32] : int (Int32.< x y))
+     int64_lt = (function {nlocal = 0} x[int64] y[int64] : int (Int64.< x y))
      nativeint_lt =
-       (function x[nativeint] y[nativeint] : int (Nativeint.< x y))
-     gen_gt = (function x y : int (caml_greaterthan x y))
-     int_gt = (function x[int] y[int] : int (> x y))
-     bool_gt = (function x[int] y[int] : int (> x y))
-     intlike_gt = (function x[int] y[int] : int (> x y))
-     float_gt = (function x[float] y[float] : int (>. x y))
-     string_gt = (function x y : int (caml_string_greaterthan x y))
-     int32_gt = (function x[int32] y[int32] : int (Int32.> x y))
-     int64_gt = (function x[int64] y[int64] : int (Int64.> x y))
+       (function {nlocal = 0} x[nativeint] y[nativeint] : int
+         (Nativeint.< x y))
+     gen_gt = (function {nlocal = 0} x y : int (caml_greaterthan x y))
+     int_gt = (function {nlocal = 0} x[int] y[int] : int (> x y))
+     bool_gt = (function {nlocal = 0} x[int] y[int] : int (> x y))
+     intlike_gt = (function {nlocal = 0} x[int] y[int] : int (> x y))
+     float_gt = (function {nlocal = 0} x[float] y[float] : int (>. x y))
+     string_gt =
+       (function {nlocal = 0} x y : int (caml_string_greaterthan x y))
+     int32_gt = (function {nlocal = 0} x[int32] y[int32] : int (Int32.> x y))
+     int64_gt = (function {nlocal = 0} x[int64] y[int64] : int (Int64.> x y))
      nativeint_gt =
-       (function x[nativeint] y[nativeint] : int (Nativeint.> x y))
-     gen_le = (function x y : int (caml_lessequal x y))
-     int_le = (function x[int] y[int] : int (<= x y))
-     bool_le = (function x[int] y[int] : int (<= x y))
-     intlike_le = (function x[int] y[int] : int (<= x y))
-     float_le = (function x[float] y[float] : int (<=. x y))
-     string_le = (function x y : int (caml_string_lessequal x y))
-     int32_le = (function x[int32] y[int32] : int (Int32.<= x y))
-     int64_le = (function x[int64] y[int64] : int (Int64.<= x y))
+       (function {nlocal = 0} x[nativeint] y[nativeint] : int
+         (Nativeint.> x y))
+     gen_le = (function {nlocal = 0} x y : int (caml_lessequal x y))
+     int_le = (function {nlocal = 0} x[int] y[int] : int (<= x y))
+     bool_le = (function {nlocal = 0} x[int] y[int] : int (<= x y))
+     intlike_le = (function {nlocal = 0} x[int] y[int] : int (<= x y))
+     float_le = (function {nlocal = 0} x[float] y[float] : int (<=. x y))
+     string_le =
+       (function {nlocal = 0} x y : int (caml_string_lessequal x y))
+     int32_le =
+       (function {nlocal = 0} x[int32] y[int32] : int (Int32.<= x y))
+     int64_le =
+       (function {nlocal = 0} x[int64] y[int64] : int (Int64.<= x y))
      nativeint_le =
-       (function x[nativeint] y[nativeint] : int (Nativeint.<= x y))
-     gen_ge = (function x y : int (caml_greaterequal x y))
-     int_ge = (function x[int] y[int] : int (>= x y))
-     bool_ge = (function x[int] y[int] : int (>= x y))
-     intlike_ge = (function x[int] y[int] : int (>= x y))
-     float_ge = (function x[float] y[float] : int (>=. x y))
-     string_ge = (function x y : int (caml_string_greaterequal x y))
-     int32_ge = (function x[int32] y[int32] : int (Int32.>= x y))
-     int64_ge = (function x[int64] y[int64] : int (Int64.>= x y))
+       (function {nlocal = 0} x[nativeint] y[nativeint] : int
+         (Nativeint.<= x y))
+     gen_ge = (function {nlocal = 0} x y : int (caml_greaterequal x y))
+     int_ge = (function {nlocal = 0} x[int] y[int] : int (>= x y))
+     bool_ge = (function {nlocal = 0} x[int] y[int] : int (>= x y))
+     intlike_ge = (function {nlocal = 0} x[int] y[int] : int (>= x y))
+     float_ge = (function {nlocal = 0} x[float] y[float] : int (>=. x y))
+     string_ge =
+       (function {nlocal = 0} x y : int (caml_string_greaterequal x y))
+     int32_ge =
+       (function {nlocal = 0} x[int32] y[int32] : int (Int32.>= x y))
+     int64_ge =
+       (function {nlocal = 0} x[int64] y[int64] : int (Int64.>= x y))
      nativeint_ge =
-       (function x[nativeint] y[nativeint] : int (Nativeint.>= x y))
-     eta_gen_cmp = (function prim prim stub (caml_compare prim prim))
-     eta_int_cmp = (function prim prim stub (compare_ints prim prim))
-     eta_bool_cmp = (function prim prim stub (compare_ints prim prim))
-     eta_intlike_cmp = (function prim prim stub (compare_ints prim prim))
-     eta_float_cmp = (function prim prim stub (compare_floats prim prim))
+       (function {nlocal = 0} x[nativeint] y[nativeint] : int
+         (Nativeint.>= x y))
+     eta_gen_cmp =
+       (function {nlocal = 0} prim prim stub (caml_compare prim prim))
+     eta_int_cmp =
+       (function {nlocal = 0} prim prim stub (compare_ints prim prim))
+     eta_bool_cmp =
+       (function {nlocal = 0} prim prim stub (compare_ints prim prim))
+     eta_intlike_cmp =
+       (function {nlocal = 0} prim prim stub (compare_ints prim prim))
+     eta_float_cmp =
+       (function {nlocal = 0} prim prim stub (compare_floats prim prim))
      eta_string_cmp =
-       (function prim prim stub (caml_string_compare prim prim))
+       (function {nlocal = 0} prim prim stub (caml_string_compare prim prim))
      eta_int32_cmp =
-       (function prim prim stub (compare_bints int32 prim prim))
+       (function {nlocal = 0} prim prim stub (compare_bints int32 prim prim))
      eta_int64_cmp =
-       (function prim prim stub (compare_bints int64 prim prim))
+       (function {nlocal = 0} prim prim stub (compare_bints int64 prim prim))
      eta_nativeint_cmp =
-       (function prim prim stub (compare_bints nativeint prim prim))
-     eta_gen_eq = (function prim prim stub (caml_equal prim prim))
-     eta_int_eq = (function prim prim stub (== prim prim))
-     eta_bool_eq = (function prim prim stub (== prim prim))
-     eta_intlike_eq = (function prim prim stub (== prim prim))
-     eta_float_eq = (function prim prim stub (==. prim prim))
-     eta_string_eq = (function prim prim stub (caml_string_equal prim prim))
-     eta_int32_eq = (function prim prim stub (Int32.== prim prim))
-     eta_int64_eq = (function prim prim stub (Int64.== prim prim))
-     eta_nativeint_eq = (function prim prim stub (Nativeint.== prim prim))
-     eta_gen_ne = (function prim prim stub (caml_notequal prim prim))
-     eta_int_ne = (function prim prim stub (!= prim prim))
-     eta_bool_ne = (function prim prim stub (!= prim prim))
-     eta_intlike_ne = (function prim prim stub (!= prim prim))
-     eta_float_ne = (function prim prim stub (!=. prim prim))
+       (function {nlocal = 0} prim prim stub
+         (compare_bints nativeint prim prim))
+     eta_gen_eq =
+       (function {nlocal = 0} prim prim stub (caml_equal prim prim))
+     eta_int_eq = (function {nlocal = 0} prim prim stub (== prim prim))
+     eta_bool_eq = (function {nlocal = 0} prim prim stub (== prim prim))
+     eta_intlike_eq = (function {nlocal = 0} prim prim stub (== prim prim))
+     eta_float_eq = (function {nlocal = 0} prim prim stub (==. prim prim))
+     eta_string_eq =
+       (function {nlocal = 0} prim prim stub (caml_string_equal prim prim))
+     eta_int32_eq =
+       (function {nlocal = 0} prim prim stub (Int32.== prim prim))
+     eta_int64_eq =
+       (function {nlocal = 0} prim prim stub (Int64.== prim prim))
+     eta_nativeint_eq =
+       (function {nlocal = 0} prim prim stub (Nativeint.== prim prim))
+     eta_gen_ne =
+       (function {nlocal = 0} prim prim stub (caml_notequal prim prim))
+     eta_int_ne = (function {nlocal = 0} prim prim stub (!= prim prim))
+     eta_bool_ne = (function {nlocal = 0} prim prim stub (!= prim prim))
+     eta_intlike_ne = (function {nlocal = 0} prim prim stub (!= prim prim))
+     eta_float_ne = (function {nlocal = 0} prim prim stub (!=. prim prim))
      eta_string_ne =
-       (function prim prim stub (caml_string_notequal prim prim))
-     eta_int32_ne = (function prim prim stub (Int32.!= prim prim))
-     eta_int64_ne = (function prim prim stub (Int64.!= prim prim))
-     eta_nativeint_ne = (function prim prim stub (Nativeint.!= prim prim))
-     eta_gen_lt = (function prim prim stub (caml_lessthan prim prim))
-     eta_int_lt = (function prim prim stub (< prim prim))
-     eta_bool_lt = (function prim prim stub (< prim prim))
-     eta_intlike_lt = (function prim prim stub (< prim prim))
-     eta_float_lt = (function prim prim stub (<. prim prim))
+       (function {nlocal = 0} prim prim stub
+         (caml_string_notequal prim prim))
+     eta_int32_ne =
+       (function {nlocal = 0} prim prim stub (Int32.!= prim prim))
+     eta_int64_ne =
+       (function {nlocal = 0} prim prim stub (Int64.!= prim prim))
+     eta_nativeint_ne =
+       (function {nlocal = 0} prim prim stub (Nativeint.!= prim prim))
+     eta_gen_lt =
+       (function {nlocal = 0} prim prim stub (caml_lessthan prim prim))
+     eta_int_lt = (function {nlocal = 0} prim prim stub (< prim prim))
+     eta_bool_lt = (function {nlocal = 0} prim prim stub (< prim prim))
+     eta_intlike_lt = (function {nlocal = 0} prim prim stub (< prim prim))
+     eta_float_lt = (function {nlocal = 0} prim prim stub (<. prim prim))
      eta_string_lt =
-       (function prim prim stub (caml_string_lessthan prim prim))
-     eta_int32_lt = (function prim prim stub (Int32.< prim prim))
-     eta_int64_lt = (function prim prim stub (Int64.< prim prim))
-     eta_nativeint_lt = (function prim prim stub (Nativeint.< prim prim))
-     eta_gen_gt = (function prim prim stub (caml_greaterthan prim prim))
-     eta_int_gt = (function prim prim stub (> prim prim))
-     eta_bool_gt = (function prim prim stub (> prim prim))
-     eta_intlike_gt = (function prim prim stub (> prim prim))
-     eta_float_gt = (function prim prim stub (>. prim prim))
+       (function {nlocal = 0} prim prim stub
+         (caml_string_lessthan prim prim))
+     eta_int32_lt =
+       (function {nlocal = 0} prim prim stub (Int32.< prim prim))
+     eta_int64_lt =
+       (function {nlocal = 0} prim prim stub (Int64.< prim prim))
+     eta_nativeint_lt =
+       (function {nlocal = 0} prim prim stub (Nativeint.< prim prim))
+     eta_gen_gt =
+       (function {nlocal = 0} prim prim stub (caml_greaterthan prim prim))
+     eta_int_gt = (function {nlocal = 0} prim prim stub (> prim prim))
+     eta_bool_gt = (function {nlocal = 0} prim prim stub (> prim prim))
+     eta_intlike_gt = (function {nlocal = 0} prim prim stub (> prim prim))
+     eta_float_gt = (function {nlocal = 0} prim prim stub (>. prim prim))
      eta_string_gt =
-       (function prim prim stub (caml_string_greaterthan prim prim))
-     eta_int32_gt = (function prim prim stub (Int32.> prim prim))
-     eta_int64_gt = (function prim prim stub (Int64.> prim prim))
-     eta_nativeint_gt = (function prim prim stub (Nativeint.> prim prim))
-     eta_gen_le = (function prim prim stub (caml_lessequal prim prim))
-     eta_int_le = (function prim prim stub (<= prim prim))
-     eta_bool_le = (function prim prim stub (<= prim prim))
-     eta_intlike_le = (function prim prim stub (<= prim prim))
-     eta_float_le = (function prim prim stub (<=. prim prim))
+       (function {nlocal = 0} prim prim stub
+         (caml_string_greaterthan prim prim))
+     eta_int32_gt =
+       (function {nlocal = 0} prim prim stub (Int32.> prim prim))
+     eta_int64_gt =
+       (function {nlocal = 0} prim prim stub (Int64.> prim prim))
+     eta_nativeint_gt =
+       (function {nlocal = 0} prim prim stub (Nativeint.> prim prim))
+     eta_gen_le =
+       (function {nlocal = 0} prim prim stub (caml_lessequal prim prim))
+     eta_int_le = (function {nlocal = 0} prim prim stub (<= prim prim))
+     eta_bool_le = (function {nlocal = 0} prim prim stub (<= prim prim))
+     eta_intlike_le = (function {nlocal = 0} prim prim stub (<= prim prim))
+     eta_float_le = (function {nlocal = 0} prim prim stub (<=. prim prim))
      eta_string_le =
-       (function prim prim stub (caml_string_lessequal prim prim))
-     eta_int32_le = (function prim prim stub (Int32.<= prim prim))
-     eta_int64_le = (function prim prim stub (Int64.<= prim prim))
-     eta_nativeint_le = (function prim prim stub (Nativeint.<= prim prim))
-     eta_gen_ge = (function prim prim stub (caml_greaterequal prim prim))
-     eta_int_ge = (function prim prim stub (>= prim prim))
-     eta_bool_ge = (function prim prim stub (>= prim prim))
-     eta_intlike_ge = (function prim prim stub (>= prim prim))
-     eta_float_ge = (function prim prim stub (>=. prim prim))
+       (function {nlocal = 0} prim prim stub
+         (caml_string_lessequal prim prim))
+     eta_int32_le =
+       (function {nlocal = 0} prim prim stub (Int32.<= prim prim))
+     eta_int64_le =
+       (function {nlocal = 0} prim prim stub (Int64.<= prim prim))
+     eta_nativeint_le =
+       (function {nlocal = 0} prim prim stub (Nativeint.<= prim prim))
+     eta_gen_ge =
+       (function {nlocal = 0} prim prim stub (caml_greaterequal prim prim))
+     eta_int_ge = (function {nlocal = 0} prim prim stub (>= prim prim))
+     eta_bool_ge = (function {nlocal = 0} prim prim stub (>= prim prim))
+     eta_intlike_ge = (function {nlocal = 0} prim prim stub (>= prim prim))
+     eta_float_ge = (function {nlocal = 0} prim prim stub (>=. prim prim))
      eta_string_ge =
-       (function prim prim stub (caml_string_greaterequal prim prim))
-     eta_int32_ge = (function prim prim stub (Int32.>= prim prim))
-     eta_int64_ge = (function prim prim stub (Int64.>= prim prim))
-     eta_nativeint_ge = (function prim prim stub (Nativeint.>= prim prim))
+       (function {nlocal = 0} prim prim stub
+         (caml_string_greaterequal prim prim))
+     eta_int32_ge =
+       (function {nlocal = 0} prim prim stub (Int32.>= prim prim))
+     eta_int64_ge =
+       (function {nlocal = 0} prim prim stub (Int64.>= prim prim))
+     eta_nativeint_ge =
+       (function {nlocal = 0} prim prim stub (Nativeint.>= prim prim))
      int_vec =[(consts (0))
                (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
        [0: [0: 1 1] [0: [0: 1 2] [0: [0: 2 1] 0]]]
@@ -171,7 +231,7 @@
                                    [(consts (0)) (non_consts ([0: *, *]))]]))]
        [0: [0: 1n 1n] [0: [0: 1n 2n] [0: [0: 2n 1n] 0]]]
      test_vec =
-       (function cmp eq ne lt gt le ge
+       (function {nlocal = 0} cmp eq ne lt gt le ge
          vec[(consts (0))
              (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
          [(consts ())
@@ -179,6 +239,7 @@
                         [(consts (0)) (non_consts ([0: *, *]))]]))](let
                                                                     (uncurry =
                                                                     (function
+                                                                    {nlocal = 0}
                                                                     f
                                                                     param
                                                                     [(consts ())
@@ -191,6 +252,7 @@
                                                                     param)))
                                                                     map =
                                                                     (function
+                                                                    {nlocal = 2}
                                                                     f
                                                                     l[(consts (0))
                                                                     (non_consts (
@@ -249,6 +311,7 @@
                                                                     (apply
                                                                     map
                                                                     (function
+                                                                    {nlocal = 2}
                                                                     gen spec
                                                                     [(consts ())
                                                                     (non_consts (
@@ -375,7 +438,7 @@
         nativeint_gt nativeint_le nativeint_ge nativeint_vec)
       (let
         (eta_test_vec =
-           (function cmp eq ne lt gt le ge
+           (function {nlocal = 0} cmp eq ne lt gt le ge
              vec[(consts (0))
                  (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
              [(consts ())
@@ -383,10 +446,11 @@
                             [(consts (0)) (non_consts ([0: *, *]))]]))]
              (let
                (uncurry =
-                  (function f param[(consts ()) (non_consts ([0: *, *]))]
+                  (function {nlocal = 0} f
+                    param[(consts ()) (non_consts ([0: *, *]))]
                     (apply f (field 0 param) (field 1 param)))
                 map =
-                  (function f
+                  (function {nlocal = 2} f
                     l[(consts (0))
                       (non_consts ([0: *,
                                     [(consts (0)) (non_consts ([0: *, *]))]]))]
@@ -413,7 +477,7 @@
                                   [(consts (0)) (non_consts ([0: *, *]))]]))])
                    (apply map eta_gen_cmp vec) (apply map cmp vec))
                  (apply map
-                   (function gen spec
+                   (function {nlocal = 2} gen spec
                      [(consts ())
                       (non_consts ([0:
                                     [(consts (0)) (non_consts ([0: *, *]))],

--- a/testsuite/tests/translprim/module_coercion.compilers.flat.reference
+++ b/testsuite/tests/translprim/module_coercion.compilers.flat.reference
@@ -5,86 +5,114 @@
          (makeblock 0)))
     (makeblock 0 M
       (module-defn(M_int) Module_coercion module_coercion.ml(46):1552-1591
-        (makeblock 0 (function prim stub (array.length[int] prim))
-          (function prim prim stub (array.get[int] prim prim))
-          (function prim prim stub (array.unsafe_get[int] prim prim))
-          (function prim prim prim stub (array.set[int] prim prim prim))
-          (function prim prim prim stub
+        (makeblock 0
+          (function {nlocal = 0} prim stub (array.length[int] prim))
+          (function {nlocal = 0} prim prim stub (array.get[int] prim prim))
+          (function {nlocal = 0} prim prim stub
+            (array.unsafe_get[int] prim prim))
+          (function {nlocal = 0} prim prim prim stub
+            (array.set[int] prim prim prim))
+          (function {nlocal = 0} prim prim prim stub
             (array.unsafe_set[int] prim prim prim))
-          (function prim prim stub (compare_ints prim prim))
-          (function prim prim stub (== prim prim))
-          (function prim prim stub (!= prim prim))
-          (function prim prim stub (< prim prim))
-          (function prim prim stub (> prim prim))
-          (function prim prim stub (<= prim prim))
-          (function prim prim stub (>= prim prim))))
+          (function {nlocal = 0} prim prim stub (compare_ints prim prim))
+          (function {nlocal = 0} prim prim stub (== prim prim))
+          (function {nlocal = 0} prim prim stub (!= prim prim))
+          (function {nlocal = 0} prim prim stub (< prim prim))
+          (function {nlocal = 0} prim prim stub (> prim prim))
+          (function {nlocal = 0} prim prim stub (<= prim prim))
+          (function {nlocal = 0} prim prim stub (>= prim prim))))
       (module-defn(M_float) Module_coercion module_coercion.ml(47):1594-1637
-        (makeblock 0 (function prim stub (array.length[float] prim))
-          (function prim prim stub (array.get[float] prim prim))
-          (function prim prim stub (array.unsafe_get[float] prim prim))
-          (function prim prim prim stub (array.set[float] prim prim prim))
-          (function prim prim prim stub
+        (makeblock 0
+          (function {nlocal = 0} prim stub (array.length[float] prim))
+          (function {nlocal = 0} prim prim stub (array.get[float] prim prim))
+          (function {nlocal = 0} prim prim stub
+            (array.unsafe_get[float] prim prim))
+          (function {nlocal = 0} prim prim prim stub
+            (array.set[float] prim prim prim))
+          (function {nlocal = 0} prim prim prim stub
             (array.unsafe_set[float] prim prim prim))
-          (function prim prim stub (compare_floats prim prim))
-          (function prim prim stub (==. prim prim))
-          (function prim prim stub (!=. prim prim))
-          (function prim prim stub (<. prim prim))
-          (function prim prim stub (>. prim prim))
-          (function prim prim stub (<=. prim prim))
-          (function prim prim stub (>=. prim prim))))
+          (function {nlocal = 0} prim prim stub (compare_floats prim prim))
+          (function {nlocal = 0} prim prim stub (==. prim prim))
+          (function {nlocal = 0} prim prim stub (!=. prim prim))
+          (function {nlocal = 0} prim prim stub (<. prim prim))
+          (function {nlocal = 0} prim prim stub (>. prim prim))
+          (function {nlocal = 0} prim prim stub (<=. prim prim))
+          (function {nlocal = 0} prim prim stub (>=. prim prim))))
       (module-defn(M_string) Module_coercion module_coercion.ml(48):1640-1685
-        (makeblock 0 (function prim stub (array.length[addr] prim))
-          (function prim prim stub (array.get[addr] prim prim))
-          (function prim prim stub (array.unsafe_get[addr] prim prim))
-          (function prim prim prim stub (array.set[addr] prim prim prim))
-          (function prim prim prim stub
+        (makeblock 0
+          (function {nlocal = 0} prim stub (array.length[addr] prim))
+          (function {nlocal = 0} prim prim stub (array.get[addr] prim prim))
+          (function {nlocal = 0} prim prim stub
+            (array.unsafe_get[addr] prim prim))
+          (function {nlocal = 0} prim prim prim stub
+            (array.set[addr] prim prim prim))
+          (function {nlocal = 0} prim prim prim stub
             (array.unsafe_set[addr] prim prim prim))
-          (function prim prim stub (caml_string_compare prim prim))
-          (function prim prim stub (caml_string_equal prim prim))
-          (function prim prim stub (caml_string_notequal prim prim))
-          (function prim prim stub (caml_string_lessthan prim prim))
-          (function prim prim stub (caml_string_greaterthan prim prim))
-          (function prim prim stub (caml_string_lessequal prim prim))
-          (function prim prim stub (caml_string_greaterequal prim prim))))
+          (function {nlocal = 0} prim prim stub
+            (caml_string_compare prim prim))
+          (function {nlocal = 0} prim prim stub
+            (caml_string_equal prim prim))
+          (function {nlocal = 0} prim prim stub
+            (caml_string_notequal prim prim))
+          (function {nlocal = 0} prim prim stub
+            (caml_string_lessthan prim prim))
+          (function {nlocal = 0} prim prim stub
+            (caml_string_greaterthan prim prim))
+          (function {nlocal = 0} prim prim stub
+            (caml_string_lessequal prim prim))
+          (function {nlocal = 0} prim prim stub
+            (caml_string_greaterequal prim prim))))
       (module-defn(M_int32) Module_coercion module_coercion.ml(49):1688-1731
-        (makeblock 0 (function prim stub (array.length[addr] prim))
-          (function prim prim stub (array.get[addr] prim prim))
-          (function prim prim stub (array.unsafe_get[addr] prim prim))
-          (function prim prim prim stub (array.set[addr] prim prim prim))
-          (function prim prim prim stub
+        (makeblock 0
+          (function {nlocal = 0} prim stub (array.length[addr] prim))
+          (function {nlocal = 0} prim prim stub (array.get[addr] prim prim))
+          (function {nlocal = 0} prim prim stub
+            (array.unsafe_get[addr] prim prim))
+          (function {nlocal = 0} prim prim prim stub
+            (array.set[addr] prim prim prim))
+          (function {nlocal = 0} prim prim prim stub
             (array.unsafe_set[addr] prim prim prim))
-          (function prim prim stub (compare_bints int32 prim prim))
-          (function prim prim stub (Int32.== prim prim))
-          (function prim prim stub (Int32.!= prim prim))
-          (function prim prim stub (Int32.< prim prim))
-          (function prim prim stub (Int32.> prim prim))
-          (function prim prim stub (Int32.<= prim prim))
-          (function prim prim stub (Int32.>= prim prim))))
+          (function {nlocal = 0} prim prim stub
+            (compare_bints int32 prim prim))
+          (function {nlocal = 0} prim prim stub (Int32.== prim prim))
+          (function {nlocal = 0} prim prim stub (Int32.!= prim prim))
+          (function {nlocal = 0} prim prim stub (Int32.< prim prim))
+          (function {nlocal = 0} prim prim stub (Int32.> prim prim))
+          (function {nlocal = 0} prim prim stub (Int32.<= prim prim))
+          (function {nlocal = 0} prim prim stub (Int32.>= prim prim))))
       (module-defn(M_int64) Module_coercion module_coercion.ml(50):1734-1777
-        (makeblock 0 (function prim stub (array.length[addr] prim))
-          (function prim prim stub (array.get[addr] prim prim))
-          (function prim prim stub (array.unsafe_get[addr] prim prim))
-          (function prim prim prim stub (array.set[addr] prim prim prim))
-          (function prim prim prim stub
+        (makeblock 0
+          (function {nlocal = 0} prim stub (array.length[addr] prim))
+          (function {nlocal = 0} prim prim stub (array.get[addr] prim prim))
+          (function {nlocal = 0} prim prim stub
+            (array.unsafe_get[addr] prim prim))
+          (function {nlocal = 0} prim prim prim stub
+            (array.set[addr] prim prim prim))
+          (function {nlocal = 0} prim prim prim stub
             (array.unsafe_set[addr] prim prim prim))
-          (function prim prim stub (compare_bints int64 prim prim))
-          (function prim prim stub (Int64.== prim prim))
-          (function prim prim stub (Int64.!= prim prim))
-          (function prim prim stub (Int64.< prim prim))
-          (function prim prim stub (Int64.> prim prim))
-          (function prim prim stub (Int64.<= prim prim))
-          (function prim prim stub (Int64.>= prim prim))))
+          (function {nlocal = 0} prim prim stub
+            (compare_bints int64 prim prim))
+          (function {nlocal = 0} prim prim stub (Int64.== prim prim))
+          (function {nlocal = 0} prim prim stub (Int64.!= prim prim))
+          (function {nlocal = 0} prim prim stub (Int64.< prim prim))
+          (function {nlocal = 0} prim prim stub (Int64.> prim prim))
+          (function {nlocal = 0} prim prim stub (Int64.<= prim prim))
+          (function {nlocal = 0} prim prim stub (Int64.>= prim prim))))
       (module-defn(M_nativeint) Module_coercion module_coercion.ml(51):1780-1831
-        (makeblock 0 (function prim stub (array.length[addr] prim))
-          (function prim prim stub (array.get[addr] prim prim))
-          (function prim prim stub (array.unsafe_get[addr] prim prim))
-          (function prim prim prim stub (array.set[addr] prim prim prim))
-          (function prim prim prim stub
+        (makeblock 0
+          (function {nlocal = 0} prim stub (array.length[addr] prim))
+          (function {nlocal = 0} prim prim stub (array.get[addr] prim prim))
+          (function {nlocal = 0} prim prim stub
+            (array.unsafe_get[addr] prim prim))
+          (function {nlocal = 0} prim prim prim stub
+            (array.set[addr] prim prim prim))
+          (function {nlocal = 0} prim prim prim stub
             (array.unsafe_set[addr] prim prim prim))
-          (function prim prim stub (compare_bints nativeint prim prim))
-          (function prim prim stub (Nativeint.== prim prim))
-          (function prim prim stub (Nativeint.!= prim prim))
-          (function prim prim stub (Nativeint.< prim prim))
-          (function prim prim stub (Nativeint.> prim prim))
-          (function prim prim stub (Nativeint.<= prim prim))
-          (function prim prim stub (Nativeint.>= prim prim)))))))
+          (function {nlocal = 0} prim prim stub
+            (compare_bints nativeint prim prim))
+          (function {nlocal = 0} prim prim stub (Nativeint.== prim prim))
+          (function {nlocal = 0} prim prim stub (Nativeint.!= prim prim))
+          (function {nlocal = 0} prim prim stub (Nativeint.< prim prim))
+          (function {nlocal = 0} prim prim stub (Nativeint.> prim prim))
+          (function {nlocal = 0} prim prim stub (Nativeint.<= prim prim))
+          (function {nlocal = 0} prim prim stub (Nativeint.>= prim prim)))))))

--- a/testsuite/tests/translprim/ref_spec.compilers.reference
+++ b/testsuite/tests/translprim/ref_spec.compilers.reference
@@ -25,14 +25,22 @@
           (setfield_ptr 1 gen_rec [0: "foo"]) (setfield_ptr 1 gen_rec 0)
           (setfield_ptr 1 flt_rec 1.) (setfloatfield 1 flt_rec' 1.)
           (let
-            (set_open_poly = (function r y : int (setfield_ptr 0 r y))
-             set_open_poly = (function r y[int] : int (setfield_imm 0 r y))
-             set_open_poly = (function r y[int] : int (setfield_imm 0 r y))
-             set_open_poly = (function r y[int] : int (setfield_imm 0 r y))
-             set_open_poly = (function r y : int (setfield_ptr 0 r y))
-             set_open_poly = (function r y : int (setfield_ptr 0 r y))
-             set_open_poly = (function r y : int (setfield_ptr 0 r y))
-             set_open_poly = (function r y : int (setfield_ptr 0 r y)))
+            (set_open_poly =
+               (function {nlocal = 2} r y : int (setfield_ptr 0 r y))
+             set_open_poly =
+               (function {nlocal = 2} r y[int] : int (setfield_imm 0 r y))
+             set_open_poly =
+               (function {nlocal = 2} r y[int] : int (setfield_imm 0 r y))
+             set_open_poly =
+               (function {nlocal = 2} r y[int] : int (setfield_imm 0 r y))
+             set_open_poly =
+               (function {nlocal = 2} r y : int (setfield_ptr 0 r y))
+             set_open_poly =
+               (function {nlocal = 2} r y : int (setfield_ptr 0 r y))
+             set_open_poly =
+               (function {nlocal = 2} r y : int (setfield_ptr 0 r y))
+             set_open_poly =
+               (function {nlocal = 0} r y : int (setfield_ptr 0 r y)))
             (makeblock 0 int_ref var_ref vargen_ref cst_ref gen_ref flt_ref
               int_rec var_rec vargen_rec cst_rec gen_rec flt_rec flt_rec'
               set_open_poly)))))))


### PR DESCRIPTION
I'm open to bikeshedding on the syntax (we want to be able to read this nicely!), but I think we should print this somewhere; without it, I was lead astray in thinking two things were the same that weren't.