### PR TITLE
Fully switch over Jane Street Merlin support to `.local-*`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -292,8 +292,5 @@ _build
 /otherlibs/dynlink/natdynlinkops
 
 # Jane Street Merlin support
-/.for-jane-street-merlin/
-/.merlin-binaries
-/.ocaml-lib
 /.local-merlin-binaries
 /.local-ocaml-lib

--- a/.ocaml-bin
+++ b/.ocaml-bin
@@ -1,1 +1,0 @@
-Stub for Jane Street .merlin-binaries search

--- a/jane-street-merlin-setup.sh
+++ b/jane-street-merlin-setup.sh
@@ -14,14 +14,3 @@ set -e
 merlin_dir="$(dirname "$ocamlmerlin")"
 echo "$merlin_dir" > .local-merlin-binaries
 ocamlc -where > .local-ocaml-lib
-
-# When `.local-merlin-binaries` is fully supported (rather than just supported
-# in dev Emacs), we can drop the extra directory `.for-jane-street-merlin` as
-# well as the stub `jenga.conf` file.
-
-mkdir -p .for-jane-street-merlin
-ln -sfn "$merlin_dir" .for-jane-street-merlin/dev
-ln -sfn "$merlin_dir" .for-jane-street-merlin/prod
-
-echo "$PWD/.for-jane-street-merlin" > .merlin-binaries
-cp .local-ocaml-lib .ocaml-lib

--- a/jenga.conf
+++ b/jenga.conf
@@ -1,1 +1,0 @@
-Stub for Jane Street .merlin-binaries search


### PR DESCRIPTION
This removes hacky code that we think was breaking with Emacs changes.