### PR TITLE
Remove `( .:() )` from `Stdlib`

### DIFF
--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -162,15 +162,6 @@ let of_list = function
         | hd::tl -> unsafe_set a i hd; fill (i+1) tl in
       fill 1 tl
 
-(* Immutable and mutable arrays have the same runtime representation; we
-   construct immutable arrays by constructing mutable arrays and then blindly
-   casting them to become immutable.  This is safe here because [copy]:
-   1. doesn't mutate its input;
-   2. doesn't hold on to its input; and
-   3. returns a fresh array as its output. *)
-let to_iarray = Obj.magic (copy : 'a array -> 'a array)
-let of_iarray = Obj.magic (copy : 'a array -> 'a array)
-
 let fold_left f x a =
   let r = ref x in
   for i = 0 to length a - 1 do

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -167,16 +167,6 @@ val of_list : 'a list -> 'a array
    @raise Invalid_argument if the length of [l] is greater than
    [Sys.max_array_length]. *)
 
-(** {1 Converting to and from mutable arrays} *)
-
-val to_iarray : 'a array -> 'a iarray
-(** [to_iarray a] returns an immutable copy of the (mutable) array [a]; that is,
-   a fresh immutable array containing the same elements as [a] *)
-
-val of_iarray : 'a iarray -> 'a array
-(** [of_iarray ia] returns a mutable copy of the immutable array [ia]; that is,
-   a fresh (mutable) array containing the same elements as [ia] *)
-
 (** {1 Iterators} *)
 
 val iter : ('a -> unit) -> 'a array -> unit

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -162,16 +162,6 @@ val of_list : 'a list -> 'a array
    @raise Invalid_argument if the length of [l] is greater than
    [Sys.max_array_length]. *)
 
