### PR TITLE
Change modular extensions to produce `AST_desc` types

### DIFF
--- a/.depend
+++ b/.depend
@@ -306,6 +306,7 @@ parsing/ast_mapper.cmo : \
     parsing/longident.cmi \
     parsing/location.cmi \
     utils/load_path.cmi \
+    parsing/extensions_parsing.cmi \
     parsing/extensions.cmi \
     utils/config.cmi \
     utils/clflags.cmi \
@@ -318,6 +319,7 @@ parsing/ast_mapper.cmx : \
     parsing/longident.cmx \
     parsing/location.cmx \
     utils/load_path.cmx \
+    parsing/extensions_parsing.cmx \
     parsing/extensions.cmx \
     utils/config.cmx \
     utils/clflags.cmx \

--- a/boot/menhir/parser.ml
+++ b/boot/menhir/parser.ml
@@ -556,9 +556,9 @@ module Generic_array = struct
 end
 
 let ppat_iarray loc elts =
-  (Extensions.Immutable_arrays.pat_of
-     ~loc:(make_loc loc)
-     (Iapat_immutable_array elts)).ppat_desc
+  Extensions.Immutable_arrays.pat_of
+    ~loc:(make_loc loc)
+    (Iapat_immutable_array elts)
 
 let expecting loc nonterm =
     raise Syntaxerr.(Error(Expecting(make_loc loc, nonterm)))
@@ -42309,9 +42309,9 @@ module Tables = struct
       ( Generic_array.expression
           "[:" ":]"
           (fun elts ->
-            (Extensions.Immutable_arrays.expr_of
+             Extensions.Immutable_arrays.expr_of
                ~loc:(make_loc _sloc)
-               (Iaexp_immutable_array elts)).pexp_desc)
+               (Iaexp_immutable_array elts))
           _1 )
 # 42317 "parsing/parser.ml"
             
@@ -42397,9 +42397,9 @@ module Tables = struct
       ( Generic_array.expression
           "[:" ":]"
           (fun elts ->
-            (Extensions.Immutable_arrays.expr_of
+             Extensions.Immutable_arrays.expr_of
                ~loc:(make_loc _sloc)
-               (Iaexp_immutable_array elts)).pexp_desc)
+               (Iaexp_immutable_array elts))
           _1 )
 # 42405 "parsing/parser.ml"
             
@@ -42469,9 +42469,9 @@ module Tables = struct
       ( Generic_array.expression
           "[:" ":]"
           (fun elts ->
-            (Extensions.Immutable_arrays.expr_of
+             Extensions.Immutable_arrays.expr_of
                ~loc:(make_loc _sloc)
-               (Iaexp_immutable_array elts)).pexp_desc)
+               (Iaexp_immutable_array elts))
           _1 )
 # 42477 "parsing/parser.ml"
             
@@ -42583,9 +42583,9 @@ module Tables = struct
       ( Generic_array.expression
           "[:" ":]"
           (fun elts ->
-            (Extensions.Immutable_arrays.expr_of
+             Extensions.Immutable_arrays.expr_of
                ~loc:(make_loc _sloc)
-               (Iaexp_immutable_array elts)).pexp_desc)
+               (Iaexp_immutable_array elts))
           _1 )
 # 42591 "parsing/parser.ml"
             
@@ -42686,9 +42686,9 @@ module Tables = struct
       ( Generic_array.expression
           "[:" ":]"
           (fun elts ->
-            (Extensions.Immutable_arrays.expr_of
+             Extensions.Immutable_arrays.expr_of
                ~loc:(make_loc _sloc)
-               (Iaexp_immutable_array elts)).pexp_desc)
+               (Iaexp_immutable_array elts))
           _1 )
 # 42694 "parsing/parser.ml"
             
@@ -42781,9 +42781,9 @@ module Tables = struct
       ( Generic_array.expression
           "[:" ":]"
           (fun elts ->
-            (Extensions.Immutable_arrays.expr_of
+             Extensions.Immutable_arrays.expr_of
                ~loc:(make_loc _sloc)
-               (Iaexp_immutable_array elts)).pexp_desc)
+               (Iaexp_immutable_array elts))
           _1 )
 # 42789 "parsing/parser.ml"
             
@@ -43006,7 +43006,7 @@ module Tables = struct
               let _sloc = (_symbolstartpos, _endpos) in
               
 # 2603 "parsing/parser.mly"
-    ( (Extensions.Comprehensions.expr_of ~loc:(make_loc _sloc) _1).pexp_desc )
+    ( Extensions.Comprehensions.expr_of ~loc:(make_loc _sloc) _1 )
 # 43011 "parsing/parser.ml"
               
             in
@@ -43107,7 +43107,7 @@ module Tables = struct
               let _sloc = (_symbolstartpos, _endpos) in
               
 # 2603 "parsing/parser.mly"
-    ( (Extensions.Comprehensions.expr_of ~loc:(make_loc _sloc) _1).pexp_desc )
+    ( Extensions.Comprehensions.expr_of ~loc:(make_loc _sloc) _1 )
 # 43112 "parsing/parser.ml"
               
             in
