### PR TITLE
Fix bug where incorrect levels from type_package led to scope escape

### DIFF
--- a/testsuite/tests/typing-modules-bugs/pr12195_bad.compilers.reference
+++ b/testsuite/tests/typing-modules-bugs/pr12195_bad.compilers.reference
@@ -1,0 +1,19 @@
+File "pr12195_bad.ml", lines 21-25, characters 11-5:
+21 | ...........struct
+22 |     type s = A
+23 | 
+24 |     let created = Foo.create (fun _ -> ())
+25 |   end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type s = A val created : '_weak1 Foo.t end
+       is not included in
+         Bar
+       Values do not match:
+         val created : '_weak1 Foo.t
+       is not included in
+         val created : s Foo.t
+       The type '_weak1 Foo.t is not compatible with the type s Foo.t
+       The type constructor s would escape its scope
+       File "pr12195_bad.ml", line 17, characters 2-23: Expected declaration
+       File "pr12195_bad.ml", line 24, characters 8-15: Actual declaration

--- a/testsuite/tests/typing-modules-bugs/pr12195_bad.ml
+++ b/testsuite/tests/typing-modules-bugs/pr12195_bad.ml
@@ -1,0 +1,25 @@
+(* TEST
+ocamlc_byte_exit_status = "2"
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+*** check-ocamlc.byte-output
+*)
+module Foo = struct
+  type 'a t
+
+  let create : ('a -> unit) -> 'a t =
+    fun  _ -> assert false
+end
+
+module type Bar = sig
+  type s = A
+
+  val created : s Foo.t
+end
+
+let baz : (module Bar) =
+  (module (struct
+    type s = A
+
+    let created = Foo.create (fun _ -> ())
+  end))

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3052,12 +3052,14 @@ let lookup_type_in_sig sg =
 let type_package env m p fl =
   (* Same as Pexp_letmodule *)
   (* remember original level *)
+  let outer_scope = Ctype.get_current_level () in
   Ctype.begin_def ();
   let modl, scope = Typetexp.TyVarEnv.with_local_scope begin fun () ->
     let modl, _mod_shape = type_module env m in
     let scope = Ctype.create_scope () in
     modl, scope
   end in
+  Mtype.lower_nongen outer_scope modl.mod_type;
   let fl', env =
     match fl with
     | [] -> [], env


### PR DESCRIPTION
This fixes a bug Leo and I spotted this morning.  It becomes more of a problem with layouts.

I submitted the fix simultaneously upstream - [see here](https://github.com/ocaml/ocaml/pull/12195) for the full explanation.