### PR TITLE
Fix `nlocal` in the generated Lambda for list comprehensions

### DIFF
--- a/lambda/transl_list_comprehension.ml
+++ b/lambda/transl_list_comprehension.ml
@@ -235,7 +235,9 @@ let rec translate_bindings
       in
       let body_func =
         Lambda.lfunction
-          ~kind:(Curried { nlocal = 1 }) (* The accumulator is local *)
+          ~kind:(Curried { nlocal = 2 })
+          (* Only the accumulator is local, but since the function itself is
+             local, [nlocal] has to be equal to the number of parameters *)
           ~params:[element, element_kind; inner_acc, Pgenval]
           ~return:Pgenval
           ~attr:default_function_attribute

--- a/testsuite/tests/comprehensions/comprehensions_from_quickcheck.ml
+++ b/testsuite/tests/comprehensions/comprehensions_from_quickcheck.ml
@@ -1,9 +1,5 @@
 (* TEST
-   skip
-   * reason = "locals bug"
-*)
-(*
-   flags = "-extension comprehensions_experimental -extension immutable_arrays"
+   flags = "-extension comprehensions_experimental -extension immutable_arrays_experimental"
    * expect
 *)
 

--- a/testsuite/tests/comprehensions/list_comprehensions_pure.ml
+++ b/testsuite/tests/comprehensions/list_comprehensions_pure.ml
@@ -1,8 +1,4 @@
 (* TEST
-   skip
-   * reason = "locals bug"
-*)
-(*
   flags = "-extension comprehensions_experimental"
    * expect
 *)

--- a/testsuite/tests/comprehensions/list_comprehensions_side_effects.ml
+++ b/testsuite/tests/comprehensions/list_comprehensions_side_effects.ml
@@ -1,8 +1,4 @@
 (* TEST
-   skip
-   * reason = "locals bug"
-*)
-(*
   flags = "-extension comprehensions_experimental"
 *)
 


### PR DESCRIPTION
This fixes the bug that was causing list comprehensions to fail to build with stack allocation enabled, and reenables all the tests