-(** {1 Converting to and from mutable arrays} *)
-
-val to_iarray : 'a array -> 'a iarray
-(** [to_iarray a] returns an immutable copy of the (mutable) array [a]; that is,
-   a fresh immutable array containing the same elements as [a] *)
-
-val of_iarray : 'a iarray -> 'a array
-(** [of_iarray ia] returns a mutable copy of the immutable array [ia]; that is,
-   a fresh (mutable) array containing the same elements as [ia] *)
-
 (** {1 Iterators} *)
 
 val iter : f:('a -> unit) -> 'a array -> unit

--- a/stdlib/iarray.ml
+++ b/stdlib/iarray.ml
@@ -80,16 +80,17 @@ let of_seq =
 
 (* Only safe if the array isn't used after this call *)
 let unsafe_of_array : 'a array -> 'a iarray = Obj.magic
+let unsafe_to_array : 'a iarray -> 'a array = Obj.magic
+
+let to_array ia = Array.copy (unsafe_to_array ia)
+let of_array ma = unsafe_of_array (Array.copy ma)
 
 (* Must be fully applied due to the value restriction *)
 let lift_sort sorter cmp iarr =
-  let arr = Array.of_iarray iarr in
+  let arr = to_array iarr in
   sorter cmp arr;
   unsafe_of_array arr
 
 let sort cmp iarr = lift_sort Array.sort cmp iarr
 let stable_sort cmp iarr = lift_sort Array.stable_sort cmp iarr
 let fast_sort cmp iarr = lift_sort Array.fast_sort cmp iarr
-
-let to_array = Array.of_iarray
-let of_array = Array.to_iarray

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -229,10 +229,6 @@ external unsafe_char_of_int : int -> char = "%identity"
 let char_of_int n =
   if n < 0 || n > 255 then invalid_arg "char_of_int" else unsafe_char_of_int n
 
-(* Array operations -- more in modules Array and Iarray *)
-
-external ( .:() ) : 'a iarray -> int -> 'a = "%array_safe_get"
-
 (* Unit operations *)
 
 external ignore : 'a -> unit = "%ignore"

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -724,21 +724,6 @@ val char_of_int : int -> char
    outside the range 0--255. *)
 
 
-(** {1 Array operations}
-
-   More array operations are provided in modules {!Array} and {!Iarray}.
-*)
-
-external ( .:() ) : 'a iarray -> int -> 'a = "%array_safe_get"
-(** [a.:(n)] returns the element number [n] of immutable array [a].
-   The first element has number 0.
-   The last element has number [length a - 1].
-   You can also write [a.:(n)] instead of [get a n].
-
-   @raise Invalid_argument
-   if [n] is outside the range 0 to [(length a - 1)]. *)
-
-
 (** {1 Unit operations} *)
 
 external ignore : 'a -> unit = "%ignore"

--- a/testsuite/tests/array-functions/test_iarray.ml
+++ b/testsuite/tests/array-functions/test_iarray.ml
@@ -4,6 +4,9 @@
 
 (* Copied from [test.ml], but with all the [Array.fill] tests deleted *)
 
+(* The get operator isn't available in the stdlib *)
+let ( .:() ) = Iarray.( .:() );;
+
 (* [iarray]s don't have the [make*] functions, so we redefine them here *)
 let make n x = Iarray.init n (fun _ -> x);;
 let make_matrix m n x = make m (make n x);;

--- a/testsuite/tests/backtrace/pr2195-locs.byte.reference
+++ b/testsuite/tests/backtrace/pr2195-locs.byte.reference
@@ -1,4 +1,4 @@
 Fatal error: exception Stdlib.Exit
-Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 412, characters 28-54
+Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 408, characters 28-54
 Called from Pr2195 in file "pr2195.ml", line 24, characters 6-19
 Re-raised at Pr2195 in file "pr2195.ml", line 29, characters 4-41

--- a/testsuite/tests/backtrace/pr2195.opt.reference
+++ b/testsuite/tests/backtrace/pr2195.opt.reference
@@ -1,5 +1,5 @@
 Fatal error: exception Stdlib.Exit
-Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 412, characters 28-54
-Called from Stdlib.open_in in file "stdlib.ml" (inlined), line 417, characters 2-45
+Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 408, characters 28-54
+Called from Stdlib.open_in in file "stdlib.ml" (inlined), line 413, characters 2-45
 Called from Pr2195 in file "pr2195.ml", line 24, characters 6-19
 Re-raised at Pr2195 in file "pr2195.ml", line 29, characters 4-41

--- a/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -26,15 +26,15 @@ match (3, 2, 1) with
 | _ -> false
 ;;
 [%%expect{|
-(let (*match*/277 = 3 *match*/278 = 2 *match*/279 = 1)
+(let (*match*/276 = 3 *match*/277 = 2 *match*/278 = 1)
   (catch
     (catch
-      (catch (if (!= *match*/278 3) (exit 3) (exit 1)) with (3)
-        (if (!= *match*/277 1) (exit 2) (exit 1)))
+      (catch (if (!= *match*/277 3) (exit 3) (exit 1)) with (3)
+        (if (!= *match*/276 1) (exit 2) (exit 1)))
      with (2) 0)
    with (1) 1))
-(let (*match*/277 = 3 *match*/278 = 2 *match*/279 = 1)
-  (catch (if (!= *match*/278 3) (if (!= *match*/277 1) 0 (exit 1)) (exit 1))
+(let (*match*/276 = 3 *match*/277 = 2 *match*/278 = 1)
+  (catch (if (!= *match*/277 3) (if (!= *match*/276 1) 0 (exit 1)) (exit 1))
    with (1) 1))
 - : bool = false
 |}];;
@@ -47,32 +47,32 @@ match (3, 2, 1) with
 | _ -> false
 ;;
 [%%expect{|
-(let (*match*/282 = 3 *match*/283 = 2 *match*/284 = 1)
+(let (*match*/281 = 3 *match*/282 = 2 *match*/283 = 1)
   (catch
     (catch
       (catch
-        (if (!= *match*/283 3) (exit 6)
-          (let
-            (x/286 =a[(consts ()) (non_consts ([0: [int], [int], [int]]))]
-               (makeblock 0 *match*/282 *match*/283 *match*/284))
-            (exit 4 x/286)))
-       with (6)
-        (if (!= *match*/282 1) (exit 5)
+        (if (!= *match*/282 3) (exit 6)
           (let
             (x/285 =a[(consts ()) (non_consts ([0: [int], [int], [int]]))]
-               (makeblock 0 *match*/282 *match*/283 *match*/284))
-            (exit 4 x/285))))
+               (makeblock 0 *match*/281 *match*/282 *match*/283))
+            (exit 4 x/285)))
+       with (6)
+        (if (!= *match*/281 1) (exit 5)
+          (let
+            (x/284 =a[(consts ()) (non_consts ([0: [int], [int], [int]]))]
+               (makeblock 0 *match*/281 *match*/282 *match*/283))
+            (exit 4 x/284))))
      with (5) 0)
-   with (4 x/280[(consts ()) (non_consts ([0: [int], [int], [int]]))])
-    (seq (ignore x/280) 1)))
-(let (*match*/282 = 3 *match*/283 = 2 *match*/284 = 1)
+   with (4 x/279[(consts ()) (non_consts ([0: [int], [int], [int]]))])
+    (seq (ignore x/279) 1)))
+(let (*match*/281 = 3 *match*/282 = 2 *match*/283 = 1)
   (catch
-    (if (!= *match*/283 3)
-      (if (!= *match*/282 1) 0
-        (exit 4 (makeblock 0 *match*/282 *match*/283 *match*/284)))
-      (exit 4 (makeblock 0 *match*/282 *match*/283 *match*/284)))
-   with (4 x/280[(consts ()) (non_consts ([0: [int], [int], [int]]))])
-    (seq (ignore x/280) 1)))
+    (if (!= *match*/282 3)
+      (if (!= *match*/281 1) 0
+        (exit 4 (makeblock 0 *match*/281 *match*/282 *match*/283)))
+      (exit 4 (makeblock 0 *match*/281 *match*/282 *match*/283)))
+   with (4 x/279[(consts ()) (non_consts ([0: [int], [int], [int]]))])
+    (seq (ignore x/279) 1)))
 - : bool = false
 |}];;
 
@@ -82,8 +82,8 @@ let _ = fun a b ->
   | ((true, _) as _g)
   | ((false, _) as _g) -> ()
 [%%expect{|
-(function {nlocal = 0} a/287[int] b/288 : int 0)
-(function {nlocal = 0} a/287[int] b/288 : int 0)
+(function {nlocal = 0} a/286[int] b/287 : int 0)
+(function {nlocal = 0} a/286[int] b/287 : int 0)
 - : bool -> 'a -> unit = <fun>
 |}];;
 
@@ -102,15 +102,15 @@ let _ = fun a b -> match a, b with
 | (false, _) as p -> p
 (* outside, trivial *)
 [%%expect {|
-(function {nlocal = 0} a/291[int] b/292
+(function {nlocal = 0} a/290[int] b/291
   [(consts ()) (non_consts ([0: [int], *]))](let
-                                              (p/293 =a[(consts ())
+                                              (p/292 =a[(consts ())
                                                         (non_consts (
                                                         [0: [int], *]))]
-                                                 (makeblock 0 a/291 b/292))
-                                              p/293))
-(function {nlocal = 0} a/291[int] b/292
-  [(consts ()) (non_consts ([0: [int], *]))](makeblock 0 a/291 b/292))
+                                                 (makeblock 0 a/290 b/291))
+                                              p/292))
+(function {nlocal = 0} a/290[int] b/291
+  [(consts ()) (non_consts ([0: [int], *]))](makeblock 0 a/290 b/291))
 - : bool -> 'a -> bool * 'a = <fun>
 |}]
 
@@ -119,15 +119,15 @@ let _ = fun a b -> match a, b with
 | ((false, _) as p) -> p
 (* inside, trivial *)
 [%%expect{|
-(function {nlocal = 0} a/295[int] b/296
+(function {nlocal = 0} a/294[int] b/295
   [(consts ()) (non_consts ([0: [int], *]))](let
-                                              (p/297 =a[(consts ())
+                                              (p/296 =a[(consts ())
                                                         (non_consts (
                                                         [0: [int], *]))]
-                                                 (makeblock 0 a/295 b/296))
-                                              p/297))
-(function {nlocal = 0} a/295[int] b/296
-  [(consts ()) (non_consts ([0: [int], *]))](makeblock 0 a/295 b/296))
+                                                 (makeblock 0 a/294 b/295))
+                                              p/296))
+(function {nlocal = 0} a/294[int] b/295
+  [(consts ()) (non_consts ([0: [int], *]))](makeblock 0 a/294 b/295))
 - : bool -> 'a -> bool * 'a = <fun>
 |}];;
 
@@ -136,20 +136,20 @@ let _ = fun a b -> match a, b with
 | (false as x, _) as p -> x, p
 (* outside, simple *)
 [%%expect {|
-(function {nlocal = 0} a/301[int] b/302
+(function {nlocal = 0} a/300[int] b/301
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
   (let
-    (x/303 =a[int] a/301
-     p/304 =a[(consts ()) (non_consts ([0: [int], *]))]
-       (makeblock 0 a/301 b/302))
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/303
-      p/304)))
-(function {nlocal = 0} a/301[int] b/302
+    (x/302 =a[int] a/300
+     p/303 =a[(consts ()) (non_consts ([0: [int], *]))]
+       (makeblock 0 a/300 b/301))
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/302
+      p/303)))
+(function {nlocal = 0} a/300[int] b/301
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
-  (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) a/301
-    (makeblock 0 a/301 b/302)))
+  (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) a/300
+    (makeblock 0 a/300 b/301)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -158,20 +158,20 @@ let _ = fun a b -> match a, b with
 | ((false as x, _) as p) -> x, p
 (* inside, simple *)
 [%%expect {|
-(function {nlocal = 0} a/307[int] b/308
+(function {nlocal = 0} a/306[int] b/307
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
   (let
-    (x/309 =a[int] a/307
-     p/310 =a[(consts ()) (non_consts ([0: [int], *]))]
-       (makeblock 0 a/307 b/308))
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/309
-      p/310)))
-(function {nlocal = 0} a/307[int] b/308
+    (x/308 =a[int] a/306
+     p/309 =a[(consts ()) (non_consts ([0: [int], *]))]
+       (makeblock 0 a/306 b/307))
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/308
+      p/309)))
+(function {nlocal = 0} a/306[int] b/307
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
-  (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) a/307
-    (makeblock 0 a/307 b/308)))
+  (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) a/306
+    (makeblock 0 a/306 b/307)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -180,30 +180,30 @@ let _ = fun a b -> match a, b with
 | (false, x) as p -> x, p
 (* outside, complex *)
 [%%expect{|
-(function {nlocal = 0} a/317[int] b/318[int]
+(function {nlocal = 0} a/316[int] b/317[int]
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
-  (if a/317
+  (if a/316
     (let
-      (x/319 =a[int] a/317
-       p/320 =a[(consts ()) (non_consts ([0: [int], [int]]))]
-         (makeblock 0 a/317 b/318))
-      (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/319
-        p/320))
+      (x/318 =a[int] a/316
+       p/319 =a[(consts ()) (non_consts ([0: [int], [int]]))]
+         (makeblock 0 a/316 b/317))
+      (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/318
+        p/319))
     (let
-      (x/321 =a[(consts ()) (non_consts ([0: ]))] b/318
-       p/322 =a[(consts ()) (non_consts ([0: [int], [int]]))]
-         (makeblock 0 a/317 b/318))
-      (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/321
-        p/322))))
-(function {nlocal = 0} a/317[int] b/318[int]
+      (x/320 =a[(consts ()) (non_consts ([0: ]))] b/317
+       p/321 =a[(consts ()) (non_consts ([0: [int], [int]]))]
+         (makeblock 0 a/316 b/317))
+      (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/320
+        p/321))))
+(function {nlocal = 0} a/316[int] b/317[int]
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
-  (if a/317
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) a/317
-      (makeblock 0 a/317 b/318))
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) b/318
-      (makeblock 0 a/317 b/318))))
+  (if a/316
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) a/316
+      (makeblock 0 a/316 b/317))
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) b/317
+      (makeblock 0 a/316 b/317))))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -213,33 +213,33 @@ let _ = fun a b -> match a, b with
   -> x, p
 (* inside, complex *)
 [%%expect{|
-(function {nlocal = 0} a/323[int] b/324[int]
+(function {nlocal = 0} a/322[int] b/323[int]
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
   (catch
-    (if a/323
+    (if a/322
       (let
-        (x/331 =a[int] a/323
-         p/332 =a[(consts ()) (non_consts ([0: [int], [int]]))]
-           (makeblock 0 a/323 b/324))
-        (exit 10 x/331 p/332))
+        (x/330 =a[int] a/322
+         p/331 =a[(consts ()) (non_consts ([0: [int], [int]]))]
+           (makeblock 0 a/322 b/323))
+        (exit 10 x/330 p/331))
       (let
-        (x/329 =a[(consts ()) (non_consts ([0: ]))] b/324
-         p/330 =a[(consts ()) (non_consts ([0: [int], [int]]))]
-           (makeblock 0 a/323 b/324))
-        (exit 10 x/329 p/330)))
-   with (10 x/325[int] p/326[(consts ()) (non_consts ([0: [int], [int]]))])
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/325
-      p/326)))
-(function {nlocal = 0} a/323[int] b/324[int]
+        (x/328 =a[(consts ()) (non_consts ([0: ]))] b/323
+         p/329 =a[(consts ()) (non_consts ([0: [int], [int]]))]
+           (makeblock 0 a/322 b/323))
+        (exit 10 x/328 p/329)))
+   with (10 x/324[int] p/325[(consts ()) (non_consts ([0: [int], [int]]))])
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/324
+      p/325)))
+(function {nlocal = 0} a/322[int] b/323[int]
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
   (catch
-    (if a/323 (exit 10 a/323 (makeblock 0 a/323 b/324))
-      (exit 10 b/324 (makeblock 0 a/323 b/324)))
-   with (10 x/325[int] p/326[(consts ()) (non_consts ([0: [int], [int]]))])
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/325
-      p/326)))
+    (if a/322 (exit 10 a/322 (makeblock 0 a/322 b/323))
+      (exit 10 b/323 (makeblock 0 a/322 b/323)))
+   with (10 x/324[int] p/325[(consts ()) (non_consts ([0: [int], [int]]))])
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/324
+      p/325)))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -252,30 +252,30 @@ let _ = fun a b -> match a, b with
 | (false as x, _) as p -> x, p
 (* outside, onecase *)
 [%%expect {|
-(function {nlocal = 0} a/333[int] b/334[int]
+(function {nlocal = 0} a/332[int] b/333[int]
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
-  (if a/333
+  (if a/332
     (let
-      (x/335 =a[int] a/333
-       _p/336 =a[(consts ()) (non_consts ([0: [int], [int]]))]
-         (makeblock 0 a/333 b/334))
-      (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/335
+      (x/334 =a[int] a/332
+       _p/335 =a[(consts ()) (non_consts ([0: [int], [int]]))]
+         (makeblock 0 a/332 b/333))
+      (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/334
         [0: 1 1]))
     (let
-      (x/337 =a[int] a/333
-       p/338 =a[(consts ()) (non_consts ([0: [int], [int]]))]
-         (makeblock 0 a/333 b/334))
-      (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/337
-        p/338))))
-(function {nlocal = 0} a/333[int] b/334[int]
+      (x/336 =a[int] a/332
+       p/337 =a[(consts ()) (non_consts ([0: [int], [int]]))]
+         (makeblock 0 a/332 b/333))
+      (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/336
+        p/337))))
+(function {nlocal = 0} a/332[int] b/333[int]
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
-  (if a/333
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) a/333
+  (if a/332
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) a/332
       [0: 1 1])
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) a/333
-      (makeblock 0 a/333 b/334))))
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) a/332
+      (makeblock 0 a/332 b/333))))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -284,20 +284,20 @@ let _ = fun a b -> match a, b with
 | ((false as x, _) as p) -> x, p
 (* inside, onecase *)
 [%%expect{|
-(function {nlocal = 0} a/339[int] b/340
+(function {nlocal = 0} a/338[int] b/339
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
   (let
-    (x/341 =a[int] a/339
-     p/342 =a[(consts ()) (non_consts ([0: [int], *]))]
-       (makeblock 0 a/339 b/340))
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/341
-      p/342)))
-(function {nlocal = 0} a/339[int] b/340
+    (x/340 =a[int] a/338
+     p/341 =a[(consts ()) (non_consts ([0: [int], *]))]
+       (makeblock 0 a/338 b/339))
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/340
+      p/341)))
+(function {nlocal = 0} a/338[int] b/339
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
-  (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) a/339
-    (makeblock 0 a/339 b/340)))
+  (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) a/338
+    (makeblock 0 a/338 b/339)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -314,23 +314,23 @@ let _ =fun a b -> match a, b with
 | (_, _) as p -> p
 (* outside, tuplist *)
 [%%expect {|
-(function {nlocal = 0} a/352[int]
-  b/353[(consts (0))
+(function {nlocal = 0} a/351[int]
+  b/352[(consts (0))
         (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))]]))]
   [(consts ())
    (non_consts ([0: [int], [(consts (0)) (non_consts ([0: *]))]]))](catch
-                                                                    (if a/352
-                                                                    (if b/353
+                                                                    (if a/351
+                                                                    (if b/352
                                                                     (let
-                                                                    (p/354 =a
+                                                                    (p/353 =a
                                                                     (field 0
-                                                                    b/353))
-                                                                    p/354)
+                                                                    b/352))
+                                                                    p/353)
                                                                     (exit 12))
                                                                     (exit 12))
                                                                     with (12)
                                                                     (let
-                                                                    (p/355 =a
+                                                                    (p/354 =a
                                                                     [(consts ())
                                                                     (non_consts (
                                                                     [0:
@@ -339,24 +339,24 @@ let _ =fun a b -> match a, b with
                                                                     (non_consts (
                                                                     [0: *]))]]))]
                                                                     (makeblock 0
-                                                                    a/352
-                                                                    b/353))
-                                                                    p/355)))
-(function {nlocal = 0} a/352[int]
-  b/353[(consts (0))
+                                                                    a/351
+                                                                    b/352))
+                                                                    p/354)))
+(function {nlocal = 0} a/351[int]
+  b/352[(consts (0))
         (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))]]))]
   [(consts ())
    (non_consts ([0: [int], [(consts (0)) (non_consts ([0: *]))]]))](catch
-                                                                    (if a/352
-                                                                    (if b/353
+                                                                    (if a/351
+                                                                    (if b/352
                                                                     (field 0
-                                                                    b/353)
+                                                                    b/352)
                                                                     (exit 12))
                                                                     (exit 12))
                                                                     with (12)
                                                                     (makeblock 0
-                                                                    a/352
-                                                                    b/353)))
+                                                                    a/351
+                                                                    b/352)))
 - : bool -> bool tuplist -> bool * bool tuplist = <fun>
 |}]
 
