### PR TITLE
Disable 32 bit build in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,13 +21,6 @@ jobs:
             use_runtime: d
             ocamlrunparam: "v=0,V=1"
 
-          - name: i386
-            config: CC='cc32' AS='as --32' ASPP='gcc -m32 -c' -host i386-linux PARTIALLD='ld -r -melf_i386'
-            os: ubuntu-20.04
-            ocamlparam: ''
-            boot_config: CC='cc32' AS='as --32' ASPP='gcc -m32 -c' -host i386-linux PARTIALLD='ld -r -melf_i386'
-            boot_cachekey: 32bit
-
     env:
       J: "3"
 


### PR DESCRIPTION
Based on in-person discussion, it seems like there's no reason to be building this in CI.  It has already been disabled in flambda-backend, and we don't use 32-bit builds at all so any failures are only a distraction.