### PR TITLE
Remove raw_body from modular extensions setup

### DIFF
--- a/parsing/extensions_parsing.mli
+++ b/parsing/extensions_parsing.mli
@@ -77,8 +77,6 @@ module Error : sig
   (** Someone used [[%extension.EXTNAME]] wrong *)
   type malformed_extension =
     | Has_payload of Parsetree.payload
-    | Wrong_arguments of (Asttypes.arg_label * Parsetree.expression) list
-    | Wrong_tuple of Parsetree.pattern list
 
   (** An error triggered when desugaring a language extension from an OCaml AST *)
   type error =

--- a/testsuite/tests/jst-modular-extensions/user_error2.compilers.reference
+++ b/testsuite/tests/jst-modular-extensions/user_error2.compilers.reference
@@ -1,6 +1,4 @@
 File "user_error2.ml", line 21, characters 46-65:
 21 | let _malformed_extensions_wrong_arguments = [%extension.something] "two" "arguments";;
                                                    ^^^^^^^^^^^^^^^^^^^
-Error: Expression modular extension nodes must be applied to exactly
-       one unlabeled argument, but "extension.something" was applied to
-       2 arguments
+Error: Uninterpreted extension 'extension.something'.


### PR DESCRIPTION
This worsens the error message in a case that should never arise in practice, but it simplifies the process for adding new AST types.