@@ -365,25 +365,25 @@ let _ = fun a b -> match a, b with
 | ((_, _) as p) -> p
 (* inside, tuplist *)
 [%%expect{|
-(function {nlocal = 0} a/356[int]
-  b/357[(consts (0))
+(function {nlocal = 0} a/355[int]
+  b/356[(consts (0))
         (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))]]))]
   [(consts ())
    (non_consts ([0: [int], [(consts (0)) (non_consts ([0: *]))]]))](catch
                                                                     (catch
-                                                                    (if a/356
-                                                                    (if b/357
+                                                                    (if a/355
+                                                                    (if b/356
                                                                     (let
-                                                                    (p/361 =a
+                                                                    (p/360 =a
                                                                     (field 0
-                                                                    b/357))
+                                                                    b/356))
                                                                     (exit 13
-                                                                    p/361))
+                                                                    p/360))
                                                                     (exit 14))
                                                                     (exit 14))
                                                                     with (14)
                                                                     (let
-                                                                    (p/360 =a
+                                                                    (p/359 =a
                                                                     [(consts ())
                                                                     (non_consts (
                                                                     [0:
@@ -392,11 +392,11 @@ let _ = fun a b -> match a, b with
                                                                     (non_consts (
                                                                     [0: *]))]]))]
                                                                     (makeblock 0
-                                                                    a/356
-                                                                    b/357))
+                                                                    a/355
+                                                                    b/356))
                                                                     (exit 13
-                                                                    p/360)))
-                                                                    with (13 p/358
+                                                                    p/359)))
+                                                                    with (13 p/357
                                                                     [(consts ())
                                                                     (non_consts (
                                                                     [0:
@@ -404,26 +404,26 @@ let _ = fun a b -> match a, b with
                                                                     [(consts (0))
                                                                     (non_consts (
                                                                     [0: *]))]]))])
