### PR TITLE
Add `promote-failed` targets to the Makefiles

### DIFF
--- a/Makefile.common-jst
+++ b/Makefile.common-jst
@@ -295,6 +295,14 @@ test: install_for_test
                fi \
              fi)
 
+promote-failed:
+	(export OCAMLSRCDIR=$$(pwd)/_runtest; \
+	 export CAML_LD_LIBRARY_PATH=$$(pwd)/_runtest/lib/ocaml/stublibs; \
+	 if $$(which gfortran > /dev/null 2>&1); then \
+	   export LIBRARY_PATH=$$(dirname $$(gfortran -print-file-name=libgfortran.a)); \
+	 fi; \
+	 cd _runtest/testsuite && make promote-failed)
+
 runtest-upstream: test
 
 test-one: install_for_test

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -145,6 +145,7 @@ default:
 	@echo "  promote DIR=p   promote the output for the tests located in path p"
 	@echo "  promote LIST=f  promote the output for the tests listed in f (one \
 	per line)"
+	@echo "  promote-failed  promote all the tests that failed in the previous run"
 	@echo "  lib             build library modules"
 	@echo "  tools           build test tools"
 	@echo "  clean           delete generated files"
@@ -348,3 +349,12 @@ clean:
 report:
 	@if [ ! -f $(TESTLOG) ]; then echo "No $(TESTLOG) file."; exit 1; fi
 	@$(AWK) -f ./summarize.awk < $(TESTLOG)
+
+.PHONY: promote-failed
+promote-failed: lib tools
+	@if [ ! -f $(TESTLOG) ]; then echo "No $(TESTLOG) file."; exit 1; fi
+	@for test in \
+	     $$(awk -f ./summarize.awk -v only_report_failed_tests=1 < $(TESTLOG)); \
+	 do \
+	   $(MAKE) promote TEST="$$test"; \
+	 done

--- a/testsuite/summarize.awk
+++ b/testsuite/summarize.awk
@@ -143,6 +143,15 @@ END {
     if (errored){
         printf ("\n#### Some fatal error occurred during testing.\n\n");
         exit (3);
+    }else if (only_report_failed_tests){
+        for (key in RESULTS){
+            if (RESULTS[key] == "f"){
+                split(key, key_parts);
+                test_file = key_parts[1];
+                gsub("'", "", test_file);
+                printf("%s\n", test_file);
+            }
+        }
     }else{
         for (key in SKIPPED){
             if (!SKIPPED[key]){


### PR DESCRIPTION
This target promotes all tests that failed on the previous run; it's good for after running `make -C testsuite parallel`, for example.

If this looks good here I'll also send it upstream separately.

(This is the awkified, Makefileified version of my little shell script

```
for test in $(awk -f testsuite/summarize.awk < testsuite/_log  | perl -ne 'print if /List of failed tests/../^$/ and s/^\s+(tests\/\S+) with \d.+/$1/'); do make -C testsuite promote TEST="$test"; done
```
)