### PR TITLE
Fix stdlib mlis

### DIFF
--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -20,21 +20,6 @@
   See {{!examples} the examples} below.
   See 'Memory model: The hard bits' chapter in the manual.
 
-<<<<<<< HEAD
-    This sequential implementation is provided in the interest of
-    compatibility: when people will start writing code to run on
-    Multicore, it would be nice if their use of Atomic was
-    backward-compatible with older versions of OCaml without having to
-    import additional compatibility layers.
-
-||||||| merged common ancestors
-    This sequential implementation is provided in the interest of
-    compatibility: when people will start writing code to run on
-    Multicore, it would be nice if their use of Atomic was
-    backward-compatible with older versions of OCaml without having to
-    import additional compatibility layers. *)
-=======
->>>>>>> ocaml/5.1
     @since 4.12
 *)
 

--- a/stdlib/bigarray.mli
+++ b/stdlib/bigarray.mli
@@ -975,13 +975,7 @@ external genarray_of_array0 :
   ('a, 'b, 'c) Array0.t -> ('a, 'b, 'c) Genarray.t = "%identity"
 (** Return the generic Bigarray corresponding to the given zero-dimensional
     Bigarray.
-<<<<<<< HEAD
-    @since 4.05.0 *)
-||||||| merged common ancestors
-   Bigarray. @since 4.05.0 *)
-=======
     @since 4.05 *)
->>>>>>> ocaml/5.1
 
 external genarray_of_array1 :
   ('a, 'b, 'c) Array1.t -> ('a, 'b, 'c) Genarray.t = "%identity"

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -33,10 +33,8 @@ open! Stdlib
 
 *)
 
-<<<<<<< HEAD
 [@@@ocaml.warning "A"]
-||||||| merged common ancestors
-=======
+
 (** {b Unsynchronized accesses} *)
 
 [@@@alert unsynchronized_access
@@ -48,7 +46,6 @@ open! Stdlib
     Thus, concurrent accesses to a buffer must be synchronized (for instance
     with a {!Mutex.t}).
 *)
->>>>>>> ocaml/5.1
 
 type t
 (** The abstract type of buffers. *)

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -117,22 +117,6 @@ val nan : float
     IEEE 754 standard.  As for floating-point comparisons,
     [=], [<], [<=], [>] and [>=] return [false] and [<>] returns [true]
     if one or both of their arguments is [nan].
-<<<<<<< HEAD
-    Returns [quiet_nan] since 5.0.0. *)
-
-val signaling_nan : float
-(** Signaling NaN. The corresponding signals do not raise OCaml exception,
-    but the value can be useful for interop with C libraries.
-
-    @since 5.0.0 *)
-
-val quiet_nan : float
-(** Quiet NaN.
-
-    @since 5.0.0 *)
-||||||| merged common ancestors
-    if one or both of their arguments is [nan]. *)
-=======
 
     [nan] is [quiet_nan] since 5.1; it was a signaling NaN before. *)
 
@@ -146,7 +130,6 @@ val quiet_nan : float
 (** Quiet NaN.
 
     @since 5.1 *)
->>>>>>> ocaml/5.1
 
 val pi : float
 (** The constant pi. *)

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -66,6 +66,12 @@ external major : unit -> unit = "caml_gc_major"
 external full_major : unit -> unit = "caml_gc_full_major"
 external compact : unit -> unit = "caml_gc_compaction"
 external get_minor_free : unit -> int = "caml_get_minor_free"
+
+(* CR ocaml 5 runtime: These functions are no-ops upstream. We should make them
+   no-ops internally when we delete the corresponding C functions from the
+   runtime -- they're already marked as deprecated in the mli.
+*)
+
 external eventlog_pause : unit -> unit = "caml_eventlog_pause"
 external eventlog_resume : unit -> unit = "caml_eventlog_resume"
 

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -66,9 +66,8 @@ external major : unit -> unit = "caml_gc_major"
 external full_major : unit -> unit = "caml_gc_full_major"
 external compact : unit -> unit = "caml_gc_compaction"
 external get_minor_free : unit -> int = "caml_get_minor_free"
-
-let eventlog_pause () = ()
-let eventlog_resume () = ()
+external eventlog_pause : unit -> unit = "caml_eventlog_pause"
+external eventlog_resume : unit -> unit = "caml_eventlog_resume"
 
 open Printf
 

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -95,26 +95,16 @@ type stat =
 
     stack_size: int;
     (** Current size of the stack, in words.
-<<<<<<< HEAD
-        @since 3.12.0 *)
-||||||| merged common ancestors
-    (** Current size of the stack, in words. @since 3.12.0 *)
-=======
-        This metrics is currently not available in OCaml 5: the field value is
-        always [0].
+
+        This metrics will not be available in the OCaml 5 runtime: the field
+        value will always be [0].
+
         @since 3.12 *)
->>>>>>> ocaml/5.1
 
     forced_major_collections: int;
     (** Number of forced full major collections completed since the program
         was started.
-<<<<<<< HEAD
-        @since 4.12.0 *)
-||||||| merged common ancestors
-        was started. @since 4.12.0 *)
-=======
         @since 4.12 *)
->>>>>>> ocaml/5.1
 }
 (** The memory management counters are returned in a [stat] record. These
    counters give values for the whole program.
@@ -221,13 +211,7 @@ type control =
         out variations in its workload. This is an integer between
         1 and 50.
         Default: 1.
-<<<<<<< HEAD
-        @since 4.03.0 *)
-||||||| merged common ancestors
-        Default: 1. @since 4.03.0 *)
-=======
         @since 4.03 *)
