### PR TITLE
Add Ctype global state debug printers

### DIFF
--- a/HACKING.jst.adoc
+++ b/HACKING.jst.adoc
@@ -56,9 +56,14 @@ where the test file or test dir are specified with respect to the
 
 ## Debugging
 
-OCaml 4.14 makes `type_expr` abstract, and thus normal debug printing
-of types no longer works. However, there is now an installable printer
-for types, which we can use to see the types. Here are the instructions:
+We make several custom printers available so that we can print more values in
+`ocamldebug`. Notable examples:
+
+  * OCaml 4.14 makes `type_expr` abstract, and thus normal debug printing
+of types no longer works without a custom printer.
+  * The debug printer for `Ctypes.global_state` lets you see the global mutable state maintained within the `Ctypes` module.
+
+Here's how to install the custom printers for a run of `ocamldebug`:
 
 1. Use the old `Makefile`, not the new `Makefile.jst`. This is an infelicity
 we hope to fix.
@@ -69,4 +74,4 @@ we hope to fix.
 the debugger to load the compiler code, required for the next
 step.
 
-4. Execute `source tools/debug_printers` to install the printers.
+4. From your debugging session, run `source tools/debug_printers` to install the printers.

--- a/tools/debug_printers
+++ b/tools/debug_printers
@@ -3,3 +3,4 @@ install_printer Debug_printers.type_expr
 install_printer Debug_printers.row_field
 install_printer Debug_printers.ident
 install_printer Debug_printers.path
+install_printer Debug_printers.ctype_global_state

--- a/tools/debug_printers.ml
+++ b/tools/debug_printers.ml
@@ -3,4 +3,4 @@ let type_expr = Printtyp.raw_type_expr
 let row_field = Printtyp.raw_field
 let ident = Ident.print_with_scope
 let path = Path.print
-
+let ctype_global_state = Ctype.print_global_state

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -5711,17 +5711,11 @@ let global_state : global_state =
     global_level;
   }
 
-let print_global_state fmt { current_level; nongen_level; global_level } =
-  let record_fields =
-    [ "current_level", current_level;
-      "nongen_level", nongen_level;
-      "global_level", global_level;
-    ]
+let print_global_state fmt global_state =
+  let print_field fmt s r = Format.fprintf fmt "%s = %d;@;" s !r in
+  let print_fields fmt { current_level; nongen_level; global_level; } =
+    print_field fmt "current_level" current_level;
+    print_field fmt "nongen_level" nongen_level;
+    print_field fmt "global_level" global_level;
   in
-  !Oprint.out_value
-    fmt
-    (Oval_record
-      (List.map
-        (fun (printed_name, value) ->
-          Outcometree.Oide_ident { printed_name }, Outcometree.Oval_int !value)
-        record_fields))
+  Format.fprintf fmt "@[<1>{@;%a}@]" print_fields global_state

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -5697,3 +5697,31 @@ let immediacy env typ =
       else
         Type_immediacy.Always
   | _ -> Type_immediacy.Unknown
+
+(* For use with ocamldebug *)
+type global_state =
+  { current_level : int ref;
+    nongen_level : int ref;
+    global_level : int ref;
+  }
+
+let global_state : global_state =
+  { current_level;
+    nongen_level;
+    global_level;
+  }
+
+let print_global_state fmt { current_level; nongen_level; global_level } =
+  let record_fields =
+    [ "current_level", current_level;
+      "nongen_level", nongen_level;
+      "global_level", global_level;
+    ]
+  in
+  !Oprint.out_value
+    fmt
+    (Oval_record
+      (List.map
+        (fun (printed_name, value) ->
+          Outcometree.Oide_ident { printed_name }, Outcometree.Oval_int !value)
+        record_fields))

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -450,3 +450,8 @@ val package_subtype :
 
 (* Raises [Incompatible] *)
 val mcomp : Env.t -> type_expr -> type_expr -> unit
+
+(* For use with ocamldebug *)
+type global_state
+val global_state : global_state
+val print_global_state : Format.formatter -> global_state -> unit


### PR DESCRIPTION
This PR adds a way of printing some of `Ctype`'s global state (including current level), and adds the debug printer to the set of printers installed by `tools/debug_printers`.

Output from `ocamldebug`:

```ocaml
(ocd) p Ctype.global_state
Ctype.global_state: Ctype.global_state =
  {current_level = 2; nongen_level = 2; global_level = 2}
```