### PR TITLE
Revert "Remove `Lev_module_definition` from lambda"

### DIFF
--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -1014,6 +1014,8 @@ let rec comp_expr env exp sz cont =
             let cont1 = add_event ev cont in
             comp_expr env lam sz cont1
           end
+      | Lev_module_definition _ ->
+          comp_expr env lam sz cont
       end
   | Lifused (_, exp) ->
       comp_expr env exp sz cont

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -533,6 +533,7 @@ and lambda_event_kind =
   | Lev_after of Types.type_expr
   | Lev_function
   | Lev_pseudo
+  | Lev_module_definition of Ident.t
 
 type program =
   { compilation_unit : Compilation_unit.t;

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -447,6 +447,7 @@ and lambda_event_kind =
   | Lev_after of Types.type_expr
   | Lev_function
   | Lev_pseudo
+  | Lev_module_definition of Ident.t
 
 type program =
   { compilation_unit : Compilation_unit.t;

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -786,6 +786,8 @@ let rec lam ppf = function
        | Lev_after _  -> "after"
        | Lev_function -> "funct-body"
        | Lev_pseudo -> "pseudo"
+       | Lev_module_definition ident ->
+         Format.asprintf "module-defn(%a)" Ident.print ident
       in
       (* -dno-locations also hides the placement of debug events;
          this is good for the readability of the resulting output (usually

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -715,10 +715,16 @@ and transl_exp0 ~in_new_scope ~scopes e =
       let lam = !transl_module ~scopes Tcoerce_none None modl in
       Lsequence(Lprim(Pignore, [lam], of_location ~scopes loc.loc),
                 transl_exp ~scopes body)
-  | Texp_letmodule(Some id, _loc, Mp_present, modl, body) ->
+  | Texp_letmodule(Some id, loc, Mp_present, modl, body) ->
       let defining_expr =
         let mod_scopes = enter_module_definition ~scopes id in
-        !transl_module ~scopes:mod_scopes Tcoerce_none None modl
+        let lam = !transl_module ~scopes:mod_scopes Tcoerce_none None modl in
+        Levent (lam, {
+          lev_loc = of_location ~scopes loc.loc;
+          lev_kind = Lev_module_definition id;
+          lev_repr = None;
+          lev_env = Env.empty;
+        })
       in
       Llet(Strict, Lambda.layout_module, id, defining_expr, transl_exp ~scopes body)
   | Texp_letmodule(_, _, Mp_absent, _, body) ->

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -457,7 +457,7 @@ let compile_recmodule ~scopes compile_rhs bindings cont =
   eval_rec_bindings
     (reorder_rec_bindings
        (List.map
-          (fun {mb_id=id; mb_name; mb_expr=modl; _} ->
+          (fun {mb_id=id; mb_name; mb_expr=modl; mb_loc=loc; _} ->
              let id_or_ignore_loc, shape =
                match id with
                | None ->
@@ -465,7 +465,7 @@ let compile_recmodule ~scopes compile_rhs bindings cont =
                  Ignore_loc loc, Result.Error Unnamed
                | Some id -> Id id, init_shape id modl
              in
-             (id_or_ignore_loc, modl.mod_loc, shape, compile_rhs id modl))
+             (id_or_ignore_loc, modl.mod_loc, shape, compile_rhs id modl loc))
           bindings))
     cont
 
@@ -720,6 +720,14 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
                                of_location ~scopes mb.mb_name.loc), body),
               size
           | Some id ->
+              let module_body =
+                Levent (module_body, {
+                  lev_loc = of_location ~scopes mb.mb_loc;
+                  lev_kind = Lev_module_definition id;
+                  lev_repr = None;
+                  lev_env = Env.empty;
+                })
+              in
               Llet(pure_module mb.mb_expr, Lambda.layout_module, id, module_body, body), size
           end
       | Tstr_module ({mb_presence=Mp_absent}) ->
@@ -733,13 +741,21 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
             transl_structure ~scopes loc ext_fields cc rootpath final_env rem
           in
           let lam =
-            compile_recmodule ~scopes (fun id modl ->
+            compile_recmodule ~scopes (fun id modl loc ->
               match id with
               | None -> transl_module ~scopes Tcoerce_none None modl
               | Some id ->
-                  transl_module
-                    ~scopes:(enter_module_definition ~scopes id)
-                    Tcoerce_none (field_path rootpath id) modl
+                  let module_body =
+                    transl_module
+                      ~scopes:(enter_module_definition ~scopes id)
+                      Tcoerce_none (field_path rootpath id) modl
+                  in
+                  Levent (module_body, {
+                    lev_loc = of_location ~scopes loc;
+                    lev_kind = Lev_module_definition id;
+                    lev_repr = None;
+                    lev_env = Env.empty;
+                  })
             ) bindings body
           in
           lam, size
@@ -1222,7 +1238,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
         | Tstr_recmodule bindings ->
             let ids = List.filter_map (fun mb -> mb.mb_id) bindings in
             compile_recmodule ~scopes
-              (fun id modl ->
+              (fun id modl _loc ->
                  Lambda.subst no_env_update subst
                    (match id with
                     | None ->
@@ -1622,7 +1638,7 @@ let transl_toplevel_item ~scopes item =
   | Tstr_recmodule bindings ->
       let idents = List.filter_map (fun mb -> mb.mb_id) bindings in
       compile_recmodule ~scopes
-        (fun id modl ->
+        (fun id modl _loc ->
            match id with
            | None ->
              transl_module ~scopes Tcoerce_none None modl

--- a/testsuite/tests/basic-modules/anonymous.ocamlc.reference
+++ b/testsuite/tests/basic-modules/anonymous.ocamlc.reference
@@ -14,10 +14,12 @@
         (ignore
           (let (x =[(consts ()) (non_consts ([0: [int], [int]]))] [0: 4 2])
             (makeblock 0 x)))
-        (apply (field 1 (global CamlinternalMod!)) [0: [0]] A A)
+        (apply (field 1 (global CamlinternalMod!)) [0: [0]] A
+          (module-defn(A) Anonymous anonymous.ml(23):567-608 A))
         (apply (field 1 (global CamlinternalMod!)) [0: [0]] B
-          (let (x =[(consts ()) (non_consts ([0: *, *]))] [0: "foo" "bar"])
-            (makeblock 0)))
+          (module-defn(B) Anonymous anonymous.ml(33):703-773
+            (let (x =[(consts ()) (non_consts ([0: *, *]))] [0: "foo" "bar"])
+              (makeblock 0))))
         (let
           (f = (function {nlocal = 0} param : int 0) s = (makemutable 0 ""))
           (seq

--- a/testsuite/tests/basic-modules/anonymous.ocamlopt.flambda.reference
+++ b/testsuite/tests/basic-modules/anonymous.ocamlopt.flambda.reference
@@ -13,10 +13,12 @@
       (ignore
         (let (x =[(consts ()) (non_consts ([0: [int], [int]]))] [0: 4 2])
           (makeblock 0 x)))
-      (apply (field 1 (global CamlinternalMod!)) [0: [0]] A A)
+      (apply (field 1 (global CamlinternalMod!)) [0: [0]] A
+        (module-defn(A) Anonymous anonymous.ml(23):567-608 A))
       (apply (field 1 (global CamlinternalMod!)) [0: [0]] B
-        (let (x =[(consts ()) (non_consts ([0: *, *]))] [0: "foo" "bar"])
-          (makeblock 0)))
+        (module-defn(B) Anonymous anonymous.ml(33):703-773
+          (let (x =[(consts ()) (non_consts ([0: *, *]))] [0: "foo" "bar"])
+            (makeblock 0))))
       (let (f = (function {nlocal = 0} param : int 0) s = (makemutable 0 ""))
         (seq
           (ignore

--- a/testsuite/tests/functors/functors.compilers.reference
+++ b/testsuite/tests/functors/functors.compilers.reference
@@ -1,53 +1,66 @@
 (setglobal Functors!
   (let
     (O =
-       (function {nlocal = 0} X is_a_functor always_inline never_loop
-         (let
-           (cow = (function {nlocal = 0} x[int] : int (apply (field 0 X) x))
-            sheep = (function {nlocal = 0} x[int] : int (+ 1 (apply cow x))))
-           (makeblock 0 cow sheep)))
+       (module-defn(O) Functors functors.ml(12):184-279
+         (function {nlocal = 0} X is_a_functor always_inline never_loop
+           (let
+             (cow =
+                (function {nlocal = 0} x[int] : int (apply (field 0 X) x))
+              sheep =
+                (function {nlocal = 0} x[int] : int (+ 1 (apply cow x))))
+             (makeblock 0 cow sheep))))
      F =
-       (function {nlocal = 0} X Y is_a_functor always_inline never_loop
-         (let
-           (cow =
-              (function {nlocal = 0} x[int] : int
-                (apply (field 0 Y) (apply (field 0 X) x)))
-            sheep = (function {nlocal = 0} x[int] : int (+ 1 (apply cow x))))
-           (makeblock 0 cow sheep)))
+       (module-defn(F) Functors functors.ml(17):281-392
+         (function {nlocal = 0} X Y is_a_functor always_inline never_loop
+           (let
+             (cow =
+                (function {nlocal = 0} x[int] : int
+                  (apply (field 0 Y) (apply (field 0 X) x)))
+              sheep =
+                (function {nlocal = 0} x[int] : int (+ 1 (apply cow x))))
+             (makeblock 0 cow sheep))))
      F1 =
-       (function {nlocal = 0} X Y is_a_functor always_inline never_loop
-         (let
-           (cow =
-              (function {nlocal = 0} x[int] : int
-                (apply (field 0 Y) (apply (field 0 X) x)))
-            sheep = (function {nlocal = 0} x[int] : int (+ 1 (apply cow x))))
-           (makeblock 0 sheep)))
+       (module-defn(F1) Functors functors.ml(31):516-632
+         (function {nlocal = 0} X Y is_a_functor always_inline never_loop
+           (let
+             (cow =
+                (function {nlocal = 0} x[int] : int
+                  (apply (field 0 Y) (apply (field 0 X) x)))
+              sheep =
+                (function {nlocal = 0} x[int] : int (+ 1 (apply cow x))))
+             (makeblock 0 sheep))))
      F2 =
-       (function {nlocal = 0} X Y is_a_functor always_inline never_loop
-         (let
-           (X =a (makeblock 0 (field 1 X))
-            Y =a (makeblock 0 (field 1 Y))
-            cow =
-              (function {nlocal = 0} x[int] : int
-                (apply (field 0 Y) (apply (field 0 X) x)))
-            sheep = (function {nlocal = 0} x[int] : int (+ 1 (apply cow x))))
-           (makeblock 0 sheep)))
+       (module-defn(F2) Functors functors.ml(36):634-784
+         (function {nlocal = 0} X Y is_a_functor always_inline never_loop
+           (let
+             (X =a (makeblock 0 (field 1 X))
+              Y =a (makeblock 0 (field 1 Y))
+              cow =
+                (function {nlocal = 0} x[int] : int
+                  (apply (field 0 Y) (apply (field 0 X) x)))
+              sheep =
+                (function {nlocal = 0} x[int] : int (+ 1 (apply cow x))))
+             (makeblock 0 sheep))))
      M =
-       (let
-         (F =
-            (function {nlocal = 0} X Y is_a_functor always_inline never_loop
-              (let
-                (cow =
-                   (function {nlocal = 0} x[int] : int
-                     (apply (field 0 Y) (apply (field 0 X) x)))
-                 sheep =
-                   (function {nlocal = 0} x[int] : int (+ 1 (apply cow x))))
-                (makeblock 0 cow sheep))))
-         (makeblock 0
-           (function {nlocal = 0} funarg funarg is_a_functor stub
-             (let
-               (let =
-                  (apply F (makeblock 0 (field 1 funarg))
-                    (makeblock 0 (field 1 funarg))))
-               (makeblock 0 (field 1 let)))))))
+       (module-defn(M) Functors functors.ml(41):786-970
+         (let
+           (F =
+              (module-defn(F) Functors.M functors.ml(44):849-966
+                (function {nlocal = 0} X Y is_a_functor always_inline
+                  never_loop
+                  (let
+                    (cow =
+                       (function {nlocal = 0} x[int] : int
+                         (apply (field 0 Y) (apply (field 0 X) x)))
+                     sheep =
+                       (function {nlocal = 0} x[int] : int
+                         (+ 1 (apply cow x))))
+                    (makeblock 0 cow sheep)))))
+           (makeblock 0
+             (function {nlocal = 0} funarg funarg is_a_functor stub
+               (let
+                 (let =
+                    (apply F (makeblock 0 (field 1 funarg))
+                      (makeblock 0 (field 1 funarg))))
+                 (makeblock 0 (field 1 let))))))))
     (makeblock 0 O F F1 F2 M)))

--- a/testsuite/tests/translprim/module_coercion.compilers.flat.reference
+++ b/testsuite/tests/translprim/module_coercion.compilers.flat.reference
@@ -1,139 +1,154 @@
 (setglobal Module_coercion!
-  (let (M = (makeblock 0))
+  (let
+    (M =
+       (module-defn(M) Module_coercion module_coercion.ml(15):436-1135
+         (makeblock 0)))
     (makeblock 0 M
-      (makeblock 0
-        (function {nlocal = 0} prim[intarray] stub (array.length[int] prim))
-        (function {nlocal = 0} prim[intarray] prim[int] stub
-          (array.get[int] prim prim))
-        (function {nlocal = 0} prim[intarray] prim[int] stub
-          (array.unsafe_get[int] prim prim))
-        (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub
-          (array.set[int] prim prim prim))
-        (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub
-          (array.unsafe_set[int] prim prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub
-          (compare_ints prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub (== prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub (!= prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub (< prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub (> prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub (<= prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub (>= prim prim)))
-      (makeblock 0
-        (function {nlocal = 0} prim[floatarray] stub
-          (array.length[float] prim))
-        (function {nlocal = 0} prim[floatarray] prim[int] stub
-          (array.get[float] prim prim))
-        (function {nlocal = 0} prim[floatarray] prim[int] stub
-          (array.unsafe_get[float] prim prim))
-        (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub
-          (array.set[float] prim prim prim))
-        (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub
-          (array.unsafe_set[float] prim prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub
-          (compare_floats prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub (==. prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub (!=. prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub (<. prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub (>. prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub (<=. prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub (>=. prim prim)))
-      (makeblock 0
-        (function {nlocal = 0} prim[addrarray] stub
-          (array.length[addr] prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.unsafe_get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim stub
-          (array.set[addr] prim prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim stub
-          (array.unsafe_set[addr] prim prim prim))
-        (function {nlocal = 0} prim prim stub
-          (caml_string_compare prim prim))
-        (function {nlocal = 0} prim prim stub (caml_string_equal prim prim))
-        (function {nlocal = 0} prim prim stub
-          (caml_string_notequal prim prim))
-        (function {nlocal = 0} prim prim stub
-          (caml_string_lessthan prim prim))
-        (function {nlocal = 0} prim prim stub
-          (caml_string_greaterthan prim prim))
-        (function {nlocal = 0} prim prim stub
-          (caml_string_lessequal prim prim))
-        (function {nlocal = 0} prim prim stub
-          (caml_string_greaterequal prim prim)))
-      (makeblock 0
-        (function {nlocal = 0} prim[addrarray] stub
-          (array.length[addr] prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.unsafe_get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[int32] stub
-          (array.set[addr] prim prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[int32] stub
-          (array.unsafe_set[addr] prim prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          (compare_bints int32 prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          (Int32.== prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          (Int32.!= prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          (Int32.< prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          (Int32.> prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          (Int32.<= prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          (Int32.>= prim prim)))
-      (makeblock 0
-        (function {nlocal = 0} prim[addrarray] stub
-          (array.length[addr] prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.unsafe_get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[int64] stub
-          (array.set[addr] prim prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[int64] stub
-          (array.unsafe_set[addr] prim prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          (compare_bints int64 prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          (Int64.== prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          (Int64.!= prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          (Int64.< prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          (Int64.> prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          (Int64.<= prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          (Int64.>= prim prim)))
-      (makeblock 0
-        (function {nlocal = 0} prim[addrarray] stub
-          (array.length[addr] prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.unsafe_get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[nativeint] stub
-          (array.set[addr] prim prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[nativeint] stub
-          (array.unsafe_set[addr] prim prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          (compare_bints nativeint prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          (Nativeint.== prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          (Nativeint.!= prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          (Nativeint.< prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          (Nativeint.> prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          (Nativeint.<= prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          (Nativeint.>= prim prim))))))
+      (module-defn(M_int) Module_coercion module_coercion.ml(46):1552-1591
+        (makeblock 0
+          (function {nlocal = 0} prim[intarray] stub
+            (array.length[int] prim))
+          (function {nlocal = 0} prim[intarray] prim[int] stub
+            (array.get[int] prim prim))
+          (function {nlocal = 0} prim[intarray] prim[int] stub
+            (array.unsafe_get[int] prim prim))
+          (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub
+            (array.set[int] prim prim prim))
+          (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub
+            (array.unsafe_set[int] prim prim prim))
+          (function {nlocal = 0} prim[int] prim[int] stub
+            (compare_ints prim prim))
+          (function {nlocal = 0} prim[int] prim[int] stub (== prim prim))
+          (function {nlocal = 0} prim[int] prim[int] stub (!= prim prim))
+          (function {nlocal = 0} prim[int] prim[int] stub (< prim prim))
+          (function {nlocal = 0} prim[int] prim[int] stub (> prim prim))
+          (function {nlocal = 0} prim[int] prim[int] stub (<= prim prim))
+          (function {nlocal = 0} prim[int] prim[int] stub (>= prim prim))))
+      (module-defn(M_float) Module_coercion module_coercion.ml(47):1594-1637
+        (makeblock 0
+          (function {nlocal = 0} prim[floatarray] stub
+            (array.length[float] prim))
+          (function {nlocal = 0} prim[floatarray] prim[int] stub
+            (array.get[float] prim prim))
+          (function {nlocal = 0} prim[floatarray] prim[int] stub
+            (array.unsafe_get[float] prim prim))
+          (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub
+            (array.set[float] prim prim prim))
+          (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub
+            (array.unsafe_set[float] prim prim prim))
+          (function {nlocal = 0} prim[float] prim[float] stub
+            (compare_floats prim prim))
+          (function {nlocal = 0} prim[float] prim[float] stub
+            (==. prim prim))
+          (function {nlocal = 0} prim[float] prim[float] stub
+            (!=. prim prim))
+          (function {nlocal = 0} prim[float] prim[float] stub (<. prim prim))
+          (function {nlocal = 0} prim[float] prim[float] stub (>. prim prim))
+          (function {nlocal = 0} prim[float] prim[float] stub
+            (<=. prim prim))
+          (function {nlocal = 0} prim[float] prim[float] stub
+            (>=. prim prim))))
+      (module-defn(M_string) Module_coercion module_coercion.ml(48):1640-1685
+        (makeblock 0
+          (function {nlocal = 0} prim[addrarray] stub
+            (array.length[addr] prim))
+          (function {nlocal = 0} prim[addrarray] prim[int] stub
+            (array.get[addr] prim prim))
+          (function {nlocal = 0} prim[addrarray] prim[int] stub
+            (array.unsafe_get[addr] prim prim))
+          (function {nlocal = 0} prim[addrarray] prim[int] prim stub
+            (array.set[addr] prim prim prim))
+          (function {nlocal = 0} prim[addrarray] prim[int] prim stub
+            (array.unsafe_set[addr] prim prim prim))
+          (function {nlocal = 0} prim prim stub
+            (caml_string_compare prim prim))
+          (function {nlocal = 0} prim prim stub
+            (caml_string_equal prim prim))
+          (function {nlocal = 0} prim prim stub
+            (caml_string_notequal prim prim))
+          (function {nlocal = 0} prim prim stub
+            (caml_string_lessthan prim prim))
+          (function {nlocal = 0} prim prim stub
+            (caml_string_greaterthan prim prim))
+          (function {nlocal = 0} prim prim stub
+            (caml_string_lessequal prim prim))
+          (function {nlocal = 0} prim prim stub
+            (caml_string_greaterequal prim prim))))
+      (module-defn(M_int32) Module_coercion module_coercion.ml(49):1688-1731
+        (makeblock 0
+          (function {nlocal = 0} prim[addrarray] stub
+            (array.length[addr] prim))
+          (function {nlocal = 0} prim[addrarray] prim[int] stub
+            (array.get[addr] prim prim))
+          (function {nlocal = 0} prim[addrarray] prim[int] stub
+            (array.unsafe_get[addr] prim prim))
+          (function {nlocal = 0} prim[addrarray] prim[int] prim[int32] stub
+            (array.set[addr] prim prim prim))
+          (function {nlocal = 0} prim[addrarray] prim[int] prim[int32] stub
+            (array.unsafe_set[addr] prim prim prim))
+          (function {nlocal = 0} prim[int32] prim[int32] stub
+            (compare_bints int32 prim prim))
+          (function {nlocal = 0} prim[int32] prim[int32] stub
+            (Int32.== prim prim))
+          (function {nlocal = 0} prim[int32] prim[int32] stub
+            (Int32.!= prim prim))
+          (function {nlocal = 0} prim[int32] prim[int32] stub
+            (Int32.< prim prim))
+          (function {nlocal = 0} prim[int32] prim[int32] stub
+            (Int32.> prim prim))
+          (function {nlocal = 0} prim[int32] prim[int32] stub
+            (Int32.<= prim prim))
+          (function {nlocal = 0} prim[int32] prim[int32] stub
+            (Int32.>= prim prim))))
+      (module-defn(M_int64) Module_coercion module_coercion.ml(50):1734-1777
+        (makeblock 0
+          (function {nlocal = 0} prim[addrarray] stub
+            (array.length[addr] prim))
+          (function {nlocal = 0} prim[addrarray] prim[int] stub
+            (array.get[addr] prim prim))
+          (function {nlocal = 0} prim[addrarray] prim[int] stub
+            (array.unsafe_get[addr] prim prim))
+          (function {nlocal = 0} prim[addrarray] prim[int] prim[int64] stub
+            (array.set[addr] prim prim prim))
+          (function {nlocal = 0} prim[addrarray] prim[int] prim[int64] stub
+            (array.unsafe_set[addr] prim prim prim))
+          (function {nlocal = 0} prim[int64] prim[int64] stub
+            (compare_bints int64 prim prim))
+          (function {nlocal = 0} prim[int64] prim[int64] stub
+            (Int64.== prim prim))
+          (function {nlocal = 0} prim[int64] prim[int64] stub
+            (Int64.!= prim prim))
+          (function {nlocal = 0} prim[int64] prim[int64] stub
+            (Int64.< prim prim))
+          (function {nlocal = 0} prim[int64] prim[int64] stub
+            (Int64.> prim prim))
+          (function {nlocal = 0} prim[int64] prim[int64] stub
+            (Int64.<= prim prim))
+          (function {nlocal = 0} prim[int64] prim[int64] stub
+            (Int64.>= prim prim))))
+      (module-defn(M_nativeint) Module_coercion module_coercion.ml(51):1780-1831
+        (makeblock 0
+          (function {nlocal = 0} prim[addrarray] stub
+            (array.length[addr] prim))
+          (function {nlocal = 0} prim[addrarray] prim[int] stub
+            (array.get[addr] prim prim))
+          (function {nlocal = 0} prim[addrarray] prim[int] stub
+            (array.unsafe_get[addr] prim prim))
+          (function {nlocal = 0} prim[addrarray] prim[int] prim[nativeint]
+            stub (array.set[addr] prim prim prim))
+          (function {nlocal = 0} prim[addrarray] prim[int] prim[nativeint]
+            stub (array.unsafe_set[addr] prim prim prim))
+          (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
+            (compare_bints nativeint prim prim))
+          (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
+            (Nativeint.== prim prim))
+          (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
+            (Nativeint.!= prim prim))
+          (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
+            (Nativeint.< prim prim))
+          (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
+            (Nativeint.> prim prim))
+          (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
+            (Nativeint.<= prim prim))
+          (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
+            (Nativeint.>= prim prim)))))))

--- a/testsuite/tests/translprim/module_coercion.compilers.no-flat.reference
+++ b/testsuite/tests/translprim/module_coercion.compilers.no-flat.reference
@@ -1,139 +1,90 @@
 (setglobal Module_coercion!
-  (let (M = (makeblock 0))
+  (let
+    (M =
+       (module-defn(M) Module_coercion module_coercion.ml(15):436-1135
+         (makeblock 0)))
     (makeblock 0 M
-      (makeblock 0
-        (function {nlocal = 0} prim[intarray] stub (array.length[int] prim))
-        (function {nlocal = 0} prim[intarray] prim[int] stub
-          (array.get[int] prim prim))
-        (function {nlocal = 0} prim[intarray] prim[int] stub
-          (array.unsafe_get[int] prim prim))
-        (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub
-          (array.set[int] prim prim prim))
-        (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub
-          (array.unsafe_set[int] prim prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub
-          (compare_ints prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub (== prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub (!= prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub (< prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub (> prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub (<= prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub (>= prim prim)))
-      (makeblock 0
-        (function {nlocal = 0} prim[addrarray] stub
-          (array.length[addr] prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.unsafe_get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[float] stub
-          (array.set[addr] prim prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[float] stub
-          (array.unsafe_set[addr] prim prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub
-          (compare_floats prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub (==. prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub (!=. prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub (<. prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub (>. prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub (<=. prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub (>=. prim prim)))
-      (makeblock 0
-        (function {nlocal = 0} prim[addrarray] stub
-          (array.length[addr] prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.unsafe_get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim stub
-          (array.set[addr] prim prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim stub
-          (array.unsafe_set[addr] prim prim prim))
-        (function {nlocal = 0} prim prim stub
-          (caml_string_compare prim prim))
-        (function {nlocal = 0} prim prim stub (caml_string_equal prim prim))
-        (function {nlocal = 0} prim prim stub
-          (caml_string_notequal prim prim))
-        (function {nlocal = 0} prim prim stub
-          (caml_string_lessthan prim prim))
-        (function {nlocal = 0} prim prim stub
-          (caml_string_greaterthan prim prim))
-        (function {nlocal = 0} prim prim stub
-          (caml_string_lessequal prim prim))
-        (function {nlocal = 0} prim prim stub
-          (caml_string_greaterequal prim prim)))
-      (makeblock 0
-        (function {nlocal = 0} prim[addrarray] stub
-          (array.length[addr] prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.unsafe_get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[int32] stub
-          (array.set[addr] prim prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[int32] stub
-          (array.unsafe_set[addr] prim prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          (compare_bints int32 prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          (Int32.== prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          (Int32.!= prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          (Int32.< prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          (Int32.> prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          (Int32.<= prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          (Int32.>= prim prim)))
-      (makeblock 0
-        (function {nlocal = 0} prim[addrarray] stub
-          (array.length[addr] prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.unsafe_get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[int64] stub
-          (array.set[addr] prim prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[int64] stub
-          (array.unsafe_set[addr] prim prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          (compare_bints int64 prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          (Int64.== prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          (Int64.!= prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          (Int64.< prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          (Int64.> prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          (Int64.<= prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          (Int64.>= prim prim)))
-      (makeblock 0
-        (function {nlocal = 0} prim[addrarray] stub
-          (array.length[addr] prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.unsafe_get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[nativeint] stub
-          (array.set[addr] prim prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[nativeint] stub
-          (array.unsafe_set[addr] prim prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          (compare_bints nativeint prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          (Nativeint.== prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          (Nativeint.!= prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          (Nativeint.< prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          (Nativeint.> prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          (Nativeint.<= prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          (Nativeint.>= prim prim))))))
+      (module-defn(M_int) Module_coercion module_coercion.ml(46):1552-1591
+        (makeblock 0 (function prim stub (array.length[int] prim))
+          (function prim prim stub (array.get[int] prim prim))
+          (function prim prim stub (array.unsafe_get[int] prim prim))
+          (function prim prim prim stub (array.set[int] prim prim prim))
+          (function prim prim prim stub
+            (array.unsafe_set[int] prim prim prim))
+          (function prim prim stub (compare_ints prim prim))
+          (function prim prim stub (== prim prim))
+          (function prim prim stub (!= prim prim))
+          (function prim prim stub (< prim prim))
+          (function prim prim stub (> prim prim))
+          (function prim prim stub (<= prim prim))
+          (function prim prim stub (>= prim prim))))
+      (module-defn(M_float) Module_coercion module_coercion.ml(47):1594-1637
+        (makeblock 0 (function prim stub (array.length[addr] prim))
+          (function prim prim stub (array.get[addr] prim prim))
+          (function prim prim stub (array.unsafe_get[addr] prim prim))
+          (function prim prim prim stub (array.set[addr] prim prim prim))
+          (function prim prim prim stub
+            (array.unsafe_set[addr] prim prim prim))
+          (function prim prim stub (compare_floats prim prim))
+          (function prim prim stub (==. prim prim))
+          (function prim prim stub (!=. prim prim))
+          (function prim prim stub (<. prim prim))
+          (function prim prim stub (>. prim prim))
+          (function prim prim stub (<=. prim prim))
+          (function prim prim stub (>=. prim prim))))
+      (module-defn(M_string) Module_coercion module_coercion.ml(48):1640-1685
+        (makeblock 0 (function prim stub (array.length[addr] prim))
+          (function prim prim stub (array.get[addr] prim prim))
+          (function prim prim stub (array.unsafe_get[addr] prim prim))
+          (function prim prim prim stub (array.set[addr] prim prim prim))
+          (function prim prim prim stub
+            (array.unsafe_set[addr] prim prim prim))
+          (function prim prim stub (caml_string_compare prim prim))
+          (function prim prim stub (caml_string_equal prim prim))
+          (function prim prim stub (caml_string_notequal prim prim))
+          (function prim prim stub (caml_string_lessthan prim prim))
+          (function prim prim stub (caml_string_greaterthan prim prim))
+          (function prim prim stub (caml_string_lessequal prim prim))
+          (function prim prim stub (caml_string_greaterequal prim prim))))
+      (module-defn(M_int32) Module_coercion module_coercion.ml(49):1688-1731
+        (makeblock 0 (function prim stub (array.length[addr] prim))
+          (function prim prim stub (array.get[addr] prim prim))
+          (function prim prim stub (array.unsafe_get[addr] prim prim))
+          (function prim prim prim stub (array.set[addr] prim prim prim))
+          (function prim prim prim stub
+            (array.unsafe_set[addr] prim prim prim))
+          (function prim prim stub (compare_bints int32 prim prim))
+          (function prim prim stub (Int32.== prim prim))
+          (function prim prim stub (Int32.!= prim prim))
+          (function prim prim stub (Int32.< prim prim))
+          (function prim prim stub (Int32.> prim prim))
+          (function prim prim stub (Int32.<= prim prim))
+          (function prim prim stub (Int32.>= prim prim))))
+      (module-defn(M_int64) Module_coercion module_coercion.ml(50):1734-1777
+        (makeblock 0 (function prim stub (array.length[addr] prim))
+          (function prim prim stub (array.get[addr] prim prim))
+          (function prim prim stub (array.unsafe_get[addr] prim prim))
+          (function prim prim prim stub (array.set[addr] prim prim prim))
+          (function prim prim prim stub
+            (array.unsafe_set[addr] prim prim prim))
+          (function prim prim stub (compare_bints int64 prim prim))
+          (function prim prim stub (Int64.== prim prim))
+          (function prim prim stub (Int64.!= prim prim))
+          (function prim prim stub (Int64.< prim prim))
+          (function prim prim stub (Int64.> prim prim))
+          (function prim prim stub (Int64.<= prim prim))
+          (function prim prim stub (Int64.>= prim prim))))
+      (module-defn(M_nativeint) Module_coercion module_coercion.ml(51):1780-1831
+        (makeblock 0 (function prim stub (array.length[addr] prim))
+          (function prim prim stub (array.get[addr] prim prim))
+          (function prim prim stub (array.unsafe_get[addr] prim prim))
+          (function prim prim prim stub (array.set[addr] prim prim prim))
+          (function prim prim prim stub
+            (array.unsafe_set[addr] prim prim prim))
+          (function prim prim stub (compare_bints nativeint prim prim))
+          (function prim prim stub (Nativeint.== prim prim))
+          (function prim prim stub (Nativeint.!= prim prim))
+          (function prim prim stub (Nativeint.< prim prim))
+          (function prim prim stub (Nativeint.> prim prim))
+          (function prim prim stub (Nativeint.<= prim prim))
+          (function prim prim stub (Nativeint.>= prim prim)))))))


### PR DESCRIPTION
Reverts ocaml-flambda/ocaml-jst#135 due to a bad interaction with inlining. See discussion in https://github.com/ocaml/ocaml/pull/12092#issuecomment-1463977121; we'll want to reopen this later with whatever approach we decide on there.