-                                                                    p/358))
-(function {nlocal = 0} a/356[int]
-  b/357[(consts (0))
+                                                                    p/357))
+(function {nlocal = 0} a/355[int]
+  b/356[(consts (0))
         (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))]]))]
   [(consts ())
    (non_consts ([0: [int], [(consts (0)) (non_consts ([0: *]))]]))](catch
                                                                     (catch
-                                                                    (if a/356
-                                                                    (if b/357
+                                                                    (if a/355
+                                                                    (if b/356
                                                                     (exit 13
                                                                     (field 0
-                                                                    b/357))
+                                                                    b/356))
                                                                     (exit 14))
                                                                     (exit 14))
                                                                     with (14)
                                                                     (exit 13
                                                                     (makeblock 0
-                                                                    a/356
-                                                                    b/357)))
-                                                                    with (13 p/358
+                                                                    a/355
+                                                                    b/356)))
+                                                                    with (13 p/357
                                                                     [(consts ())
                                                                     (non_consts (
                                                                     [0:
@@ -431,6 +431,6 @@ let _ = fun a b -> match a, b with
                                                                     [(consts (0))
                                                                     (non_consts (
                                                                     [0: *]))]]))])
-                                                                    p/358))
+                                                                    p/357))
 - : bool -> bool tuplist -> bool * bool tuplist = <fun>
 |}]