->>>>>>> ocaml/5.1
 
     custom_major_ratio : int;
     (** Target ratio of floating garbage to major heap size for
@@ -449,7 +433,6 @@ val delete_alarm : alarm -> unit
 (** [delete_alarm a] will stop the calls to the function associated
    to [a]. Calling [delete_alarm a] again has no effect. *)
 
-<<<<<<< HEAD
 external eventlog_pause : unit -> unit = "caml_eventlog_pause"
 (** [eventlog_pause ()] will pause the collection of traces in the
    runtime.
@@ -472,30 +455,6 @@ external eventlog_resume : unit -> unit = "caml_eventlog_resume"
 
    @since 4.11
   *)
-||||||| merged common ancestors
-external eventlog_pause : unit -> unit = "caml_eventlog_pause"
-(** [eventlog_pause ()] will pause the collection of traces in the
-   runtime.
-   Traces are collected if the program is linked to the instrumented runtime
-   and started with the environment variable OCAML_EVENTLOG_ENABLED.
-   Events are flushed to disk after pausing, and no new events will be
-   recorded until [eventlog_resume] is called. *)
-
-external eventlog_resume : unit -> unit = "caml_eventlog_resume"
-(** [eventlog_resume ()] will resume the collection of traces in the
-   runtime.
-   Traces are collected if the program is linked to the instrumented runtime
-   and started with the environment variable OCAML_EVENTLOG_ENABLED.
-   This call can be used after calling [eventlog_pause], or if the program
-   was started with OCAML_EVENTLOG_ENABLED=p. (which pauses the collection of
-   traces before the first event.) *)
-=======
-val eventlog_pause : unit -> unit
-[@@ocaml.deprecated "Use Runtime_events.pause instead."]
->>>>>>> ocaml/5.1
-
-val eventlog_resume : unit -> unit
-[@@ocaml.deprecated "Use Runtime_events.resume instead."]
 
 (** [Memprof] is a sampling engine for allocated memory words. Every
    allocated word has a probability of being sampled equal to a

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -100,6 +100,11 @@ type stat =
         value will always be [0].
 
         @since 3.12 *)
+    (* CR ocaml 5 runtime: Update the above comment to what it is upstream:
+
+       This metrics is currently not available in OCaml 5: the field value is
+       always [0].
+    *)
 
     forced_major_collections: int;
     (** Number of forced full major collections completed since the program
@@ -434,27 +439,10 @@ val delete_alarm : alarm -> unit
    to [a]. Calling [delete_alarm a] again has no effect. *)
 
 external eventlog_pause : unit -> unit = "caml_eventlog_pause"
-(** [eventlog_pause ()] will pause the collection of traces in the
-   runtime.
-   Traces are collected if the program is linked to the instrumented runtime
-   and started with the environment variable OCAML_EVENTLOG_ENABLED.
-   Events are flushed to disk after pausing, and no new events will be
-   recorded until [eventlog_resume] is called.
-
-   @since 4.11
-  *)
+[@@ocaml.deprecated "Use Runtime_events.pause instead."]
 
 external eventlog_resume : unit -> unit = "caml_eventlog_resume"
-(** [eventlog_resume ()] will resume the collection of traces in the
-   runtime.
-   Traces are collected if the program is linked to the instrumented runtime
-   and started with the environment variable OCAML_EVENTLOG_ENABLED.
-   This call can be used after calling [eventlog_pause], or if the program
-   was started with OCAML_EVENTLOG_ENABLED=p. (which pauses the collection of
-   traces before the first event.)
-
-   @since 4.11
-  *)
+[@@ocaml.deprecated "Use Runtime_events.resume instead."]
 
 (** [Memprof] is a sampling engine for allocated memory words. Every
    allocated word has a probability of being sampled equal to a

--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -440,19 +440,9 @@ module type SeededHashedType =
     val seeded_hash: int -> t -> int
       (** A seeded hashing function on keys.  The first argument is
           the seed.  It must be the case that if [equal x y] is true,
-<<<<<<< HEAD
-          then [hash seed x = hash seed y] for any value of [seed].
-          A suitable choice for [hash] is the function
-          {!Stdlib.Hashtbl.seeded_hash} below. *)
-||||||| merged common ancestors
-          then [hash seed x = hash seed y] for any value of [seed].
-          A suitable choice for [hash] is the function {!seeded_hash}
-          below. *)
-=======
           then [seeded_hash seed x = seeded_hash seed y] for any value of
           [seed].  A suitable choice for [seeded_hash] is the function
-          {!Hashtbl.seeded_hash} below. *)
->>>>>>> ocaml/5.1
+          {!Stdlib.Hashtbl.seeded_hash} below. *)
   end
 (** The input signature of the functor {!MakeSeeded}.
     @since 4.00 *)

--- a/stdlib/in_channel.mli
+++ b/stdlib/in_channel.mli
@@ -15,13 +15,6 @@
 
 (** Input channels.
 
-<<<<<<< HEAD
-    @since 4.14.0 *)
-open! Stdlib
-||||||| merged common ancestors
-    @since 4.14.0 *)
-
-=======
     This module provides functions for working with input channels.
 
     See {{!examples} the example section} below.
@@ -30,7 +23,6 @@ open! Stdlib
 
 (** {1:channels Channels} *)
 
->>>>>>> ocaml/5.1
 type t = in_channel
 (** The type of input channel. *)
 

--- a/stdlib/int32.mli
+++ b/stdlib/int32.mli
@@ -242,15 +242,4 @@ val hash : t -> int
     {!Hashtbl.hash}. This function allows this module to be passed as argument
     to the functor {!Hashtbl.Make}.
 
-<<<<<<< HEAD
-external format : string -> int32 -> string = "caml_int32_format"
-[@@ocaml.deprecated "Use Printf.sprintf with a [%l...] format instead."]
-(** Do not use this deprecated function.  Instead,
-   used {!Printf.sprintf} with a [%l...] format. *)
-||||||| merged common ancestors
-external format : string -> int32 -> string = "caml_int32_format"
-(** Do not use this deprecated function.  Instead,
-   used {!Printf.sprintf} with a [%l...] format. *)
-=======
     @since 5.1 *)
->>>>>>> ocaml/5.1

--- a/stdlib/int64.mli
+++ b/stdlib/int64.mli
@@ -256,20 +256,9 @@ val seeded_hash : int -> t -> int
 
     @since 5.1 *)
 
-<<<<<<< HEAD
-external format : string -> int64 -> string = "caml_int64_format"
-[@@ocaml.deprecated "Use Printf.sprintf with a [%L...] format instead."]
-(** Do not use this deprecated function.  Instead,
-   used {!Printf.sprintf} with a [%L...] format. *)
-||||||| merged common ancestors
-external format : string -> int64 -> string = "caml_int64_format"
-(** Do not use this deprecated function.  Instead,
-   used {!Printf.sprintf} with a [%L...] format. *)
-=======
 val hash : t -> int
 (** An unseeded hash function for 64-bit ints, with the same output value as
     {!Hashtbl.hash}. This function allows this module to be passed as argument
     to the functor {!Hashtbl.Make}.
 
     @since 5.1 *)
->>>>>>> ocaml/5.1

--- a/stdlib/map.mli
+++ b/stdlib/map.mli
@@ -290,121 +290,8 @@ module type S =
         [m1] contains all the bindings of [m] that satisfy the
         predicate [f], and [m2] is the map with all the bindings of
         [m] that do not satisfy [f].
-<<<<<<< HEAD
-        @since 3.12.0
+        @since 3.12
      *)
