### PR TITLE
A better place to generate the `ocamlc` you use in a debug session

### DIFF
--- a/Makefile.common-jst
+++ b/Makefile.common-jst
@@ -166,10 +166,16 @@ _install: compiler
           -or -name "flambda2*.cmti" -or -name "flambda2*.cmt" \) \
           -exec cp -f {} _install/lib/ocaml/compiler-libs \;
 
-# Copy _install to the final install directory (no-op if they are the same)
+# Copy _install to the final install directory (no-op if they are the same).
+# Also generate ocamlc at the root of the repo, as this is convenient to use
+# with ocamldebug: ocamldebug inherits the pwd of the file passed as argument,
+# so breakpoints bring you to the less-convenient _build source file if you use
+# the ocamlc.byte in $prefix/bin.
 install: _install
 	mkdir -p '$(prefix)'
 	rsync --chmod=u+rw,go+r -rl _install/ '$(prefix)'
+	rm -f ocamlc
+	ln -s '$(prefix)'/bin/ocamlc.byte ocamlc
 
 # Same as above, but relies on a successfull earlier _install
 install_for_opam:


### PR DESCRIPTION
`make -f Makefile.jst install` now also puts `ocamlc` at the root of the repo. It's recommended to run `ocamldebug` on it rather than the one in `$prefix/bin`.

Why's that? The `ocamldebug` session inherits the pwd of the bytecode file you pass as argument. In particular, breakpoints bring you to the proper file if you use the root `ocamlc`, and would bring you to the copied file in the `_build` directory if you used the `$prefix/bin` `ocamlc.byte`. (Well, actually, emacs would prompt you and bring you to the proper file, but it was a disruptive workflow.)