@@ -43208,7 +43208,7 @@ module Tables = struct
               let _sloc = (_symbolstartpos, _endpos) in
               
 # 2603 "parsing/parser.mly"
-    ( (Extensions.Comprehensions.expr_of ~loc:(make_loc _sloc) _1).pexp_desc )
+    ( Extensions.Comprehensions.expr_of ~loc:(make_loc _sloc) _1 )
 # 43213 "parsing/parser.ml"
               
             in
@@ -43324,7 +43324,7 @@ module Tables = struct
               let _sloc = (_symbolstartpos, _endpos) in
               
 # 2603 "parsing/parser.mly"
-    ( (Extensions.Comprehensions.expr_of ~loc:(make_loc _sloc) _1).pexp_desc )
+    ( Extensions.Comprehensions.expr_of ~loc:(make_loc _sloc) _1 )
 # 43329 "parsing/parser.ml"
               
             in
@@ -43462,7 +43462,7 @@ module Tables = struct
               let _sloc = (_symbolstartpos, _endpos) in
               
 # 2603 "parsing/parser.mly"
-    ( (Extensions.Comprehensions.expr_of ~loc:(make_loc _sloc) _1).pexp_desc )
+    ( Extensions.Comprehensions.expr_of ~loc:(make_loc _sloc) _1 )
 # 43467 "parsing/parser.ml"
               
             in
@@ -43600,7 +43600,7 @@ module Tables = struct
               let _sloc = (_symbolstartpos, _endpos) in
               
 # 2603 "parsing/parser.mly"
-    ( (Extensions.Comprehensions.expr_of ~loc:(make_loc _sloc) _1).pexp_desc )
+    ( Extensions.Comprehensions.expr_of ~loc:(make_loc _sloc) _1 )
 # 43605 "parsing/parser.ml"
               
             in

--- a/parsing/ast_mapper.mli
+++ b/parsing/ast_mapper.mli
@@ -75,7 +75,7 @@ type mapper = {
   constructor_declaration: mapper -> constructor_declaration
                            -> constructor_declaration;
   expr: mapper -> expression -> expression;
-  expr_extension: mapper -> Location.t -> Extensions.Expression.t -> expression;
+  expr_extension: mapper -> Extensions.Expression.t -> Extensions.Expression.t;
   extension: mapper -> extension -> extension;
   extension_constructor: mapper -> extension_constructor
                          -> extension_constructor;
@@ -93,7 +93,7 @@ type mapper = {
   open_declaration: mapper -> open_declaration -> open_declaration;
   open_description: mapper -> open_description -> open_description;
   pat: mapper -> pattern -> pattern;
-  pat_extension: mapper -> Location.t -> Extensions.Pattern.t -> pattern;
+  pat_extension: mapper -> Extensions.Pattern.t -> Extensions.Pattern.t;
   payload: mapper -> payload -> payload;
   signature: mapper -> signature -> signature;
   signature_item: mapper -> signature_item -> signature_item;

--- a/parsing/extensions.ml
+++ b/parsing/extensions.ml
@@ -90,8 +90,8 @@ module Comprehensions = struct
      v}
   *)
 
-  let comprehension_expr ~loc names =
-    Expression.make_extension ~loc (extension_string :: names)
+  let comprehension_expr ~loc names x =
+    Expression.wrap_desc ~loc ~attrs:[] @@ Expression.make_extension ~loc (extension_string :: names) x
 
   (** First, we define how to go from the nice AST to the OCaml AST; this is
       the [expr_of_...] family of expressions, culminating in

--- a/parsing/extensions.mli
+++ b/parsing/extensions.mli
@@ -55,7 +55,7 @@ module Comprehensions : sig
         [:BODY ...CLAUSES...:] (flag = Immutable)
           (only allowed with [-extension immutable_arrays]) *)
 