-
-    val cardinal: 'a t -> int
-    (** Return the number of bindings of a map.
-        @since 3.12.0
-     *)
-
-    val bindings: 'a t -> (key * 'a) list
-    (** Return the list of all bindings of the given map.
-       The returned list is sorted in increasing order of keys with respect
-       to the ordering [Ord.compare], where [Ord] is the argument
-       given to {!Stdlib.Map.Make}.
-        @since 3.12.0
-     *)
-
-    val min_binding: 'a t -> (key * 'a)
-    (** Return the binding with the smallest key in a given map
-       (with respect to the [Ord.compare] ordering), or raise
-       [Not_found] if the map is empty.
-        @since 3.12.0
-     *)
-
-    val min_binding_opt: 'a t -> (key * 'a) option
-    (** Return the binding with the smallest key in the given map
-       (with respect to the [Ord.compare] ordering), or [None]
-       if the map is empty.
-        @since 4.05
-     *)
-
-    val max_binding: 'a t -> (key * 'a)
-    (** Same as {!min_binding}, but returns the binding with
-        the largest key in the given map.
-        @since 3.12.0
-     *)
-
-    val max_binding_opt: 'a t -> (key * 'a) option
-    (** Same as {!min_binding_opt}, but returns the binding with
-        the largest key in the given map.
-        @since 4.05
-     *)
-
-    val choose: 'a t -> (key * 'a)
-    (** Return one binding of the given map, or raise [Not_found] if
-       the map is empty. Which binding is chosen is unspecified,
-       but equal bindings will be chosen for equal maps.
-        @since 3.12.0
-     *)
-
-    val choose_opt: 'a t -> (key * 'a) option
-    (** Return one binding of the given map, or [None] if
-       the map is empty. Which binding is chosen is unspecified,
-       but equal bindings will be chosen for equal maps.
-        @since 4.05
-     *)
-||||||| merged common ancestors
-        @since 3.12.0
-     *)
-
-    val cardinal: 'a t -> int
-    (** Return the number of bindings of a map.
-        @since 3.12.0
-     *)
-
-    val bindings: 'a t -> (key * 'a) list
-    (** Return the list of all bindings of the given map.
-       The returned list is sorted in increasing order of keys with respect
-       to the ordering [Ord.compare], where [Ord] is the argument
-       given to {!Make}.
-        @since 3.12.0
-     *)
-
-    val min_binding: 'a t -> (key * 'a)
-    (** Return the binding with the smallest key in a given map
-       (with respect to the [Ord.compare] ordering), or raise
-       [Not_found] if the map is empty.
-        @since 3.12.0
-     *)
-
-    val min_binding_opt: 'a t -> (key * 'a) option
-    (** Return the binding with the smallest key in the given map
-       (with respect to the [Ord.compare] ordering), or [None]
-       if the map is empty.
-        @since 4.05
-     *)
-
-    val max_binding: 'a t -> (key * 'a)
-    (** Same as {!S.min_binding}, but returns the binding with
-        the largest key in the given map.
-        @since 3.12.0
-     *)
-
-    val max_binding_opt: 'a t -> (key * 'a) option
-    (** Same as {!S.min_binding_opt}, but returns the binding with
-        the largest key in the given map.
-        @since 4.05
-     *)
-
-    val choose: 'a t -> (key * 'a)
-    (** Return one binding of the given map, or raise [Not_found] if
-       the map is empty. Which binding is chosen is unspecified,
-       but equal bindings will be chosen for equal maps.
-        @since 3.12.0
-     *)
-
-    val choose_opt: 'a t -> (key * 'a) option
-    (** Return one binding of the given map, or [None] if
-       the map is empty. Which binding is chosen is unspecified,
-       but equal bindings will be chosen for equal maps.
-        @since 4.05
-     *)
-=======
-        @since 3.12 *)
->>>>>>> ocaml/5.1
 
     val split: key -> 'a t -> 'a t * 'a option * 'a t
     (** [split x m] returns a triple [(l, data, r)], where
@@ -451,25 +338,11 @@ module type S =
     (** [to_list m] is {!bindings}[ m].
         @since 5.1 *)
 
-<<<<<<< HEAD
-    val mapi: (key -> 'a -> 'b) -> 'a t -> 'b t
-    (** Same as {!map}, but the function receives as arguments both the
-       key and the associated value for each binding of the map. *)
-
-    (** {1 Maps and Sequences} *)
-||||||| merged common ancestors
-    val mapi: (key -> 'a -> 'b) -> 'a t -> 'b t
-    (** Same as {!S.map}, but the function receives as arguments both the
-       key and the associated value for each binding of the map. *)
-
-    (** {1 Maps and Sequences} *)
-=======
     val of_list : (key * 'a) list -> 'a t
     (** [of_list bs] adds the bindings of [bs] to the empty map,
         in list order (if a key is bound twice in [bs] the last one
         takes over).
         @since 5.1 *)
->>>>>>> ocaml/5.1
 
     val to_seq : 'a t -> (key * 'a) Seq.t
     (** Iterate on the whole map, in ascending order of keys

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -461,19 +461,9 @@ module Hashtbl : sig
       val seeded_hash: int -> t -> int
         (** A seeded hashing function on keys.  The first argument is
             the seed.  It must be the case that if [equal x y] is true,
-<<<<<<< HEAD
-            then [hash seed x = hash seed y] for any value of [seed].
-            A suitable choice for [hash] is the function
-            {!Stdlib.Hashtbl.seeded_hash} below. *)
-||||||| merged common ancestors
-            then [hash seed x = hash seed y] for any value of [seed].
-            A suitable choice for [hash] is the function {!seeded_hash}
-            below. *)
-=======
             then [seeded_hash seed x = seeded_hash seed y] for any value of
             [seed].  A suitable choice for [seeded_hash] is the function
-            {!Hashtbl.seeded_hash} below. *)
->>>>>>> ocaml/5.1
+            {!Stdlib.Hashtbl.seeded_hash} below. *)
     end
   (** The input signature of the functor {!MakeSeeded}.
       @since 4.00 *)
@@ -950,121 +940,7 @@ module Map : sig
           [m1] contains all the bindings of [m] that satisfy the
           predicate [f], and [m2] is the map with all the bindings of
           [m] that do not satisfy [f].
