### PR TITLE
Ocaml 5 runtime and configure tweaks

### DIFF
--- a/configure
+++ b/configure
@@ -18461,6 +18461,23 @@ case $enable_debug_runtime in #(
     debug_runtime=true ;;
 esac
 
+## Determine if system stack overflows can be detected
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether stack overflows can be detected" >&5
+printf %s "checking whether stack overflows can be detected... " >&6; }
+
+case $arch,$system in #(
+  i386,linux_elf|amd64,linux|amd64,macosx \
+    |amd64,openbsd|i386,bsd_elf|arm64,linux|arm64,macosx) :
+    printf "%s\n" "#define HAS_STACK_OVERFLOW_DETECTION 1" >>confdefs.h
+
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; } ;; #(
+  *) :
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; } ;;
+esac
+
 ## Determine how to link with the POSIX threads library
 
 case $host in #(

--- a/configure.ac
+++ b/configure.ac
@@ -2069,6 +2069,17 @@ AS_CASE([$enable_debug_runtime],
   [no], [debug_runtime=false],
   [debug_runtime=true])
 
+## Determine if system stack overflows can be detected
+
+AC_MSG_CHECKING([whether stack overflows can be detected])
+
+AS_CASE([$arch,$system],
+  [i386,linux_elf|amd64,linux|amd64,macosx \
+    |amd64,openbsd|i386,bsd_elf|arm64,linux|arm64,macosx],
+    [AC_DEFINE([HAS_STACK_OVERFLOW_DETECTION])
+    AC_MSG_RESULT([yes])],
+  [AC_MSG_RESULT([no])])
+
 ## Determine how to link with the POSIX threads library
 
 AS_CASE([$host],

--- a/runtime4/Makefile
+++ b/runtime4/Makefile
@@ -117,6 +117,11 @@ endif
 
 OC_CPPFLAGS += -DCAMLDLLIMPORT=
 
+# merge5: runtime4 requires -DCAML_NAME_SPACE and doesn't compile cleanly with two
+# new warnings added to the build in ocaml5
+OC_CPPFLAGS += -DCAML_NAME_SPACE
+OC_CFLAGS := $(filter-out -Wstrict-prototypes -Wold-style-definition, $(OC_CFLAGS))
+
 OC_NATIVE_CPPFLAGS = -DNATIVE_CODE -DTARGET_$(ARCH)
 
 ifeq "$(UNIX_OR_WIN32)" "unix"

--- a/runtime4/caml/config.h
+++ b/runtime4/caml/config.h
@@ -190,10 +190,24 @@ typedef uint64_t uintnat;
 #define Page_size (1 << Page_log)
 
 /* Initial size of stack (bytes). */
+#ifdef DEBUG
+#define Stack_size (64 * sizeof(value))
+#else
 #define Stack_size (4096 * sizeof(value))
+#endif
 
 /* Minimum free size of stack (bytes); below that, it is reallocated. */
-#define Stack_threshold (256 * sizeof(value))
+#define Stack_threshold_words 32
+#define Stack_threshold (Stack_threshold_words * sizeof(value))
+
+/* Definition of fiber control structure sizes from OCaml 5
+   (Backported here because it is used to generate stack overflow check
+   code, even though that logic can never trigger on runtime4) */
+#ifdef ARCH_SIXTYFOUR
+#define Stack_ctx_words (6 + 1)
+#else
+#define Stack_ctx_words (6 + 2)
+#endif
 
 /* Default maximum size of the stack (words). */
 #define Max_stack_def (1024 * 1024)

--- a/runtime4/caml/dune
+++ b/runtime4/caml/dune
@@ -23,7 +23,12 @@
 
 (rule
   (targets opnames.h)
-  (deps instruct.h ../Makefile)
+  (deps instruct.h ../Makefile
+   ../../Makefile.common
+   ../../Makefile.config
+   ../../Makefile.build_config
+   ../../Makefile.config_if_required
+  )
   (action (run make -s -C .. COMPUTE_DEPS=false caml/opnames.h)))
 
 (rule

--- a/runtime4/dune
+++ b/runtime4/dune
@@ -38,6 +38,7 @@
    ../Makefile.config_if_required
    ../Makefile.common Makefile
    (glob_files caml/*.h)
+   caml/domain_state.tbl
    primitives
    signals_osdep.h (glob_files *.S)
    (glob_files *.c)
@@ -46,6 +47,7 @@
  (no-infer
    (progn
      (bash "touch .depend") ; hack.
+     (run make "SAK_LINK=cc -o $(1) $(2)" COMPUTE_DEPS=false sak)
      (run make -sj8 %{targets} COMPUTE_DEPS=false)
      (bash "rm .depend")))))
 

--- a/utils/domainstate.ml.c
+++ b/utils/domainstate.ml.c
@@ -15,6 +15,7 @@
 /**************************************************************************/
 
 #define CAML_CONFIG_H_NO_TYPEDEFS
+#define CAML_NAME_SPACE
 #include "config.h"
 let stack_ctx_words = Stack_ctx_words
 

--- a/utils/dune
+++ b/utils/dune
@@ -26,7 +26,7 @@
  (deps    (:conf ../Makefile.config)
           (:c domainstate.ml.c)
           (:tbl ../runtime4/caml/domain_state.tbl)
-          (glob_files ../runtime4/caml/*.h))
+          (glob_files ../runtime4/caml/{config,m,s}.h))
  (action
    (with-stdout-to %{targets}
      (bash
@@ -39,7 +39,7 @@
  (deps    (:conf ../Makefile.config)
           (:c domainstate.mli.c)
           (:tbl ../runtime4/caml/domain_state.tbl)
-          (glob_files ../runtime4/caml/*.h))
+          (glob_files ../runtime4/caml/{config,m,s}.h))
  (action
    (with-stdout-to %{targets}
      (bash


### PR DESCRIPTION
This PR tweaks the dune files so that the following two targets now build (the latter, with a suitable ocamlopt on PATH):

```
dune b --workspace=duneconf/boot.ws _build/default/.ocamlcommon.objs/native/domainstate.cmx
dune b --workspace=duneconf/runtime_stdlib.ws _build/runtime_stdlib/runtime4/libasmrun.a
```

There is also a tweak to configure.ac to re-enable stack overflow detection (which is done in a different way on the ocaml 5 runtime)