-  val expr_of : loc:Location.t -> expression -> Parsetree.expression
+  val expr_of : loc:Location.t -> expression -> Parsetree.expression_desc
 end
 
 (** The ASTs for immutable arrays.  When we merge this upstream, we'll merge
@@ -72,8 +72,8 @@ module Immutable_arrays : sig
     (** [: P1; ...; Pn :] **)
     (* CR aspectorzabusky: Or [Iapat_iarray]? *)
 
-  val expr_of : loc:Location.t -> expression -> Parsetree.expression
-  val pat_of : loc:Location.t -> pattern -> Parsetree.pattern
+  val expr_of : loc:Location.t -> expression -> Parsetree.expression_desc
+  val pat_of : loc:Location.t -> pattern -> Parsetree.pattern_desc
 end
 
 (** The module type of language extension ASTs, instantiated once for each

--- a/parsing/extensions_parsing.mli
+++ b/parsing/extensions_parsing.mli
@@ -100,6 +100,10 @@ module type AST = sig
   (** The AST type (e.g., [Parsetree.expression]) *)
   type ast
 
+  (** The "AST description" type, without the location and attributes (e.g.,
+      [Parsetree.expression_desc]) *)
+  type ast_desc
+
   (** The name for this syntactic category in the plural form; used for error
       messages (e.g., "expressions") *)
   val plural : string
@@ -107,10 +111,14 @@ module type AST = sig
   (** How to get the location attached to an AST node *)
   val location : ast -> Location.t
 
+  (** Turn an [ast_desc] into an [ast] by adding the appropriate metadata *)
+  val wrap_desc :
+    loc:Location.t -> attrs:Parsetree.attributes -> ast_desc -> ast
+
   (** Embed a language extension term in the AST with the given name
       and body (the [ast]).  The name will be joined with dots
       and preceded by [extension.].  Partial inverse of [match_extension]. *)
-  val make_extension  : loc:Location.t -> string list -> ast -> ast
+  val make_extension  : loc:Location.t -> string list -> ast -> ast_desc
 
   (** Given an AST node, check if it's a language extension term; if it is,
       split it back up into its name (the [string list]) and the body (the
@@ -125,8 +133,10 @@ end
     adding these lazily as we need them. When you add another one, make
     sure also to add special handling in [Ast_iterator] and [Ast_mapper]. *)
 
-module Expression : AST with type ast = Parsetree.expression
-module Pattern    : AST with type ast = Parsetree.pattern
+module Expression : AST with type ast      = Parsetree.expression
+                         and type ast_desc = Parsetree.expression_desc
+module Pattern    : AST with type ast      = Parsetree.pattern
+                         and type ast_desc = Parsetree.pattern_desc
 
 (** Each syntactic category will include a module that meets this signature.
     Then, the [Make_of_ast] functor produces the functions that actually

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -344,9 +344,9 @@ module Generic_array = struct
 end
 
 let ppat_iarray loc elts =
-  (Extensions.Immutable_arrays.pat_of
-     ~loc:(make_loc loc)
-     (Iapat_immutable_array elts)).ppat_desc
+  Extensions.Immutable_arrays.pat_of
+    ~loc:(make_loc loc)
+    (Iapat_immutable_array elts)
 
 let expecting loc nonterm =
     raise Syntaxerr.(Error(Expecting(make_loc loc, nonterm)))
@@ -2600,7 +2600,7 @@ comprehension_clause:
 
 %inline comprehension_expr:
   comprehension_ext_expr
-    { (Extensions.Comprehensions.expr_of ~loc:(make_loc $sloc) $1).pexp_desc }
+    { Extensions.Comprehensions.expr_of ~loc:(make_loc $sloc) $1 }
 ;
 
 %inline array_simple(ARR_OPEN, ARR_CLOSE, contents_semi_list):
@@ -2688,9 +2688,9 @@ comprehension_clause:
       { Generic_array.expression
           "[:" ":]"
           (fun elts ->
-            (Extensions.Immutable_arrays.expr_of
+             Extensions.Immutable_arrays.expr_of
                ~loc:(make_loc $sloc)
-               (Iaexp_immutable_array elts)).pexp_desc)
+               (Iaexp_immutable_array elts))
           $1 }
   | LBRACKET expr_semi_list RBRACKET
       { fst (mktailexp $loc($3) $2) }

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -1913,10 +1913,9 @@ module Conv = struct
           let ppat = match am with
             | Mutable   -> Ppat_array pats
             | Immutable ->
-                (Extensions.Immutable_arrays.pat_of
-                   ~loc:pat.pat_loc
-                   (Iapat_immutable_array pats)
-                ).ppat_desc
+                Extensions.Immutable_arrays.pat_of
+                  ~loc:pat.pat_loc
+                  (Iapat_immutable_array pats)
           in
           mkpat ppat
       | Tpat_lazy p ->

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -361,10 +361,9 @@ let pattern : type k . _ -> k T.general_pattern -> _ = fun sub pat ->
         let pats = List.map (sub.pat sub) list in
         match am with
         | Mutable   -> Ppat_array pats
-        | Immutable -> (Extensions.Immutable_arrays.pat_of
-                          ~loc
-                          (Iapat_immutable_array pats)
-                       ).ppat_desc
+        | Immutable -> Extensions.Immutable_arrays.pat_of
+                         ~loc
+                         (Iapat_immutable_array pats)
       end
     | Tpat_lazy p -> Ppat_lazy (sub.pat sub p)
 
@@ -430,12 +429,9 @@ let comprehension ~loc sub comp_type comp =
     { body    = sub.expr sub comp_body
     ; clauses = List.map clause comp_clauses }
   in
-  let comprehension_expr =
-    Extensions.Comprehensions.expr_of
-      ~loc
-      (comp_type (comprehension comp))
-  in
-  comprehension_expr.pexp_desc
+  Extensions.Comprehensions.expr_of
+    ~loc
+    (comp_type (comprehension comp))
 
 let expression sub exp =
   let loc = sub.location sub exp.exp_loc in
@@ -507,12 +503,9 @@ let expression sub exp =
         | Mutable ->
             Pexp_array plist
         | Immutable ->
-          let expr =
             Extensions.Immutable_arrays.expr_of
               ~loc
               (Iaexp_immutable_array plist)
-          in
-          expr.pexp_desc
       end
     | Texp_list_comprehension comp ->
         comprehension


### PR DESCRIPTION
This also tweaks the `Ast_mapper` types for modular extension nodes to be more uniform