-<<<<<<< HEAD
-          @since 3.12.0
-       *)
-
-      val cardinal: 'a t -> int
-      (** Return the number of bindings of a map.
-          @since 3.12.0
-       *)
-
-      val bindings: 'a t -> (key * 'a) list
-      (** Return the list of all bindings of the given map.
-         The returned list is sorted in increasing order of keys with respect
-         to the ordering [Ord.compare], where [Ord] is the argument
-         given to {!Stdlib.Map.Make}.
-          @since 3.12.0
-       *)
-
-      val min_binding: 'a t -> (key * 'a)
-      (** Return the binding with the smallest key in a given map
-         (with respect to the [Ord.compare] ordering), or raise
-         [Not_found] if the map is empty.
-          @since 3.12.0
-       *)
-
-      val min_binding_opt: 'a t -> (key * 'a) option
-      (** Return the binding with the smallest key in the given map
-         (with respect to the [Ord.compare] ordering), or [None]
-         if the map is empty.
-          @since 4.05
-       *)
-
-      val max_binding: 'a t -> (key * 'a)
-      (** Same as {!min_binding}, but returns the binding with
-          the largest key in the given map.
-          @since 3.12.0
-       *)
-
-      val max_binding_opt: 'a t -> (key * 'a) option
-      (** Same as {!min_binding_opt}, but returns the binding with
-          the largest key in the given map.
-          @since 4.05
-       *)
-
-      val choose: 'a t -> (key * 'a)
-      (** Return one binding of the given map, or raise [Not_found] if
-         the map is empty. Which binding is chosen is unspecified,
-         but equal bindings will be chosen for equal maps.
-          @since 3.12.0
-       *)
-
-      val choose_opt: 'a t -> (key * 'a) option
-      (** Return one binding of the given map, or [None] if
-         the map is empty. Which binding is chosen is unspecified,
-         but equal bindings will be chosen for equal maps.
-          @since 4.05
-       *)
-||||||| merged common ancestors
-          @since 3.12.0
-       *)
-
-      val cardinal: 'a t -> int
-      (** Return the number of bindings of a map.
-          @since 3.12.0
-       *)
-
-      val bindings: 'a t -> (key * 'a) list
-      (** Return the list of all bindings of the given map.
-         The returned list is sorted in increasing order of keys with respect
-         to the ordering [Ord.compare], where [Ord] is the argument
-         given to {!Make}.
-          @since 3.12.0
-       *)
-
-      val min_binding: 'a t -> (key * 'a)
-      (** Return the binding with the smallest key in a given map
-         (with respect to the [Ord.compare] ordering), or raise
-         [Not_found] if the map is empty.
-          @since 3.12.0
-       *)
-
-      val min_binding_opt: 'a t -> (key * 'a) option
-      (** Return the binding with the smallest key in the given map
-         (with respect to the [Ord.compare] ordering), or [None]
-         if the map is empty.
-          @since 4.05
-       *)
-
-      val max_binding: 'a t -> (key * 'a)
-      (** Same as {!S.min_binding}, but returns the binding with
-          the largest key in the given map.
-          @since 3.12.0
-       *)
-
-      val max_binding_opt: 'a t -> (key * 'a) option
-      (** Same as {!S.min_binding_opt}, but returns the binding with
-          the largest key in the given map.
-          @since 4.05
-       *)
-
-      val choose: 'a t -> (key * 'a)
-      (** Return one binding of the given map, or raise [Not_found] if
-         the map is empty. Which binding is chosen is unspecified,
-         but equal bindings will be chosen for equal maps.
-          @since 3.12.0
-       *)
-
-      val choose_opt: 'a t -> (key * 'a) option
-      (** Return one binding of the given map, or [None] if
-         the map is empty. Which binding is chosen is unspecified,
-         but equal bindings will be chosen for equal maps.
-          @since 4.05
-       *)
-=======
           @since 3.12 *)
->>>>>>> ocaml/5.1
 
       val split: key -> 'a t -> 'a t * 'a option * 'a t
       (** [split x m] returns a triple [(l, data, r)], where
@@ -1111,25 +987,11 @@ module Map : sig
       (** [to_list m] is {!bindings}[ m].
           @since 5.1 *)
 
-<<<<<<< HEAD
-      val mapi: f:(key -> 'a -> 'b) -> 'a t -> 'b t
-      (** Same as {!map}, but the function receives as arguments both the
-         key and the associated value for each binding of the map. *)
-
-      (** {1 Maps and Sequences} *)
-||||||| merged common ancestors
-      val mapi: f:(key -> 'a -> 'b) -> 'a t -> 'b t
-      (** Same as {!S.map}, but the function receives as arguments both the
-         key and the associated value for each binding of the map. *)
-
-      (** {1 Maps and Sequences} *)
-=======
       val of_list : (key * 'a) list -> 'a t
       (** [of_list bs] adds the bindings of [bs] to the empty map,
           in list order (if a key is bound twice in [bs] the last one
           takes over).
           @since 5.1 *)
->>>>>>> ocaml/5.1
 
       val to_seq : 'a t -> (key * 'a) Seq.t
       (** Iterate on the whole map, in ascending order of keys
@@ -1260,19 +1122,9 @@ module Set : sig
 
       val elements: t -> elt list
       (** Return the list of all elements of the given set.
-<<<<<<< HEAD
-         The returned list is sorted in increasing order with respect
-         to the ordering [Ord.compare], where [Ord] is the argument
-         given to {!Stdlib.Set.Make}. *)
-||||||| merged common ancestors
-         The returned list is sorted in increasing order with respect
-         to the ordering [Ord.compare], where [Ord] is the argument
-         given to {!Make}. *)
-=======
           The returned list is sorted in increasing order with respect
           to the ordering [Ord.compare], where [Ord] is the argument
           given to {!Set.Make}. *)
->>>>>>> ocaml/5.1
 
       val min_elt: t -> elt
       (** Return the smallest element of the given set
@@ -1287,14 +1139,7 @@ module Set : sig
 
       val max_elt: t -> elt
       (** Same as {!min_elt}, but returns the largest element of the
-<<<<<<< HEAD
-         given set. *)
-||||||| merged common ancestors
-      (** Same as {!S.min_elt}, but returns the largest element of the
-         given set. *)
-=======
           given set. *)
