### PR TITLE
Incorporate upstream comments into type-variable refactor

### DIFF
--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -259,9 +259,9 @@ let unify_delayed_method_type loc env label ty expected_ty=
       raise(Error(loc, env, Field_type_mismatch ("method", label, trace)))
 
 let type_constraint val_env sty sty' loc =
-  let cty  = transl_simple_type val_env ~fixed:false Global sty in
+  let cty  = transl_simple_type val_env ~closed:false Global sty in
   let ty = cty.ctyp_type in
-  let cty' = transl_simple_type val_env ~fixed:false Global sty' in
+  let cty' = transl_simple_type val_env ~closed:false Global sty' in
   let ty' = cty'.ctyp_type in
   begin
     try Ctype.unify val_env ty ty' with Ctype.Unify err ->
@@ -301,7 +301,7 @@ let rec class_type_field env sign self_scope ctf =
   | Pctf_val ({txt=lab}, mut, virt, sty) ->
       mkctf_with_attrs
         (fun () ->
-          let cty = transl_simple_type env ~fixed:false Global sty in
+          let cty = transl_simple_type env ~closed:false Global sty in
           let ty = cty.ctyp_type in
           add_instance_variable ~strict:false loc env lab mut virt ty sign;
           Tctf_val (lab, mut, virt, cty))
@@ -325,7 +325,7 @@ let rec class_type_field env sign self_scope ctf =
                  ) :: !delayed_meth_specs;
                Tctf_method (lab, priv, virt, returned_cty)
            | _ ->
-               let cty = transl_simple_type env ~fixed:false Global sty in
+               let cty = transl_simple_type env ~closed:false Global sty in
                let ty = cty.ctyp_type in
                add_method loc env lab priv virt ty sign;
                Tctf_method (lab, priv, virt, cty))
@@ -349,7 +349,7 @@ and class_signature virt env pcsig self_scope loc =
   (* Introduce a dummy method preventing self type from being closed. *)
   Ctype.add_dummy_method env ~scope:self_scope sign;
 
-  let self_cty = transl_simple_type env ~fixed:false Global sty in
+  let self_cty = transl_simple_type env ~closed:false Global sty in
   let self_type = self_cty.ctyp_type in
   begin try
     Ctype.unify env self_type sign.csig_self
