### PR TITLE
Functions with no clauses aren't local-returning

### DIFF
--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3260,6 +3260,7 @@ let rec is_an_uncurried_function e =
 let is_local_returning_function cases =
   let rec loop_cases cases =
     match cases with
+    | [] -> false
     | [{pc_lhs = _; pc_guard = None; pc_rhs = e}] ->
         loop_body e
     | cases ->


### PR DESCRIPTION
As we observed, such functions can be constructed by a ppx.

It's kind of a pain to write a test case for this, so I haven't, but I could if it seems necessary.