->>>>>>> ocaml/5.1
 
       val max_elt_opt: t -> elt option
       (** Same as {!min_elt_opt}, but returns the largest element of the

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -1124,7 +1124,7 @@ module Set : sig
       (** Return the list of all elements of the given set.
           The returned list is sorted in increasing order with respect
           to the ordering [Ord.compare], where [Ord] is the argument
-          given to {!Set.Make}. *)
+          given to {!Stdlib.Set.Make}. *)
 
       val min_elt: t -> elt
       (** Return the smallest element of the given set

--- a/stdlib/nativeint.mli
+++ b/stdlib/nativeint.mli
@@ -251,23 +251,4 @@ val hash : t -> int
     {!Hashtbl.hash}. This function allows this module to be passed as argument
     to the functor {!Hashtbl.Make}.
 
-<<<<<<< HEAD
-external format : string -> nativeint -> string = "caml_nativeint_format"
-[@@ocaml.deprecated "Use Printf.sprintf with a [%n...] format instead."]
-(** [Nativeint.format fmt n] return the string representation of the
-   native integer [n] in the format specified by [fmt].
-   [fmt] is a [Printf]-style format consisting of exactly
-   one [%d], [%i], [%u], [%x], [%X] or [%o] conversion specification.
-   This function is deprecated; use {!Printf.sprintf} with a [%nx] format
-   instead. *)
-||||||| merged common ancestors
-external format : string -> nativeint -> string = "caml_nativeint_format"
-(** [Nativeint.format fmt n] return the string representation of the
-   native integer [n] in the format specified by [fmt].
-   [fmt] is a [Printf]-style format consisting of exactly
-   one [%d], [%i], [%u], [%x], [%X] or [%o] conversion specification.
-   This function is deprecated; use {!Printf.sprintf} with a [%nx] format
-   instead. *)
-=======
     @since 5.1 *)
->>>>>>> ocaml/5.1

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -55,39 +55,17 @@ val field : t -> int -> t
 
 (** When using flambda:
 
-<<<<<<< HEAD
-    [set_field] and [set_double_field] MUST NOT be called on immutable
-    blocks.  (Blocks allocated in C stubs, or with [new_block] below,
-    are always considered mutable.)
-||||||| merged common ancestors
-    [set_field] MUST NOT be called on immutable blocks.  (Blocks allocated
-    in C stubs, or with [new_block] below, are always considered mutable.)
-
-    The same goes for [set_double_field] and [set_tag].  However, for
-    [set_tag], in the case of immutable blocks where the middle-end optimizers
-    never see code that discriminates on their tag (for example records), the
-    operation should be safe.  Such uses are nonetheless discouraged.
-=======
     [set_field] MUST NOT be called on immutable blocks.  (Blocks allocated
     in C stubs, or with [new_block] below, are always considered mutable.)
 
     The same goes for [set_double_field].
->>>>>>> ocaml/5.1
 
     For experts only:
     [set_field] et al can be made safe by first wrapping the block in
     {!Sys.opaque_identity}, so any information about its contents will not
     be propagated.
 *)
-<<<<<<< HEAD
 val set_field : t -> int -> t -> unit
-||||||| merged common ancestors
-external set_field : t -> int -> t -> unit = "%obj_set_field"
-external set_tag : t -> int -> unit = "caml_obj_set_tag"
-  [@@ocaml.deprecated "Use with_tag instead."]
-=======
-external set_field : t -> int -> t -> unit = "%obj_set_field"
->>>>>>> ocaml/5.1
 
 val double_field : t -> int -> float  (* @since 3.11.2 *)
 val set_double_field : t -> int -> float -> unit
@@ -100,19 +78,11 @@ external set_raw_field : t -> int -> raw_data -> unit
   (* @since 4.12 *)
 
 external new_block : int -> int -> t = "caml_obj_block"
-<<<<<<< HEAD
 
 external dup : t -> t = "%obj_dup"
 (** [dup t] returns a shallow copy of [t].  However if [t] is immutable then
     it might be returned unchanged. *)
 
-||||||| merged common ancestors
-external dup : t -> t = "caml_obj_dup"
-external truncate : t -> int -> unit = "caml_obj_truncate"
-  [@@ocaml.deprecated]
-=======
-external dup : t -> t = "caml_obj_dup"
->>>>>>> ocaml/5.1
 external add_offset : t -> Int32.t -> t = "caml_obj_add_offset"
          (* @since 3.12 *)
 external with_tag : int -> t -> t = "caml_obj_with_tag"
@@ -154,22 +124,6 @@ sig
   val name : t -> string
   val id : t -> int
 end
-<<<<<<< HEAD
-val extension_constructor : 'a -> extension_constructor
-  [@@ocaml.deprecated "use Obj.Extension_constructor.of_val"]
-val extension_name : extension_constructor -> string
-  [@@ocaml.deprecated "use Obj.Extension_constructor.name"]
-val extension_id : extension_constructor -> int
-  [@@ocaml.deprecated "use Obj.Extension_constructor.id"]
-||||||| merged common ancestors
-val extension_constructor : 'a -> extension_constructor
-  [@@ocaml.deprecated "use Obj.Extension_constructor.of_val"]
-val [@inline always] extension_name : extension_constructor -> string
-  [@@ocaml.deprecated "use Obj.Extension_constructor.name"]
-val [@inline always] extension_id : extension_constructor -> int
-  [@@ocaml.deprecated "use Obj.Extension_constructor.id"]
-=======
->>>>>>> ocaml/5.1
 
 module Ephemeron: sig
   (** Ephemeron with arbitrary arity and untyped *)
@@ -191,100 +145,28 @@ module Ephemeron: sig
   (** return the number of keys *)
 
   val get_key: t -> int -> obj_t option
-<<<<<<< HEAD
-  (** Same as {!Stdlib.Ephemeron.K1.get_key} *)
-||||||| merged common ancestors
-  (** Same as {!Ephemeron.K1.get_key} *)
-=======
->>>>>>> ocaml/5.1
 
   val get_key_copy: t -> int -> obj_t option
-<<<<<<< HEAD
-  (** Same as {!Stdlib.Ephemeron.K1.get_key_copy} *)
-||||||| merged common ancestors
-  (** Same as {!Ephemeron.K1.get_key_copy} *)
-=======
->>>>>>> ocaml/5.1
 
   val set_key: t -> int -> obj_t -> unit
-<<<<<<< HEAD
-  (** Same as {!Stdlib.Ephemeron.K1.set_key} *)
-||||||| merged common ancestors
-  (** Same as {!Ephemeron.K1.set_key} *)
-=======
->>>>>>> ocaml/5.1
 
   val unset_key: t -> int -> unit
-<<<<<<< HEAD
-  (** Same as {!Stdlib.Ephemeron.K1.unset_key} *)
-||||||| merged common ancestors
-  (** Same as {!Ephemeron.K1.unset_key} *)
-=======
->>>>>>> ocaml/5.1
 
   val check_key: t -> int -> bool
