### PR TITLE
Remove `-absname` to improve dune build errors

### DIFF
--- a/dune
+++ b/dune
@@ -48,7 +48,7 @@
  (name ocamlcommon)
  (wrapped false)
  (flags (
-   -strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66-70
+   -strict-sequence -principal -w +a-4-9-40-41-42-44-45-48-66-70
    -warn-error A -bin-annot -safe-string -strict-formats
    -w -67
    ; remove -w -67 by adding the camlinternalMenhirLib hack like the Makefile
@@ -105,7 +105,7 @@
  (name ocamlbytecomp)
  (wrapped false)
  (flags (
-   -strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66-70
+   -strict-sequence -principal -w +a-4-9-40-41-42-44-45-48-66-70
    -warn-error A -bin-annot -safe-string -strict-formats
  ))
  (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
@@ -123,7 +123,7 @@
  (name main)
  (modes byte)
  (flags (
-   -strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66-70
+   -strict-sequence -principal -w +a-4-9-40-41-42-44-45-48-66-70
    -warn-error A -bin-annot -safe-string -strict-formats
  ))
  (libraries ocamlbytecomp ocamlcommon)
@@ -133,7 +133,7 @@
  (name main_native)
  (modes native)
  (flags (
-   -strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66-70
+   -strict-sequence -principal -w +a-4-9-40-41-42-44-45-48-66-70
    -warn-error A -bin-annot -safe-string -strict-formats
  ))
  (libraries ocamlbytecomp ocamlcommon)


### PR DESCRIPTION
Strike `-absname` from dune builds. This means that (when we build the compiler) we'll get error messages like:

```
File "typing/typecore.ml", line 3888, characters 6-8:
Error: This pattern matches values of type unit
       but a pattern was expected which matches values of type int
```

instead of error messages like:

```
File "/usr/local/home/nroberts/ocaml/nroberts/_build/default/typing/typecore.ml", line 3888, characters 6-8:
Error: This pattern matches values of type unit
       but a pattern was expected which matches values of type int
```

This has better compatibility with e.g. emacs `compile`.
  * Old behavior: jumping to next error brought you to the `_build` directory
  * New behavior: jumping to next error brings you to the file you care about