@@ -399,7 +399,7 @@ and class_type_aux env virt self_scope scty =
                                                    List.length styl)));
       let ctys = List.map2
         (fun sty ty ->
-          let cty' = transl_simple_type env ~fixed:false Global sty in
+          let cty' = transl_simple_type env ~closed:false Global sty in
           let ty' = cty'.ctyp_type in
           begin
            try Ctype.unify env ty' ty with Ctype.Unify err ->
@@ -419,7 +419,7 @@ and class_type_aux env virt self_scope scty =
       cltyp (Tcty_signature clsig) typ
 
   | Pcty_arrow (l, sty, scty) ->
-      let cty = transl_simple_type env ~fixed:false Global sty in
+      let cty = transl_simple_type env ~closed:false Global sty in
       let ty = cty.ctyp_type in
       let ty =
         if Btype.is_optional l
@@ -651,7 +651,7 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
       with_attrs
         (fun () ->
            if !Clflags.principal then Ctype.begin_def ();
-           let cty = Typetexp.transl_simple_type val_env ~fixed:false Global styp in
+           let cty = Typetexp.transl_simple_type val_env ~closed:false Global styp in
            let ty = cty.ctyp_type in
            if !Clflags.principal then begin
              Ctype.end_def ();
@@ -725,7 +725,7 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
       with_attrs
         (fun () ->
            let sty = Ast_helper.Typ.force_poly sty in
-           let cty = transl_simple_type val_env ~fixed:false Global sty in
+           let cty = transl_simple_type val_env ~closed:false Global sty in
            let ty = cty.ctyp_type in
            add_method loc val_env label.txt priv Virtual ty sign;
            let field =
@@ -765,7 +765,7 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
              | Some sty ->
                  let sty = Ast_helper.Typ.force_poly sty in
                  let cty' =
-                   Typetexp.transl_simple_type val_env ~fixed:false Global sty
+                   Typetexp.transl_simple_type val_env ~closed:false Global sty
                  in
                  cty'.ctyp_type
            in
@@ -1073,7 +1073,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
       if Path.same decl.cty_path unbound_class then
         raise(Error(scl.pcl_loc, val_env, Unbound_class_2 lid.txt));
       let tyl = List.map
-          (fun sty -> transl_simple_type val_env ~fixed:false Global sty)
+          (fun sty -> transl_simple_type val_env ~closed:false Global sty)
           styl
       in
       let (params, clty) =
@@ -1375,11 +1375,11 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
          }
   | Pcl_constraint (scl', scty) ->
       Ctype.begin_class_def ();
-      let cl = Typetexp.TyVarEnv.narrow_in (fun () ->
+      let cl = Typetexp.TyVarEnv.with_local_scope (fun () ->
         let cl = class_expr cl_num val_env met_env virt self_scope scl' in
         complete_class_type cl.cl_loc val_env virt Class_type cl.cl_type;
         cl) in
-      let clty = Typetexp.TyVarEnv.narrow_in (fun () ->
+      let clty = Typetexp.TyVarEnv.with_local_scope (fun () ->
         let clty = class_type val_env virt self_scope scty in
         complete_class_type clty.cltyp_loc val_env virt Class clty.cltyp_type;
         clty) in

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3037,7 +3037,7 @@ let type_package env m p fl =
   (* Same as Pexp_letmodule *)
   (* remember original level *)
   Ctype.begin_def ();
-  let modl, scope = Typetexp.TyVarEnv.narrow_in begin fun () ->
+  let modl, scope = Typetexp.TyVarEnv.with_local_scope begin fun () ->
     let modl, _mod_shape = type_module env m in
     let scope = Ctype.create_scope () in
     modl, scope

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -62,7 +62,7 @@ module TyVarEnv : sig
   val add : string -> type_expr -> unit
   (* add a global type variable to the environment *)
 
-  val narrow_in : (unit -> 'a) -> 'a
+  val with_local_scope : (unit -> 'a) -> 'a
   (* see mli file *)
 
   type poly_univars
@@ -75,6 +75,10 @@ module TyVarEnv : sig
   val check_poly_univars : Env.t -> Location.t -> poly_univars -> type_expr list
   (* see mli file *)
 
+  val instance_poly_univars :
+     Env.t -> Location.t -> poly_univars -> type_expr list
+  (* see mli file *)
+
   type policy
   val fixed_policy : policy (* no wildcards allowed *)
   val extensible_policy : policy (* common case *)
@@ -85,9 +89,12 @@ module TyVarEnv : sig
     (* create a new variable according to the given policy *)
 
   val add_pre_univar : type_expr -> policy -> unit
-    (* remember that a variable might become a univar if it isn't unified *)
-  val collect_pre_univars : (unit -> 'a) -> 'a * type_expr list
-    (* collect univars during a computation; returns the univars
+    (* remember that a variable might become a univar if it isn't unified;
+       used for checking method types *)
+
+  val collect_univars : (unit -> 'a) -> 'a * type_expr list
+    (* collect univars during a computation; returns the univars.
+       The wrapped computation should use [univars_policy].
        postcondition: the returned type_exprs are all Tunivar *)
 
   val reset_locals : ?univars:poly_univars -> unit -> unit
@@ -99,23 +106,51 @@ module TyVarEnv : sig
     (* look up a local type variable; throws Not_found if it isn't in scope *)
 
   val remember_used : string -> type_expr -> Location.t -> unit
-    (* remember that a given name is bound to a given type at a given location *)
+    (* remember that a given name is bound to a given type *)
 
-  val globalize_used_variables : globals_only:bool -> Env.t ->
-    fixed:bool -> unit -> unit
-    (* after finishing with a type signature, add used variables to the
-       global type variable scope; with globals_only, only already-in-scope
-       variables are considered (but they are still unified with the global
-       type variables *)
+  val globalize_used_variables : policy -> Env.t -> unit -> unit
+   (* after finishing with a type signature, used variables are unified to the
+      corresponding global type variables if they exist. Otherwise, in function
+      of the policy, fresh used variables are either
+        - added to the global type variable scope if they are not longer
+        variables under the {!fixed_policy}
+        - added to the global type variable scope under the {!extensible_policy}
+        - expected to be collected later by a call to `collect_univar` under the
+        {!universal_policy}
+   *)
 
 end = struct
   (** Map indexed by type variable names. *)
   module TyVarMap = Misc.Stdlib.String.Map
 
+  let not_generic v = get_level v <> Btype.generic_level
+
+  (* These are the "global" type variables: they were in scope before
+     we started processing the current type.
+  *)
   let type_variables = ref (TyVarMap.empty : type_expr TyVarMap.t)
-  let univars        = ref ([] : (string * type_expr) list)
-  let pre_univars    = ref ([] : type_expr list)
-  let used_variables = ref (TyVarMap.empty : (type_expr * Location.t) TyVarMap.t)
+
+  (* These are variables that have been used in the currently-being-checked
+     type.
+  *)
+  let used_variables =
+    ref (TyVarMap.empty : (type_expr * Location.t) TyVarMap.t)
+
+  (* These are variables we expect to become univars (they were introduced with
+     e.g. ['a .]), but we need to make sure they don't unify first.  Why not
+     just birth them as univars? Because they might successfully unify with a
+     row variable in the ['a. < m : ty; .. > as 'a] idiom.  They are like the
+     [used_variables], but will not be globalized in [globalize_used_variables].
+  *)
+  let univars = ref ([] : (string * type_expr) list)
+  let assert_univars uvs =
+    assert (List.for_all (fun (_name, v) -> not_generic v) uvs)
+
+  (* These are variables that will become univars when we're done with the
+     current type. Used to force free variables in method types to become
+     univars.
+  *)
+  let pre_univars = ref ([] : type_expr list)
 
   let reset () =
     reset_global_level ();
@@ -126,16 +161,21 @@ end = struct
     TyVarMap.mem name !type_variables
 
   let add name v =
+    assert (not_generic v);
     type_variables := TyVarMap.add name v !type_variables
 
-  let narrow_in f =
-    let old_gl = increase_global_level () in
-    let old_tv = !type_variables in
-    Fun.protect
-      f
-      ~finally:(fun () ->
-        restore_global_level old_gl;
-        type_variables := old_tv)
+  let narrow () =
+    (increase_global_level (), !type_variables)
+
+  let widen (gl, tv) =
+    restore_global_level gl;
+    type_variables := tv
+
+  let with_local_scope f =
+   let context = narrow () in
+   Fun.protect
+     f
+     ~finally:(fun () -> widen context)
 
   (* throws Not_found if the variable is not in scope *)
   let lookup_global_type_variable name =
@@ -149,6 +189,7 @@ end = struct
   type poly_univars = (string * type_expr) list
 
   let with_univars new_ones f =
+    assert_univars new_ones;
     let old_univars = !univars in
     univars := new_ones @ !univars;
     Fun.protect
@@ -170,22 +211,33 @@ end = struct
       end;
       v)
 
+  let instance_poly_univars env loc vars =
+    let vs = check_poly_univars env loc vars in
+    vs |> List.iter (fun v ->
+      match get_desc v with
+      | Tunivar name ->
+         set_type_desc v (Tvar name)
+      | _ -> assert false);
+    vs
+
   (*****)
   let reset_locals ?univars:(uvs=[]) () =
+    assert_univars uvs;
     univars := uvs;
     used_variables := TyVarMap.empty
 
   (* throws Not_found if the variable is not in scope *)
   let lookup_local name =
-    let v =
-      try
-        List.assoc name !univars
-      with Not_found ->
-        fst (TyVarMap.find name !used_variables)
-    in
-    instance v
+    try
+      List.assoc name !univars
+    with Not_found ->
+      instance (fst (TyVarMap.find name !used_variables))
+      (* This call to instance might be redundant; all variables
+         inserted into [used_variables] are non-generic, but some
+         might get generalized. *)
 
   let remember_used name v loc =
+    assert (not_generic v);
     used_variables := TyVarMap.add name (v, loc) !used_variables
 
 
@@ -198,10 +250,12 @@ end = struct
   let univars_policy = { flavor = Universal; extensibility = Extensible }
 
   let add_pre_univar tv = function
-    | { flavor = Universal } -> pre_univars := tv :: !pre_univars
+    | { flavor = Universal } ->
+      assert (not_generic tv);
+      pre_univars := tv :: !pre_univars
     | _ -> ()
 
-  let collect_pre_univars f =
+  let collect_univars f =
     pre_univars := [];
     let result = f () in
     let univs =
@@ -224,20 +278,21 @@ end = struct
     | { extensibility = Fixed } -> raise(Error(loc, env, No_type_wildcards))
     | policy -> new_var policy
 
-  let globalize_used_variables ~globals_only env ~fixed =
+  let globalize_used_variables { flavor; extensibility } env =
     let r = ref [] in
     TyVarMap.iter
       (fun name (ty, loc) ->
-        if not globals_only || is_in_scope name then
+        if flavor = Unification || is_in_scope name then
           let v = new_global_var () in
           let snap = Btype.snapshot () in
           if try unify env v ty; true with _ -> Btype.backtrack snap; false
           then try
             r := (loc, v, lookup_global_type_variable name) :: !r
           with Not_found ->
-            if fixed && Btype.is_Tvar ty then
+            if extensibility = Fixed && Btype.is_Tvar ty then
               raise(Error(loc, env,
-                          Unbound_type_variable ("'"^name, get_in_scope_names ())));
+                          Unbound_type_variable ("'"^name,
+                                                 get_in_scope_names ())));
             let v2 = new_global_var () in
             r := (loc, v, v2) :: !r;
             add name v2)
@@ -346,15 +401,6 @@ let rec extract_params styp =
       in
       (l, arg_mode, a) :: params, ret, ret_mode
   | _ -> final styp
-
-let instance_poly_univars env loc vars =
-  let vs = TyVarEnv.check_poly_univars env loc vars in
-  vs |> List.iter (fun v ->
-    match get_desc v with
-    | Tunivar name ->
-       set_type_desc v (Tvar name)
-    | _ -> assert false);
-  vs
 
 let check_arg_type styp =
   if not (Clflags.Extension.is_enabled Polymorphic_parameters) then begin
@@ -683,7 +729,7 @@ and transl_type_aux env policy mode styp =
       ctyp (Ttyp_poly (vars, cty)) ty'
   | Ptyp_package (p, l) ->
       let l, mty = create_package_mty true styp.ptyp_loc env (p, l) in
-      let mty = TyVarEnv.narrow_in (fun () -> !transl_modtype env mty) in
+      let mty = TyVarEnv.with_local_scope (fun () -> !transl_modtype env mty) in
       let ptys = List.map (fun (s, pty) ->
                              s, transl_type env policy Alloc_mode.Global pty
                           ) l in
@@ -795,22 +841,21 @@ let make_fixed_univars ty =
 
 let create_package_mty = create_package_mty false
 
-let transl_simple_type env ?univars ~fixed mode styp =
+let transl_simple_type env ?univars ~closed mode styp =
   TyVarEnv.reset_locals ?univars ();
-  let policy = TyVarEnv.(if fixed then fixed_policy else extensible_policy) in
+  let policy = TyVarEnv.(if closed then fixed_policy else extensible_policy) in
   let typ = transl_type env policy mode styp in
-  TyVarEnv.globalize_used_variables ~globals_only:false env ~fixed ();
+  TyVarEnv.globalize_used_variables policy env ();
   make_fixed_univars typ.ctyp_type;
   typ
 
 let transl_simple_type_univars env styp =
   TyVarEnv.reset_locals ();
-  let typ, univs = TyVarEnv.collect_pre_univars begin fun () ->
+  let typ, univs = TyVarEnv.collect_univars begin fun () ->
     begin_def ();
-    let typ = transl_type env TyVarEnv.univars_policy Alloc_mode.Global styp in
-    (* Globalize only local occurrences of variables that are already in global
-       scope; others will be univars and dealt with in make_fixed_univars. *)
-    TyVarEnv.globalize_used_variables ~globals_only:true env ~fixed:false ();
+    let policy = TyVarEnv.univars_policy in
+    let typ = transl_type env policy Alloc_mode.Global styp in
+    TyVarEnv.globalize_used_variables policy env ();
     end_def ();
     generalize typ.ctyp_type;
     typ
@@ -822,13 +867,14 @@ let transl_simple_type_univars env styp =
 let transl_simple_type_delayed env mode styp =
   TyVarEnv.reset_locals ();
   begin_def ();
-  let typ = transl_type env TyVarEnv.extensible_policy mode styp in
+  let policy = TyVarEnv.extensible_policy in
+  let typ = transl_type env policy mode styp in
   end_def ();
   make_fixed_univars typ.ctyp_type;
   (* This brings the used variables to the global level, but doesn't link them
      to their other occurrences just yet. This will be done when [force] is
      called. *)
-  let force = TyVarEnv.globalize_used_variables ~globals_only:false env ~fixed:false in
+  let force = TyVarEnv.globalize_used_variables policy env in
   (* Generalizes everything except the variables that were just globalized. *)
   generalize typ.ctyp_type;
   (typ, instance typ.ctyp_type, force)
@@ -840,10 +886,10 @@ let transl_type_scheme env styp =
      begin_def();
      let vars = List.map (fun v -> v.txt) vars in
      let univars = TyVarEnv.make_poly_univars vars in
-     let typ = transl_simple_type env ~univars ~fixed:true Alloc_mode.Global st in
+     let typ = transl_simple_type env ~univars ~closed:true Alloc_mode.Global st in
      end_def();
      generalize typ.ctyp_type;
-     let _ = instance_poly_univars env styp.ptyp_loc univars in
+     let _ = TyVarEnv.instance_poly_univars env styp.ptyp_loc univars in
      { ctyp_desc = Ttyp_poly (vars, typ);
        ctyp_type = typ.ctyp_type;
        ctyp_env = env;
@@ -851,7 +897,7 @@ let transl_type_scheme env styp =
        ctyp_attributes = styp.ptyp_attributes }
   | _ ->
      begin_def();
-     let typ = transl_simple_type env ~fixed:false Alloc_mode.Global styp in
+     let typ = transl_simple_type env ~closed:false Alloc_mode.Global styp in
      end_def();
      generalize typ.ctyp_type;
      typ
@@ -868,7 +914,7 @@ let report_error env ppf = function
       name
       did_you_mean (fun () -> Misc.spellcheck in_scope_names name )
   | No_type_wildcards ->
-    fprintf ppf "A type wildcard \"_\" is not allowed here."
+    fprintf ppf "A type wildcard \"_\" is not allowed in this type declaration."
   | Undefined_type_constructor p ->
     fprintf ppf "The type constructor@ %a@ is not yet completely defined"
       path p

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -125,13 +125,13 @@ end = struct
 
   let not_generic v = get_level v <> Btype.generic_level
 
-  (* These are the "global" type variables: they were in scope before
+  (* These are the type variables that were in scope before
      we started processing the current type.
   *)
   let type_variables = ref (TyVarMap.empty : type_expr TyVarMap.t)
 
   (* These are variables that have been used in the currently-being-checked
-     type.
+     type, possibly including the variables in [type_variables].
   *)
   let used_variables =
     ref (TyVarMap.empty : (type_expr * Location.t) TyVarMap.t)
@@ -143,7 +143,7 @@ end = struct
      [used_variables], but will not be globalized in [globalize_used_variables].
   *)
   let univars = ref ([] : (string * type_expr) list)
-  let assert_univars uvs =
+  let assert_not_generic uvs =
     assert (List.for_all (fun (_name, v) -> not_generic v) uvs)
 
   (* These are variables that will become univars when we're done with the
@@ -189,7 +189,7 @@ end = struct
   type poly_univars = (string * type_expr) list
 
   let with_univars new_ones f =
-    assert_univars new_ones;
+    assert_not_generic new_ones;
     let old_univars = !univars in
     univars := new_ones @ !univars;
     Fun.protect
@@ -222,7 +222,7 @@ end = struct
 
   (*****)
   let reset_locals ?univars:(uvs=[]) () =
-    assert_univars uvs;
+    assert_not_generic uvs;
     univars := uvs;
     used_variables := TyVarMap.empty
 

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -24,7 +24,7 @@ module TyVarEnv : sig
   val reset : unit -> unit
   (** removes all type variables from scope *)
 
-  val narrow_in: (unit -> 'a) -> 'a
+  val with_local_scope : (unit -> 'a) -> 'a
   (** Evaluate in a narrowed type-variable scope *)
 
   type poly_univars
@@ -37,17 +37,17 @@ module TyVarEnv : sig
     (** Verify that the given univars are universally quantified,
        and return the list of variables. The type in which the
        univars are used must be generalised *)
+
+  val instance_poly_univars :
+     Env.t -> Location.t -> poly_univars -> type_expr list
+    (** Same as [check_poly_univars], but instantiates the resulting
+       type scheme (i.e. variables become Tvar rather than Tunivar) *)
 end
 
 val valid_tyvar_name : string -> bool
 
-val instance_poly_univars :
-   Env.t -> Location.t -> TyVarEnv.poly_univars -> type_expr list
-  (* Same as [check_poly_univars], but instantiates the resulting
-     type scheme (i.e. variables become Tvar rather than Tunivar) *)
-
 val transl_simple_type:
-        Env.t -> ?univars:TyVarEnv.poly_univars -> fixed:bool -> alloc_mode_const
+        Env.t -> ?univars:TyVarEnv.poly_univars -> closed:bool -> alloc_mode_const
         -> Parsetree.core_type -> Typedtree.core_type
 val transl_simple_type_univars:
         Env.t -> Parsetree.core_type -> Typedtree.core_type


### PR DESCRIPTION
After merging https://github.com/ocaml/ocaml/pull/11912, I incorporated the changes I made there from comments into ocaml-jst. This subsumes #102, although it incorporates @stedolan's comments there.