### PR TITLE
Don't copy when resolving aliases in try_modtypes

### DIFF
--- a/typing/mtype.mli
+++ b/typing/mtype.mli
@@ -33,6 +33,7 @@ val scrape_for_type_of:
 val freshen: scope:int -> module_type -> module_type
         (* Return an alpha-equivalent copy of the given module type
            where bound identifiers are fresh. *)
+val strengthen_lazy: aliasable:bool -> Env.t -> Subst.Lazy.modtype -> Path.t -> Subst.Lazy.modtype
 val strengthen: aliasable:bool -> Env.t -> module_type -> Path.t -> module_type
         (* Strengthen abstract type components relative to the
            given path. *)


### PR DESCRIPTION
We were calling `expand_module_alias` to get the unstrengthened, non-lazy type (potential deep copy), then checking whether it's an ident and then strengthening it, thus throwing most of it away. This patch avoids doing that by working directly on the lazy representation. This substantially reduces the peak heap size (and improves compile times, albeit to a lesser degree) in some cases.

Note that https://github.com/ocaml-flambda/ocaml-jst/pull/119 changes this area significantly so I didn't want to refactor too much here.