--- a/testsuite/tests/generalized-open/gpr1506.ml
+++ b/testsuite/tests/generalized-open/gpr1506.ml
@@ -103,9 +103,9 @@ include struct open struct type t = T end let x = T end
 Line 1, characters 15-41:
 1 | include struct open struct type t = T end let x = T end
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The type t/340 introduced by this open appears in the signature
+Error: The type t/339 introduced by this open appears in the signature
        Line 1, characters 46-47:
-         The value x has no valid type if t/340 is hidden
+         The value x has no valid type if t/339 is hidden
 |}];;
 
 module A = struct
@@ -123,9 +123,9 @@ Lines 3-6, characters 4-7:
 4 |       type t = T
 5 |       let x = T
 6 |     end
-Error: The type t/345 introduced by this open appears in the signature
+Error: The type t/344 introduced by this open appears in the signature
        Line 7, characters 8-9:
-         The value y has no valid type if t/345 is hidden
+         The value y has no valid type if t/344 is hidden
 |}];;
 
 module A = struct
@@ -142,9 +142,9 @@ Lines 3-5, characters 4-7:
 3 | ....open struct
 4 |       type t = T
 5 |     end
-Error: The type t/350 introduced by this open appears in the signature
+Error: The type t/349 introduced by this open appears in the signature
        Line 6, characters 8-9:
-         The value y has no valid type if t/350 is hidden
+         The value y has no valid type if t/349 is hidden
 |}]
 
 (* It was decided to not allow this anymore. *)

--- a/testsuite/tests/lib-array/test_iarray.ml
+++ b/testsuite/tests/lib-array/test_iarray.ml
@@ -3,6 +3,13 @@
    * expect
 *)
 
+(** The get operator isn't available in the stdlib *)
+
+let ( .:() ) = Iarray.( .:() );;
+[%%expect{|
+val ( .:() ) : 'a iarray -> int -> 'a = <fun>
+|}];;
+
 (** Create some immutable and mutable arrays *)
 
 let iarray  : int   iarray = [:1;2;3;4;5:];;

--- a/testsuite/tests/lib-array/test_iarray.ml
+++ b/testsuite/tests/lib-array/test_iarray.ml
@@ -228,18 +228,6 @@ Iarray.of_array mfarray;;
 - : float iarray = [:1.5; 2.5; 3.5; 4.5; 5.5:]
 |}];;
 
-(* [Array] has an analog to [Iarray.to_array] *)
-Array.of_iarray ifarray;;
-[%%expect{|
-- : float array = [|1.5; 2.5; 3.5; 4.5; 5.5|]
-|}];;
-
-(* [Array] has an analog to [Iarray.of_array] *)
-Array.to_iarray marray;;
-[%%expect{|
-- : int iarray = [:1; 2; 3; 4; 5:]
-|}];;
-
 (* [Iarray.to_array] creates a fresh mutable array every time *)
 Iarray.to_array iarray == marray;;
 [%%expect{|

--- a/testsuite/tests/shapes/comp_units.ml
+++ b/testsuite/tests/shapes/comp_units.ml
@@ -25,7 +25,7 @@ module Mproj = Unit
 module F (X : sig type t end) = X
 [%%expect{|
 {
- "F"[module] -> Abs<.4>(X/280, X/280<.3>);
+ "F"[module] -> Abs<.4>(X/279, X/279<.3>);
  }
 module F : functor (X : sig type t end) -> sig type t = X.t end
 |}]

--- a/testsuite/tests/shapes/functors.ml
+++ b/testsuite/tests/shapes/functors.ml
@@ -17,7 +17,7 @@ module type S = sig type t val x : t end
 module Falias (X : S) = X
 [%%expect{|
 {
- "Falias"[module] -> Abs<.4>(X/282, X/282<.3>);
+ "Falias"[module] -> Abs<.4>(X/281, X/281<.3>);
  }
 module Falias : functor (X : S) -> sig type t = X.t val x : t end
 |}]
@@ -29,10 +29,10 @@ end
 {
  "Finclude"[module] ->
      Abs<.6>
-        (X/286,
+        (X/285,
          {
-          "t"[type] -> X/286<.5> . "t"[type];
-          "x"[value] -> X/286<.5> . "x"[value];
+          "t"[type] -> X/285<.5> . "t"[type];
+          "x"[value] -> X/285<.5> . "x"[value];
           });
  }
 module Finclude : functor (X : S) -> sig type t = X.t val x : t end
@@ -45,7 +45,7 @@ end
 [%%expect{|
 {
  "Fredef"[module] ->
-     Abs<.10>(X/293, {
+     Abs<.10>(X/292, {
                       "t"[type] -> <.8>;
                       "x"[value] -> <.9>;
                       });
@@ -223,8 +223,8 @@ module Big_to_small1 : B2S = functor (X : Big) -> X
 [%%expect{|
 {
  "Big_to_small1"[module] ->
-     Abs<.40>(X/388, {<.39>
-                      "t"[type] -> X/388<.39> . "t"[type];
+     Abs<.40>(X/387, {<.39>
+                      "t"[type] -> X/387<.39> . "t"[type];
                       });
  }
 module Big_to_small1 : B2S
@@ -234,8 +234,8 @@ module Big_to_small2 : B2S = functor (X : Big) -> struct include X end
 [%%expect{|
 {
  "Big_to_small2"[module] ->
-     Abs<.42>(X/391, {
-                      "t"[type] -> X/391<.41> . "t"[type];
+     Abs<.42>(X/390, {
+                      "t"[type] -> X/390<.41> . "t"[type];
                       });
  }
 module Big_to_small2 : B2S

--- a/testsuite/tests/shapes/open_arg.ml
+++ b/testsuite/tests/shapes/open_arg.ml
@@ -22,7 +22,7 @@ end = struct end
 
 [%%expect{|
 {
- "Make"[module] -> Abs<.3>(I/282, {
+ "Make"[module] -> Abs<.3>(I/281, {
                                    });
  }
 module Make : functor (I : sig end) -> sig end

--- a/testsuite/tests/shapes/recmodules.ml
+++ b/testsuite/tests/shapes/recmodules.ml
@@ -43,8 +43,8 @@ and B : sig
 end = B
 [%%expect{|
 {
- "A"[module] -> A/305<.11>;
- "B"[module] -> B/306<.12>;
+ "A"[module] -> A/304<.11>;
+ "B"[module] -> B/305<.12>;
  }
 module rec A : sig type t = Leaf of B.t end
 and B : sig type t = int end
@@ -82,13 +82,13 @@ end = Set.Make(A)
  "ASet"[module] ->
      {
       "compare"[value] ->
-          CU Stdlib . "Set"[module] . "Make"[module](A/327<.19>) .
+          CU Stdlib . "Set"[module] . "Make"[module](A/326<.19>) .
           "compare"[value];
       "elt"[type] ->
-          CU Stdlib . "Set"[module] . "Make"[module](A/327<.19>) .
+          CU Stdlib . "Set"[module] . "Make"[module](A/326<.19>) .
           "elt"[type];
       "t"[type] ->
-          CU Stdlib . "Set"[module] . "Make"[module](A/327<.19>) . "t"[type];
+          CU Stdlib . "Set"[module] . "Make"[module](A/326<.19>) . "t"[type];
       };
  }
 module rec A :

--- a/testsuite/tests/shapes/rotor_example.ml
+++ b/testsuite/tests/shapes/rotor_example.ml
@@ -26,7 +26,7 @@ end
 {
  "Pair"[module] ->
      Abs<.9>
-        (X/282, Abs(Y/283, {
+        (X/281, Abs(Y/282, {
                             "t"[type] -> <.5>;
                             "to_string"[value] -> <.6>;
                             }));

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -24,11 +24,11 @@ end
 Line 3, characters 2-36:
 3 |   include Comparable with type t = t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Illegal shadowing of included type t/287 by t/292
+Error: Illegal shadowing of included type t/286 by t/291
        Line 2, characters 2-19:
-         Type t/287 came from this include
+         Type t/286 came from this include
        Line 3, characters 2-23:
-         The value print has no valid type if t/287 is shadowed
+         The value print has no valid type if t/286 is shadowed
 |}]
 
 module type Sunderscore = sig


### PR DESCRIPTION
This removes `( .:() )` from `Stdlib` for better upstream compatibility, but leaves `Iarray` etc. in place.