-<<<<<<< HEAD
-  (** Same as {!Stdlib.Ephemeron.K1.check_key} *)
-||||||| merged common ancestors
-  (** Same as {!Ephemeron.K1.check_key} *)
-=======
->>>>>>> ocaml/5.1
 
   val blit_key : t -> int -> t -> int -> int -> unit
-<<<<<<< HEAD
-  (** Same as {!Stdlib.Ephemeron.K1.blit_key} *)
-||||||| merged common ancestors
-  (** Same as {!Ephemeron.K1.blit_key} *)
-=======
->>>>>>> ocaml/5.1
 
   val get_data: t -> obj_t option
-<<<<<<< HEAD
-  (** Same as {!Stdlib.Ephemeron.K1.get_data} *)
-||||||| merged common ancestors
-  (** Same as {!Ephemeron.K1.get_data} *)
-=======
->>>>>>> ocaml/5.1
 
   val get_data_copy: t -> obj_t option
-<<<<<<< HEAD
-  (** Same as {!Stdlib.Ephemeron.K1.get_data_copy} *)
-||||||| merged common ancestors
-  (** Same as {!Ephemeron.K1.get_data_copy} *)
-=======
->>>>>>> ocaml/5.1
 
   val set_data: t -> obj_t -> unit
-<<<<<<< HEAD
-  (** Same as {!Stdlib.Ephemeron.K1.set_data} *)
-||||||| merged common ancestors
-  (** Same as {!Ephemeron.K1.set_data} *)
-=======
->>>>>>> ocaml/5.1
 
   val unset_data: t -> unit
-<<<<<<< HEAD
-  (** Same as {!Stdlib.Ephemeron.K1.unset_data} *)
-||||||| merged common ancestors
-  (** Same as {!Ephemeron.K1.unset_data} *)
-=======
->>>>>>> ocaml/5.1
 
   val check_data: t -> bool
-<<<<<<< HEAD
-  (** Same as {!Stdlib.Ephemeron.K1.check_data} *)
-||||||| merged common ancestors
-  (** Same as {!Ephemeron.K1.check_data} *)
-=======
->>>>>>> ocaml/5.1
 
   val blit_data : t -> t -> unit
-<<<<<<< HEAD
-  (** Same as {!Stdlib.Ephemeron.K1.blit_data} *)
-||||||| merged common ancestors
-  (** Same as {!Ephemeron.K1.blit_data} *)
-=======
->>>>>>> ocaml/5.1
 
   val max_ephe_length: int
   (** Maximum length of an ephemeron, ie the maximum number of keys an

--- a/stdlib/oo.mli
+++ b/stdlib/oo.mli
@@ -18,14 +18,8 @@ open! Stdlib
 
 (** Operations on objects *)
 
-<<<<<<< HEAD
 [@@@ocaml.noprincipal] (* preserve structure sharing in copy (PR#9767) *)
 
-val copy : (< .. > as 'a) -> 'a
-||||||| merged common ancestors
-val copy : (< .. > as 'a) -> 'a
-=======
->>>>>>> ocaml/5.1
 (** [Oo.copy o] returns a copy of object [o], that is a fresh
    object with the same methods and instance variables as [o]. *)
 val copy : (< .. > as 'a) -> 'a

--- a/stdlib/out_channel.mli
+++ b/stdlib/out_channel.mli
@@ -15,22 +15,15 @@
 
 (** Output channels.
 
-<<<<<<< HEAD
-    @since 4.14.0 *)
-open! Stdlib
-||||||| merged common ancestors
-    @since 4.14.0 *)
-
-=======
     This module provides functions for working with output channels.
 
     See {{!examples} the example section} below.
 
     @since 4.14 *)
+open! Stdlib
 
 (** {1:channels Channels}  *)
 
->>>>>>> ocaml/5.1
 type t = out_channel
 (** The type of output channel. *)
 

--- a/stdlib/random.mli
+++ b/stdlib/random.mli
@@ -15,13 +15,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
-<<<<<<< HEAD
 open! Stdlib
 
-(** Pseudo-random number generators (PRNG). *)
-||||||| merged common ancestors
-(** Pseudo-random number generators (PRNG). *)
-=======
 (** Pseudo-random number generators (PRNG).
 
     With multiple domains, each domain has its own generator that evolves
@@ -33,7 +28,6 @@ open! Stdlib
     generator.  Independent generators can be created with the {!Random.split}
     function and used with the functions from the {!Random.State} module.
 *)
->>>>>>> ocaml/5.1
 
 (** {1 Basic functions} *)
 

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -184,13 +184,7 @@ val iteri : (int -> 'a -> unit) -> 'a t -> unit
 
     @since 4.14 *)
 
-<<<<<<< HEAD
-val fold_lefti : ('b -> int -> 'a -> 'b) -> 'b -> 'a t -> 'b
-||||||| merged common ancestors
-val fold_lefti : (int -> 'b -> 'a -> 'b) -> 'b -> 'a t -> 'b
-=======
 val fold_lefti : ('acc -> int -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
->>>>>>> ocaml/5.1
 (** [fold_lefti f _ xs] invokes [f _ i x] successively
     for every element [x] located at index [i] of the sequence [xs].
 

--- a/stdlib/set.mli
+++ b/stdlib/set.mli
@@ -116,19 +116,9 @@ module type S =
 
     val elements: t -> elt list
     (** Return the list of all elements of the given set.
-<<<<<<< HEAD
-       The returned list is sorted in increasing order with respect
-       to the ordering [Ord.compare], where [Ord] is the argument
-       given to {!Stdlib.Set.Make}. *)
-||||||| merged common ancestors
-       The returned list is sorted in increasing order with respect
-       to the ordering [Ord.compare], where [Ord] is the argument
-       given to {!Make}. *)
-=======
         The returned list is sorted in increasing order with respect
         to the ordering [Ord.compare], where [Ord] is the argument
-        given to {!Set.Make}. *)
->>>>>>> ocaml/5.1
+        given to {!Stdlib.Set.Make}. *)
 
     val min_elt: t -> elt
     (** Return the smallest element of the given set
@@ -143,14 +133,7 @@ module type S =
 
     val max_elt: t -> elt
     (** Same as {!min_elt}, but returns the largest element of the
-<<<<<<< HEAD
-       given set. *)
-||||||| merged common ancestors
-    (** Same as {!S.min_elt}, but returns the largest element of the
-       given set. *)
-=======
         given set. *)
->>>>>>> ocaml/5.1
 
     val max_elt_opt: t -> elt option
     (** Same as {!min_elt_opt}, but returns the largest element of the

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -222,47 +222,13 @@ external ( && ) : (bool[@local_opt]) -> (bool[@local_opt]) -> bool = "%sequand"
    Right-associative operator,  see {!Ocaml_operators} for more information.
 *)
 
-<<<<<<< HEAD
-external ( & ) : (bool[@local_opt]) -> (bool[@local_opt]) -> bool = "%sequand"
-  [@@ocaml.deprecated "Use (&&) instead."]
-(** @deprecated {!Stdlib.( && )} should be used instead.
-    Right-associative operator, see {!Ocaml_operators} for more information.
-*)
-
 external ( || ) : (bool[@local_opt]) -> (bool[@local_opt]) -> bool = "%sequor"
-||||||| merged common ancestors
-external ( & ) : bool -> bool -> bool = "%sequand"
-  [@@ocaml.deprecated "Use (&&) instead."]
-(** @deprecated {!Stdlib.( && )} should be used instead.
-    Right-associative operator, see {!Ocaml_operators} for more information.
-*)
-
-external ( || ) : bool -> bool -> bool = "%sequor"
-=======
-external ( || ) : bool -> bool -> bool = "%sequor"
->>>>>>> ocaml/5.1
 (** The boolean 'or'. Evaluation is sequential, left-to-right:
    in [e1 || e2], [e1] is evaluated first, and if it returns [true],
    [e2] is not evaluated at all.
    Right-associative operator,  see {!Ocaml_operators} for more information.
 *)
 
-<<<<<<< HEAD
-external ( or ) : (bool[@local_opt]) -> (bool[@local_opt]) -> bool = "%sequor"
-  [@@ocaml.deprecated "Use (||) instead."]
-(** @deprecated {!Stdlib.( || )} should be used instead.
-    Right-associative operator, see {!Ocaml_operators} for more information.
-*)
-
-||||||| merged common ancestors
-external ( or ) : bool -> bool -> bool = "%sequor"
-  [@@ocaml.deprecated "Use (||) instead."]
-(** @deprecated {!Stdlib.( || )} should be used instead.
-    Right-associative operator, see {!Ocaml_operators} for more information.
-*)
-
-=======
->>>>>>> ocaml/5.1
 (** {1 Debugging} *)
 
 external __LOC__ : string = "%loc_LOC"
@@ -692,18 +658,8 @@ val nan : float
     IEEE 754 standard.  As for floating-point comparisons,
     [=], [<], [<=], [>] and [>=] return [false] and [<>] returns [true]
     if one or both of their arguments is [nan].
-<<<<<<< HEAD
-    Returns [quiet_nan] since 5.0.0. *)
-||||||| merged common ancestors
-   undefined operation such as [0.0 /. 0.0].  Stands for
-   'not a number'.  Any floating-point operation with [nan] as
-   argument returns [nan] as result.  As for floating-point comparisons,
-   [=], [<], [<=], [>] and [>=] return [false] and [<>] returns [true]
-   if one or both of their arguments is [nan]. *)
-=======
 
     [nan] is a quiet NaN since 5.1;  it was a signaling NaN before. *)
->>>>>>> ocaml/5.1
 
 val max_float : float
 (** The largest positive finite value of type [float]. *)

--- a/stdlib/templates/float.template.mli
+++ b/stdlib/templates/float.template.mli
@@ -114,22 +114,6 @@ val nan : float
     IEEE 754 standard.  As for floating-point comparisons,
     [=], [<], [<=], [>] and [>=] return [false] and [<>] returns [true]
     if one or both of their arguments is [nan].
-<<<<<<< HEAD
-    Returns [quiet_nan] since 5.0.0. *)
-
-val signaling_nan : float
-(** Signaling NaN. The corresponding signals do not raise OCaml exception,
-    but the value can be useful for interop with C libraries.
-
-    @since 5.0.0 *)
-
-val quiet_nan : float
-(** Quiet NaN.
-
-    @since 5.0.0 *)
-||||||| merged common ancestors
-    if one or both of their arguments is [nan]. *)
-=======
 
     [nan] is [quiet_nan] since 5.1; it was a signaling NaN before. *)
 
