### PR TITLE
Autogenerate tools/debug_printer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -273,6 +273,7 @@ _build
 /tools/make_opcodes.ml
 /tools/caml-tex
 /tools/eventlog_metadata
+/tools/debug_printers
 
 /toplevel/byte/topeval.mli
 /toplevel/byte/trace.mli

--- a/HACKING.jst.adoc
+++ b/HACKING.jst.adoc
@@ -68,10 +68,17 @@ Here's how to install the custom printers for a run of `ocamldebug`:
 1. Use the old `Makefile`, not the new `Makefile.jst`. This is an infelicity
 we hope to fix.
 
-2. In the `tools` directory, run `make debug_printers.cmo`.
+2. In the `tools` directory, run `make debug_printers`.
 
 3. In the debugger, execute some instructions, with e.g. `run` or `step`. This forces
 the debugger to load the compiler code, required for the next
 step.
 
 4. From your debugging session, run `source tools/debug_printers` to install the printers.
+
+To add a new printer, simply add a line of the form
+
+    let name = Some.Compiler.printer
+
+to `tools/debug_printers.ml`, and then run `make debug_printers` in the `tools`
+directory to regenerate the printing script.

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -329,6 +329,12 @@ endif
 clean::
 	rm -f -- caml-tex caml-tex.exe caml_tex.cm?
 
+# Debug printer script
+debug_printers: debug_printers.ml debug_printers.cmo
+	echo 'load_printer "tools/$(basename $<).cmo"' > '$@'
+	awk '{ print "install_printer Debug_printers." $$2 }' \
+	  < '$<' >> '$@'
+
 # Common stuff
 
 %.cmo: %.ml
@@ -341,7 +347,7 @@ clean::
 	$(CAMLOPT) $(COMPFLAGS) -c - $<
 
 clean::
-	rm -f *.cmo *.cmi *.cma *.dll *.so *.lib *.a
+	rm -f debug_printers *.cmo *.cmi *.cma *.dll *.so *.lib *.a
 
 CAMLDEP=$(BOOT_OCAMLC) -depend
 DEPFLAGS=-slash

--- a/tools/debug_printers
+++ b/tools/debug_printers
@@ -1,6 +1,0 @@
-load_printer "tools/debug_printers.cmo"
-install_printer Debug_printers.type_expr
-install_printer Debug_printers.row_field
-install_printer Debug_printers.ident
-install_printer Debug_printers.path
-install_printer Debug_printers.ctype_global_state


### PR DESCRIPTION
This cherry-picks a generally applicable improvement from antalsz#3 so that we can just edit `tools/debug_printers.ml`, rather than two separate files, and then `make -C tools debug_printers` to build.