@@ -143,7 +127,6 @@ val quiet_nan : float
 (** Quiet NaN.
 
     @since 5.1 *)
->>>>>>> ocaml/5.1
 
 val pi : float
 (** The constant pi. *)

--- a/stdlib/templates/hashtbl.template.mli
+++ b/stdlib/templates/hashtbl.template.mli
@@ -437,19 +437,9 @@ module type SeededHashedType =
     val seeded_hash: int -> t -> int
       (** A seeded hashing function on keys.  The first argument is
           the seed.  It must be the case that if [equal x y] is true,
-<<<<<<< HEAD
-          then [hash seed x = hash seed y] for any value of [seed].
-          A suitable choice for [hash] is the function
-          {!Stdlib.Hashtbl.seeded_hash} below. *)
-||||||| merged common ancestors
-          then [hash seed x = hash seed y] for any value of [seed].
-          A suitable choice for [hash] is the function {!seeded_hash}
-          below. *)
-=======
           then [seeded_hash seed x = seeded_hash seed y] for any value of
           [seed].  A suitable choice for [seeded_hash] is the function
-          {!Hashtbl.seeded_hash} below. *)
->>>>>>> ocaml/5.1
+          {!Stdlib.Hashtbl.seeded_hash} below. *)
   end
 (** The input signature of the functor {!MakeSeeded}.
     @since 4.00 *)

--- a/stdlib/templates/map.template.mli
+++ b/stdlib/templates/map.template.mli
@@ -287,121 +287,8 @@ module type S =
         [m1] contains all the bindings of [m] that satisfy the
         predicate [f], and [m2] is the map with all the bindings of
         [m] that do not satisfy [f].
-<<<<<<< HEAD
-        @since 3.12.0
-     *)
 
-    val cardinal: 'a t -> int
-    (** Return the number of bindings of a map.
-        @since 3.12.0
-     *)
-
-    val bindings: 'a t -> (key * 'a) list
-    (** Return the list of all bindings of the given map.
-       The returned list is sorted in increasing order of keys with respect
-       to the ordering [Ord.compare], where [Ord] is the argument
-       given to {!Stdlib.Map.Make}.
-        @since 3.12.0
-     *)
-
-    val min_binding: 'a t -> (key * 'a)
-    (** Return the binding with the smallest key in a given map
-       (with respect to the [Ord.compare] ordering), or raise
-       [Not_found] if the map is empty.
-        @since 3.12.0
-     *)
-
-    val min_binding_opt: 'a t -> (key * 'a) option
-    (** Return the binding with the smallest key in the given map
-       (with respect to the [Ord.compare] ordering), or [None]
-       if the map is empty.
-        @since 4.05
-     *)
-
-    val max_binding: 'a t -> (key * 'a)
-    (** Same as {!min_binding}, but returns the binding with
-        the largest key in the given map.
-        @since 3.12.0
-     *)
-
-    val max_binding_opt: 'a t -> (key * 'a) option
-    (** Same as {!min_binding_opt}, but returns the binding with
-        the largest key in the given map.
-        @since 4.05
-     *)
-
-    val choose: 'a t -> (key * 'a)
-    (** Return one binding of the given map, or raise [Not_found] if
-       the map is empty. Which binding is chosen is unspecified,
-       but equal bindings will be chosen for equal maps.
-        @since 3.12.0
-     *)
-
-    val choose_opt: 'a t -> (key * 'a) option
-    (** Return one binding of the given map, or [None] if
-       the map is empty. Which binding is chosen is unspecified,
-       but equal bindings will be chosen for equal maps.
-        @since 4.05
-     *)
-||||||| merged common ancestors
-        @since 3.12.0
-     *)
-
-    val cardinal: 'a t -> int
-    (** Return the number of bindings of a map.
-        @since 3.12.0
-     *)
-
-    val bindings: 'a t -> (key * 'a) list
-    (** Return the list of all bindings of the given map.
-       The returned list is sorted in increasing order of keys with respect
-       to the ordering [Ord.compare], where [Ord] is the argument
-       given to {!Make}.
-        @since 3.12.0
-     *)
-
-    val min_binding: 'a t -> (key * 'a)
-    (** Return the binding with the smallest key in a given map
-       (with respect to the [Ord.compare] ordering), or raise
-       [Not_found] if the map is empty.
-        @since 3.12.0
-     *)
-
-    val min_binding_opt: 'a t -> (key * 'a) option
-    (** Return the binding with the smallest key in the given map
-       (with respect to the [Ord.compare] ordering), or [None]
-       if the map is empty.
-        @since 4.05
-     *)
-
-    val max_binding: 'a t -> (key * 'a)
-    (** Same as {!S.min_binding}, but returns the binding with
-        the largest key in the given map.
-        @since 3.12.0
-     *)
-
-    val max_binding_opt: 'a t -> (key * 'a) option
-    (** Same as {!S.min_binding_opt}, but returns the binding with
-        the largest key in the given map.
-        @since 4.05
-     *)
-
-    val choose: 'a t -> (key * 'a)
-    (** Return one binding of the given map, or raise [Not_found] if
-       the map is empty. Which binding is chosen is unspecified,
-       but equal bindings will be chosen for equal maps.
-        @since 3.12.0
-     *)
-
-    val choose_opt: 'a t -> (key * 'a) option
-    (** Return one binding of the given map, or [None] if
-       the map is empty. Which binding is chosen is unspecified,
-       but equal bindings will be chosen for equal maps.
-        @since 4.05
-     *)
-=======
         @since 3.12 *)
->>>>>>> ocaml/5.1
 
     val split: key -> 'a t -> 'a t * 'a option * 'a t
     (** [split x m] returns a triple [(l, data, r)], where
@@ -448,25 +335,11 @@ module type S =
     (** [to_list m] is {!bindings}[ m].
         @since 5.1 *)
 
-<<<<<<< HEAD
-    val mapi: f:(key -> 'a -> 'b) -> 'a t -> 'b t
-    (** Same as {!map}, but the function receives as arguments both the
-       key and the associated value for each binding of the map. *)
-
-    (** {1 Maps and Sequences} *)
-||||||| merged common ancestors
-    val mapi: f:(key -> 'a -> 'b) -> 'a t -> 'b t
-    (** Same as {!S.map}, but the function receives as arguments both the
-       key and the associated value for each binding of the map. *)
-
-    (** {1 Maps and Sequences} *)
-=======
     val of_list : (key * 'a) list -> 'a t
     (** [of_list bs] adds the bindings of [bs] to the empty map,
         in list order (if a key is bound twice in [bs] the last one
         takes over).
         @since 5.1 *)
->>>>>>> ocaml/5.1
 
     val to_seq : 'a t -> (key * 'a) Seq.t
     (** Iterate on the whole map, in ascending order of keys

--- a/stdlib/templates/set.template.mli
+++ b/stdlib/templates/set.template.mli
@@ -113,19 +113,9 @@ module type S =
 
     val elements: t -> elt list
     (** Return the list of all elements of the given set.
-<<<<<<< HEAD
-       The returned list is sorted in increasing order with respect
-       to the ordering [Ord.compare], where [Ord] is the argument
-       given to {!Stdlib.Set.Make}. *)
-||||||| merged common ancestors
-       The returned list is sorted in increasing order with respect
-       to the ordering [Ord.compare], where [Ord] is the argument
-       given to {!Make}. *)
-=======
         The returned list is sorted in increasing order with respect
         to the ordering [Ord.compare], where [Ord] is the argument
-        given to {!Set.Make}. *)
->>>>>>> ocaml/5.1
+        given to {!Stdlib.Set.Make}. *)
 
     val min_elt: t -> elt
     (** Return the smallest element of the given set
@@ -140,14 +130,7 @@ module type S =
 
     val max_elt: t -> elt
     (** Same as {!min_elt}, but returns the largest element of the
-<<<<<<< HEAD
-       given set. *)
-||||||| merged common ancestors
-    (** Same as {!S.min_elt}, but returns the largest element of the
-       given set. *)
-=======
         given set. *)
->>>>>>> ocaml/5.1
 
     val max_elt_opt: t -> elt option
     (** Same as {!min_elt_opt}, but returns the largest element of the


### PR DESCRIPTION
Resolve conflicts in stdlib mlis. These are almost always resolutions that prefer `tip-5`, but a handful of cases incorporate comments/documentation from `tip-jst`.

I make one update to `gc.ml` because, while we're still using the ocaml 4 runtime, we don't have to replace these functions with no-ops. When we finish merging the ocaml 5 runtime, we'll be flagged that these external functions don't exist and can figure out that they should be replaced with no-ops then.

Testing:

```
for x in stdlib/*.mli; do
  file=$(basename ${x%.mli});
  if echo $file | grep 'camlinternal\|stdlib\|std_exit'; then
    cmi=$file
  else
    cmi=stdlib__${file^}
  fi

  dune b --workspace=duneconf/runtime_stdlib.ws _build/runtime_stdlib/stdlib/.stdlib.objs/byte/$cmi.cmi
done
```

You'll see some syntax errors for JS-internal features: `local_`, `float#`, `global_`, but things otherwise build