### PR TITLE
Resolve conflicts in Lambda, Printlambda, Simplif, and Tmc

### DIFF
--- a/jane/build-resolved-files-for-ci
+++ b/jane/build-resolved-files-for-ci
@@ -70,6 +70,7 @@ mls=$(
   { echo driver/{compenv,compmisc,main_args}.ml
     echo parsing/parser.ml
     echo {utils,parsing}/*.ml
+    echo lambda/{lambda,tmc,simplif}.ml
     for f in "${typing_mls[@]}"; do
         echo "typing/${f}.ml"
     done

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -1619,7 +1619,9 @@ let primitive_result_layout (p : primitive) =
       layout_any_value
   | (Parray_to_iarray | Parray_of_iarray) -> layout_any_value
   | Pget_header _ -> layout_boxedint Pnativeint
-  | Prunstack | Presume | Pperform | Preperform -> layout_any_value
+  | Prunstack | Presume | Pperform | Preperform ->
+    (* CR mshinwell/ncourant: to be thought about later *)
+    layout_top
   | Patomic_load { immediate_or_pointer = Immediate } -> layout_int
   | Patomic_load { immediate_or_pointer = Pointer } -> layout_any_value
   | Patomic_exchange

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -133,21 +133,11 @@ type primitive =
   | Psetglobal of Compilation_unit.t
   | Pgetpredef of Ident.t
   (* Operations on heap blocks *)
-<<<<<<< HEAD
   | Pmakeblock of int * mutable_flag * block_shape * alloc_mode
   | Pmakefloatblock of mutable_flag * alloc_mode
   | Pmakeufloatblock of mutable_flag * alloc_mode
-  | Pfield of int * field_read_semantics
+  | Pfield of int * immediate_or_pointer * field_read_semantics
   | Pfield_computed of field_read_semantics
-||||||| merged common ancestors
-  | Pmakeblock of int * mutable_flag * block_shape
-  | Pfield of int
-  | Pfield_computed
-=======
-  | Pmakeblock of int * mutable_flag * block_shape
-  | Pfield of int * immediate_or_pointer * mutable_flag
-  | Pfield_computed
->>>>>>> ocaml/5.1
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment
   | Psetfield_computed of immediate_or_pointer * initialization_or_assignment
   | Pfloatfield of int * field_read_semantics * alloc_mode
@@ -155,20 +145,14 @@ type primitive =
   | Psetfloatfield of int * initialization_or_assignment
   | Psetufloatfield of int * initialization_or_assignment
   | Pduprecord of Types.record_representation * int
-<<<<<<< HEAD
   (* Unboxed products *)
   | Pmake_unboxed_product of layout list
   | Punboxed_product_field of int * layout list
-  (* Force lazy values *)
-||||||| merged common ancestors
-  (* Force lazy values *)
-=======
   (* Context switches *)
   | Prunstack
   | Pperform
   | Presume
   | Preperform
->>>>>>> ocaml/5.1
   (* External call *)
   | Pccall of Primitive.description
   (* Exceptions *)
@@ -252,20 +236,13 @@ type primitive =
   | Pbswap16
   | Pbbswap of boxed_integer * alloc_mode
   (* Integer to external pointer *)
-<<<<<<< HEAD
   | Pint_as_pointer of alloc_mode
-||||||| merged common ancestors
-  | Pint_as_pointer
-=======
-  | Pint_as_pointer
   (* Atomic operations *)
   | Patomic_load of {immediate_or_pointer : immediate_or_pointer}
   | Patomic_exchange
   | Patomic_cas
   | Patomic_fetch_add
->>>>>>> ocaml/5.1
   (* Inhibition of optimisation *)
-<<<<<<< HEAD
   | Popaque of layout
   (* Statically-defined probes *)
   | Pprobe_is_enabled of { name: string }
@@ -280,13 +257,8 @@ type primitive =
   | Parray_to_iarray
   | Parray_of_iarray
   | Pget_header of alloc_mode
-||||||| merged common ancestors
-  | Popaque
-=======
-  | Popaque
   (* Fetching domain-local state *)
   | Pdls_get
->>>>>>> ocaml/5.1
 
 and integer_comparison =
     Ceq | Cne | Clt | Cgt | Cle | Cge
@@ -531,7 +503,6 @@ type local_attribute =
   | Never_local (* [@local never] *)
   | Default_local (* [@local maybe] or no [@local] attribute *)
 
-<<<<<<< HEAD
 type property =
   | Zero_alloc
 
@@ -558,15 +529,6 @@ type loop_attribute =
   | Default_loop (* no [@loop] attribute *)
 
 type function_kind = Curried of {nlocal: int} | Tupled
-||||||| merged common ancestors
-type function_kind = Curried | Tupled
-=======
-type poll_attribute =
-  | Error_poll (* [@poll error] *)
-  | Default_poll (* no [@poll] attribute *)
-
-type function_kind = Curried | Tupled
->>>>>>> ocaml/5.1
 
 type let_kind = Strict | Alias | StrictOpt
 
@@ -587,14 +549,9 @@ type function_attribute = {
   inline : inline_attribute;
   specialise : specialise_attribute;
   local: local_attribute;
-<<<<<<< HEAD
   check : check_attribute;
   poll: poll_attribute;
   loop: loop_attribute;
-||||||| merged common ancestors
-=======
-  poll: poll_attribute;
->>>>>>> ocaml/5.1
   is_a_functor: bool;
   stub: bool;
   tmc_candidate: bool;
@@ -711,7 +668,6 @@ let max_arity () =
   (* 126 = 127 (the maximal number of parameters supported in C--)
            - 1 (the hidden parameter containing the environment) *)
 
-<<<<<<< HEAD
 let lfunction ~kind ~params ~return ~body ~attr ~loc ~mode ~region =
   assert (List.length params <= max_arity ());
   (* A curried function type with n parameters has n arrows. Of these,
@@ -736,12 +692,6 @@ let lfunction ~kind ~params ~return ~body ~attr ~loc ~mode ~region =
      if is_local_mode mode then assert (nlocal = nparams)
   end;
   Lfunction { kind; params; return; body; attr; loc; mode; region }
-||||||| merged common ancestors
-=======
-let lfunction ~kind ~params ~return ~body ~attr ~loc =
-  assert (List.length params <= max_arity ());
-  Lfunction { kind; params; return; body; attr; loc }
->>>>>>> ocaml/5.1
 
 let lambda_unit = Lconst const_unit
 
@@ -787,14 +737,9 @@ let default_function_attribute = {
   inline = Default_inline;
   specialise = Default_specialise;
   local = Default_local;
-<<<<<<< HEAD
   check = Default_check ;
   poll = Default_poll;
   loop = Default_loop;
-||||||| merged common ancestors
-=======
-  poll = Default_poll;
->>>>>>> ocaml/5.1
   is_a_functor = false;
   stub = false;
   tmc_candidate = false;
@@ -1102,14 +1047,8 @@ let rec transl_address loc = function
       then Lprim (Pgetpredef id, [], loc)
       else Lvar id
   | Env.Adot(addr, pos) ->
-<<<<<<< HEAD
-      Lprim(Pfield (pos, Reads_agree), [transl_address loc addr], loc)
-||||||| merged common ancestors
-      Lprim(Pfield pos, [transl_address loc addr], loc)
-=======
-      Lprim(Pfield(pos, Pointer, Immutable),
+      Lprim(Pfield(pos, Pointer, Reads_agree),
                    [transl_address loc addr], loc)
->>>>>>> ocaml/5.1
 
 let transl_path find loc env path =
   match find path env with

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -1416,7 +1416,7 @@ let reset () =
   raise_count := 0
 
 let mod_field ?(read_semantics=Reads_agree) pos =
-  Pfield (pos, read_semantics)
+  Pfield (pos, Pointer, read_semantics)
 
 let mod_setfield pos =
   Psetfield (pos, Pointer, Root_initialization)

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -1506,6 +1506,12 @@ let primitive_may_allocate : primitive -> alloc_mode option = function
   | Pobj_magic _ -> None
   | Punbox_float | Punbox_int _ -> None
   | Pbox_float m | Pbox_int (_, m) -> Some m
+  | Prunstack | Presume | Pperform | Preperform -> Some alloc_heap
+  | Patomic_load _
+  | Patomic_exchange
+  | Patomic_cas
+  | Patomic_fetch_add
+  | Pdls_get -> None
 
 let constant_layout = function
   | Const_int _ | Const_char _ -> Pvalue Pintval
@@ -1613,6 +1619,13 @@ let primitive_result_layout (p : primitive) =
       layout_any_value
   | (Parray_to_iarray | Parray_of_iarray) -> layout_any_value
   | Pget_header _ -> layout_boxedint Pnativeint
+  | Prunstack | Presume | Pperform | Preperform -> layout_any_value
+  | Patomic_load { immediate_or_pointer = Immediate } -> layout_int
+  | Patomic_load { immediate_or_pointer = Pointer } -> layout_any_value
+  | Patomic_exchange
+  | Patomic_cas
+  | Patomic_fetch_add
+  | Pdls_get -> layout_any_value
 
 let compute_expr_layout free_vars_kind lam =
   let rec compute_expr_layout kinds = function

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -1506,7 +1506,8 @@ let primitive_may_allocate : primitive -> alloc_mode option = function
   | Pobj_magic _ -> None
   | Punbox_float | Punbox_int _ -> None
   | Pbox_float m | Pbox_int (_, m) -> Some m
-  | Prunstack | Presume | Pperform | Preperform -> Some alloc_heap
+  | Prunstack | Presume | Pperform | Preperform ->
+    Misc.fatal_error "Effects-related primitives are not yet supported"
   | Patomic_load _
   | Patomic_exchange
   | Patomic_cas
@@ -1621,7 +1622,7 @@ let primitive_result_layout (p : primitive) =
   | Pget_header _ -> layout_boxedint Pnativeint
   | Prunstack | Presume | Pperform | Preperform ->
     (* CR mshinwell/ncourant: to be thought about later *)
-    layout_top
+    Misc.fatal_error "Effects-related primitives are not yet supported"
   | Patomic_load { immediate_or_pointer = Immediate } -> layout_int
   | Patomic_load { immediate_or_pointer = Pointer } -> layout_any_value
   | Patomic_exchange

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -292,12 +292,12 @@ let primitive ppf = function
   | Pmakeufloatblock (Mutable, mode) ->
      fprintf ppf "make%sufloatblock Mutable"
         (alloc_mode mode)
-  | Pfield (n, sem) ->
+  | Pfield (n, ptr, sem) ->
       let instr =
-        match ptr, mut with
+        match ptr, sem with
         | Immediate, _ -> "field_int "
-        | Pointer, Mutable -> "field_mut "
-        | Pointer, Immutable -> "field_imm "
+        | Pointer, Reads_vary -> "field_mut "
+        | Pointer, Reads_agree -> "field_imm "
       in
       fprintf ppf "%s%a %i" instr field_read_semantics sem n
   | Pfield_computed sem ->

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -155,7 +155,6 @@ let return_kind ppf (mode, kind) =
   | Ptop -> fprintf ppf ": top@ "
   | Pbottom -> fprintf ppf ": bottom@ "
 
-<<<<<<< HEAD
 let field_kind ppf = function
   | Pgenval -> pp_print_string ppf "*"
   | Pintval -> pp_print_string ppf "int"
@@ -192,13 +191,6 @@ let boxed_integer_mark name bi m =
 
 let print_boxed_integer name ppf bi m =
   fprintf ppf "%s" (boxed_integer_mark name bi m);;
-||||||| merged common ancestors
-let print_boxed_integer name ppf bi =
-  fprintf ppf "%s" (boxed_integer_mark name bi);;
-=======
-let print_boxed_integer name ppf bi =
-  fprintf ppf "%s" (boxed_integer_mark name bi)
->>>>>>> ocaml/5.1
 
 let print_bigarray name unsafe kind ppf layout =
   fprintf ppf "Bigarray.%s[%s,%s]"
@@ -227,14 +219,7 @@ let record_rep ppf r = match r with
   | Record_boxed _ -> fprintf ppf "boxed"
   | Record_inlined _ -> fprintf ppf "inlined"
   | Record_float -> fprintf ppf "float"
-<<<<<<< HEAD
   | Record_ufloat -> fprintf ppf "ufloat"
-||||||| merged common ancestors
-  | Record_extension path -> fprintf ppf "ext(%a)" Printtyp.path path
-;;
-=======
-  | Record_extension path -> fprintf ppf "ext(%a)" Printtyp.path path
->>>>>>> ocaml/5.1
 
 let block_shape ppf shape = match shape with
   | None | Some [] -> ()
@@ -277,7 +262,6 @@ let primitive ppf = function
   | Pbytes_to_string -> fprintf ppf "bytes_to_string"
   | Pbytes_of_string -> fprintf ppf "bytes_of_string"
   | Pignore -> fprintf ppf "ignore"
-<<<<<<< HEAD
   | Pgetglobal cu -> fprintf ppf "global %a!" Compilation_unit.print cu
   | Psetglobal cu -> fprintf ppf "setglobal %a!" Compilation_unit.print cu
   | Pgetpredef id -> fprintf ppf "getpredef %a!" Ident.print id
@@ -309,35 +293,15 @@ let primitive ppf = function
      fprintf ppf "make%sufloatblock Mutable"
         (alloc_mode mode)
   | Pfield (n, sem) ->
-      fprintf ppf "field%a %i" field_read_semantics sem n
-  | Pfield_computed sem ->
-      fprintf ppf "field_computed%a" field_read_semantics sem
-||||||| merged common ancestors
-  | Pgetglobal id -> fprintf ppf "global %a" Ident.print id
-  | Psetglobal id -> fprintf ppf "setglobal %a" Ident.print id
-  | Pmakeblock(tag, Immutable, shape) ->
-      fprintf ppf "makeblock %i%a" tag block_shape shape
-  | Pmakeblock(tag, Mutable, shape) ->
-      fprintf ppf "makemutable %i%a" tag block_shape shape
-  | Pfield n -> fprintf ppf "field %i" n
-  | Pfield_computed -> fprintf ppf "field_computed"
-=======
-  | Pgetglobal id -> fprintf ppf "global %a" Ident.print id
-  | Psetglobal id -> fprintf ppf "setglobal %a" Ident.print id
-  | Pmakeblock(tag, Immutable, shape) ->
-      fprintf ppf "makeblock %i%a" tag block_shape shape
-  | Pmakeblock(tag, Mutable, shape) ->
-      fprintf ppf "makemutable %i%a" tag block_shape shape
-  | Pfield(n, ptr, mut) ->
       let instr =
         match ptr, mut with
         | Immediate, _ -> "field_int "
         | Pointer, Mutable -> "field_mut "
         | Pointer, Immutable -> "field_imm "
       in
-      fprintf ppf "%s%i" instr n
-  | Pfield_computed -> fprintf ppf "field_computed"
->>>>>>> ocaml/5.1
+      fprintf ppf "%s%a %i" instr field_read_semantics sem n
+  | Pfield_computed sem ->
+      fprintf ppf "field_computed%a" field_read_semantics sem
   | Psetfield(n, ptr, init) ->
       let instr =
         match ptr with
@@ -391,20 +355,16 @@ let primitive ppf = function
       in
       fprintf ppf "setufloatfield%s %i" init n
   | Pduprecord (rep, size) -> fprintf ppf "duprecord %a %i" record_rep rep size
-<<<<<<< HEAD
+  | Prunstack -> fprintf ppf "runstack"
+  | Pperform -> fprintf ppf "perform"
+  | Presume -> fprintf ppf "resume"
+  | Preperform -> fprintf ppf "reperform"
   | Pmake_unboxed_product layouts ->
       fprintf ppf "make_unboxed_product [%a]"
         (pp_print_list ~pp_sep:(fun ppf () -> fprintf ppf ", ") layout) layouts
   | Punboxed_product_field (n, layouts) ->
       fprintf ppf "unboxed_product_field %d [%a]" n
         (pp_print_list ~pp_sep:(fun ppf () -> fprintf ppf ", ") layout) layouts
-||||||| merged common ancestors
-=======
-  | Prunstack -> fprintf ppf "runstack"
-  | Pperform -> fprintf ppf "perform"
-  | Presume -> fprintf ppf "resume"
-  | Preperform -> fprintf ppf "reperform"
->>>>>>> ocaml/5.1
   | Pccall p -> fprintf ppf "%s" p.prim_name
   | Praise k -> fprintf ppf "%s" (Lambda.raise_kind k)
   | Psequand -> fprintf ppf "&&"
@@ -477,7 +437,6 @@ let primitive ppf = function
   | Pisint { variant_only } ->
       fprintf ppf (if variant_only then "isint" else "obj_is_int")
   | Pisout -> fprintf ppf "isout"
-<<<<<<< HEAD
   | Pbintofint (bi,m) -> print_boxed_integer "of_int" ppf bi m
   | Pintofbint bi -> print_boxed_integer "to_int" ppf bi alloc_heap
   | Pcvtbint (bi1, bi2, m) -> print_boxed_integer_conversion ppf bi1 bi2 m
@@ -485,14 +444,14 @@ let primitive ppf = function
   | Paddbint (bi,m) -> print_boxed_integer "add" ppf bi m
   | Psubbint (bi,m) -> print_boxed_integer "sub" ppf bi m
   | Pmulbint (bi,m) -> print_boxed_integer "mul" ppf bi m
-  | Pdivbint { size = bi; is_safe = Safe; mode } ->
-      print_boxed_integer "div" ppf bi mode
-  | Pdivbint { size = bi; is_safe = Unsafe; mode } ->
-      print_boxed_integer "div_unsafe" ppf bi mode
-  | Pmodbint { size = bi; is_safe = Safe; mode } ->
-      print_boxed_integer "mod" ppf bi mode
-  | Pmodbint { size = bi; is_safe = Unsafe; mode } ->
-      print_boxed_integer "mod_unsafe" ppf bi mode
+  | Pdivbint { size; is_safe = Safe; mode } ->
+      print_boxed_integer "div" ppf size mode
+  | Pdivbint { size; is_safe = Unsafe; mode } ->
+      print_boxed_integer "div_unsafe" ppf size mode
+  | Pmodbint { size; is_safe = Safe; mode } ->
+      print_boxed_integer "mod" ppf size mode
+  | Pmodbint { size; is_safe = Unsafe; mode } ->
+      print_boxed_integer "mod_unsafe" ppf size mode
   | Pandbint (bi,m) -> print_boxed_integer "and" ppf bi m
   | Porbint (bi,m) -> print_boxed_integer "or" ppf bi m
   | Pxorbint (bi,m) -> print_boxed_integer "xor" ppf bi m
@@ -505,63 +464,6 @@ let primitive ppf = function
   | Pbintcomp(bi, Cgt) -> print_boxed_integer ">" ppf bi alloc_heap
   | Pbintcomp(bi, Cle) -> print_boxed_integer "<=" ppf bi alloc_heap
   | Pbintcomp(bi, Cge) -> print_boxed_integer ">=" ppf bi alloc_heap
-||||||| merged common ancestors
-  | Pbintofint bi -> print_boxed_integer "of_int" ppf bi
-  | Pintofbint bi -> print_boxed_integer "to_int" ppf bi
-  | Pcvtbint (bi1, bi2) -> print_boxed_integer_conversion ppf bi1 bi2
-  | Pnegbint bi -> print_boxed_integer "neg" ppf bi
-  | Paddbint bi -> print_boxed_integer "add" ppf bi
-  | Psubbint bi -> print_boxed_integer "sub" ppf bi
-  | Pmulbint bi -> print_boxed_integer "mul" ppf bi
-  | Pdivbint { size = bi; is_safe = Safe } ->
-      print_boxed_integer "div" ppf bi
-  | Pdivbint { size = bi; is_safe = Unsafe } ->
-      print_boxed_integer "div_unsafe" ppf bi
-  | Pmodbint { size = bi; is_safe = Safe } ->
-      print_boxed_integer "mod" ppf bi
-  | Pmodbint { size = bi; is_safe = Unsafe } ->
-      print_boxed_integer "mod_unsafe" ppf bi
-  | Pandbint bi -> print_boxed_integer "and" ppf bi
-  | Porbint bi -> print_boxed_integer "or" ppf bi
-  | Pxorbint bi -> print_boxed_integer "xor" ppf bi
-  | Plslbint bi -> print_boxed_integer "lsl" ppf bi
-  | Plsrbint bi -> print_boxed_integer "lsr" ppf bi
-  | Pasrbint bi -> print_boxed_integer "asr" ppf bi
-  | Pbintcomp(bi, Ceq) -> print_boxed_integer "==" ppf bi
-  | Pbintcomp(bi, Cne) -> print_boxed_integer "!=" ppf bi
-  | Pbintcomp(bi, Clt) -> print_boxed_integer "<" ppf bi
-  | Pbintcomp(bi, Cgt) -> print_boxed_integer ">" ppf bi
-  | Pbintcomp(bi, Cle) -> print_boxed_integer "<=" ppf bi
-  | Pbintcomp(bi, Cge) -> print_boxed_integer ">=" ppf bi
-=======
-  | Pbintofint bi -> print_boxed_integer "of_int" ppf bi
-  | Pintofbint bi -> print_boxed_integer "to_int" ppf bi
-  | Pcvtbint (bi1, bi2) -> print_boxed_integer_conversion ppf bi1 bi2
-  | Pnegbint bi -> print_boxed_integer "neg" ppf bi
-  | Paddbint bi -> print_boxed_integer "add" ppf bi
-  | Psubbint bi -> print_boxed_integer "sub" ppf bi
-  | Pmulbint bi -> print_boxed_integer "mul" ppf bi
-  | Pdivbint { size; is_safe = Safe } ->
-      print_boxed_integer "div" ppf size
-  | Pdivbint { size; is_safe = Unsafe } ->
-      print_boxed_integer "div_unsafe" ppf size
-  | Pmodbint { size; is_safe = Safe } ->
-      print_boxed_integer "mod" ppf size
-  | Pmodbint { size; is_safe = Unsafe } ->
-      print_boxed_integer "mod_unsafe" ppf size
-  | Pandbint bi -> print_boxed_integer "and" ppf bi
-  | Porbint bi -> print_boxed_integer "or" ppf bi
-  | Pxorbint bi -> print_boxed_integer "xor" ppf bi
-  | Plslbint bi -> print_boxed_integer "lsl" ppf bi
-  | Plsrbint bi -> print_boxed_integer "lsr" ppf bi
-  | Pasrbint bi -> print_boxed_integer "asr" ppf bi
-  | Pbintcomp(bi, Ceq) -> print_boxed_integer "==" ppf bi
-  | Pbintcomp(bi, Cne) -> print_boxed_integer "!=" ppf bi
-  | Pbintcomp(bi, Clt) -> print_boxed_integer "<" ppf bi
-  | Pbintcomp(bi, Cgt) -> print_boxed_integer ">" ppf bi
-  | Pbintcomp(bi, Cle) -> print_boxed_integer "<=" ppf bi
-  | Pbintcomp(bi, Cge) -> print_boxed_integer ">=" ppf bi
->>>>>>> ocaml/5.1
   | Pbigarrayref(unsafe, _n, kind, layout) ->
       print_bigarray "get" unsafe kind ppf layout
   | Pbigarrayset(unsafe, _n, kind, layout) ->
@@ -613,10 +515,17 @@ let primitive ppf = function
      if unsafe then fprintf ppf "bigarray.array1.unsafe_set64"
      else fprintf ppf "bigarray.array1.set64"
   | Pbswap16 -> fprintf ppf "bswap16"
-<<<<<<< HEAD
   | Pbbswap(bi,m) -> print_boxed_integer "bswap" ppf bi m
   | Pint_as_pointer m -> fprintf ppf "int_as_pointer%s" (alloc_kind m)
+  | Patomic_load {immediate_or_pointer} ->
+      (match immediate_or_pointer with
+        | Immediate -> fprintf ppf "atomic_load_imm"
+        | Pointer -> fprintf ppf "atomic_load_ptr")
+  | Patomic_exchange -> fprintf ppf "atomic_exchange"
+  | Patomic_cas -> fprintf ppf "atomic_cas"
+  | Patomic_fetch_add -> fprintf ppf "atomic_fetch_add"
   | Popaque _ -> fprintf ppf "opaque"
+  | Pdls_get -> fprintf ppf "dls_get"
   | Pprobe_is_enabled {name} -> fprintf ppf "probe_is_enabled[%s]" name
   | Pobj_dup -> fprintf ppf "obj_dup"
   | Pobj_magic _ -> fprintf ppf "obj_magic"
@@ -629,23 +538,6 @@ let primitive ppf = function
   | Parray_to_iarray -> fprintf ppf "array_to_iarray"
   | Parray_of_iarray -> fprintf ppf "array_of_iarray"
   | Pget_header m -> fprintf ppf "get_header%s" (alloc_kind m)
-||||||| merged common ancestors
-  | Pbbswap(bi) -> print_boxed_integer "bswap" ppf bi
-  | Pint_as_pointer -> fprintf ppf "int_as_pointer"
-  | Popaque -> fprintf ppf "opaque"
-=======
-  | Pbbswap(bi) -> print_boxed_integer "bswap" ppf bi
-  | Pint_as_pointer -> fprintf ppf "int_as_pointer"
-  | Patomic_load {immediate_or_pointer} ->
-      (match immediate_or_pointer with
-        | Immediate -> fprintf ppf "atomic_load_imm"
-        | Pointer -> fprintf ppf "atomic_load_ptr")
-  | Patomic_exchange -> fprintf ppf "atomic_exchange"
-  | Patomic_cas -> fprintf ppf "atomic_cas"
-  | Patomic_fetch_add -> fprintf ppf "atomic_fetch_add"
-  | Popaque -> fprintf ppf "opaque"
-  | Pdls_get -> fprintf ppf "dls_get"
->>>>>>> ocaml/5.1
 
 let name_of_primitive = function
   | Pbytes_of_string -> "Pbytes_of_string"
@@ -754,9 +646,20 @@ let name_of_primitive = function
   | Pbigstring_set_64 _ -> "Pbigstring_set_64"
   | Pbswap16 -> "Pbswap16"
   | Pbbswap _ -> "Pbbswap"
-<<<<<<< HEAD
   | Pint_as_pointer _ -> "Pint_as_pointer"
+  | Patomic_load {immediate_or_pointer} ->
+      (match immediate_or_pointer with
+        | Immediate -> "atomic_load_imm"
+        | Pointer -> "atomic_load_ptr")
+  | Patomic_exchange -> "Patomic_exchange"
+  | Patomic_cas -> "Patomic_cas"
+  | Patomic_fetch_add -> "Patomic_fetch_add"
   | Popaque _ -> "Popaque"
+  | Prunstack -> "Prunstack"
+  | Presume -> "Presume"
+  | Pperform -> "Pperform"
+  | Preperform -> "Preperform"
+  | Pdls_get -> "Pdls_get"
   | Pprobe_is_enabled _ -> "Pprobe_is_enabled"
   | Pobj_dup -> "Pobj_dup"
   | Pobj_magic _ -> "Pobj_magic"
@@ -785,25 +688,6 @@ let check_attribute ppf check =
     fprintf ppf "assert_%s%s@ "
       (check_property p)
       (if strict then "_strict" else "")
-||||||| merged common ancestors
-  | Pint_as_pointer -> "Pint_as_pointer"
-  | Popaque -> "Popaque"
-=======
-  | Pint_as_pointer -> "Pint_as_pointer"
-  | Patomic_load {immediate_or_pointer} ->
-      (match immediate_or_pointer with
-        | Immediate -> "atomic_load_imm"
-        | Pointer -> "atomic_load_ptr")
-  | Patomic_exchange -> "Patomic_exchange"
-  | Patomic_cas -> "Patomic_cas"
-  | Patomic_fetch_add -> "Patomic_fetch_add"
-  | Popaque -> "Popaque"
-  | Prunstack -> "Prunstack"
-  | Presume -> "Presume"
-  | Pperform -> "Pperform"
-  | Preperform -> "Preperform"
-  | Pdls_get -> "Pdls_get"
->>>>>>> ocaml/5.1
 
 let function_attribute ppf t =
   if t.is_a_functor then
@@ -830,16 +714,11 @@ let function_attribute ppf t =
   check_attribute ppf t.check;
   if t.tmc_candidate then
     fprintf ppf "tail_mod_cons@ ";
-<<<<<<< HEAD
   begin match t.loop with
   | Default_loop -> ()
   | Always_loop -> fprintf ppf "always_loop@ "
   | Never_loop -> fprintf ppf "never_loop@ "
   end;
-||||||| merged common ancestors
-    fprintf ppf "tail_mod_cons@ "
-=======
->>>>>>> ocaml/5.1
   begin match t.poll with
   | Default_poll -> ()
   | Error_poll -> fprintf ppf "error_poll@ "

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -295,9 +295,9 @@ let primitive ppf = function
   | Pfield (n, ptr, sem) ->
       let instr =
         match ptr, sem with
-        | Immediate, _ -> "field_int "
-        | Pointer, Reads_vary -> "field_mut "
-        | Pointer, Reads_agree -> "field_imm "
+        | Immediate, _ -> "field_int"
+        | Pointer, Reads_vary -> "field_mut"
+        | Pointer, Reads_agree -> "field_imm"
       in
       fprintf ppf "%s%a %i" instr field_read_semantics sem n
   | Pfield_computed sem ->

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -42,13 +42,7 @@ let rec eliminate_ref id = function
   | Lletrec(idel, e2) ->
       Lletrec(List.map (fun (v, e) -> (v, eliminate_ref id e)) idel,
               eliminate_ref id e2)
-<<<<<<< HEAD
-  | Lprim(Pfield (0, _sem), [Lvar v], _) when Ident.same v id ->
-||||||| merged common ancestors
-  | Lprim(Pfield 0, [Lvar v], _) when Ident.same v id ->
-=======
   | Lprim(Pfield (0, _, _), [Lvar v], _) when Ident.same v id ->
->>>>>>> ocaml/5.1
       Lmutvar id
   | Lprim(Psetfield(0, _, _), [Lvar v; e], _) when Ident.same v id ->
       Lassign(id, eliminate_ref id e)
@@ -237,23 +231,11 @@ let simplify_exits lam =
     match l with
   | Lvar _| Lmutvar _ | Lconst _ -> l
   | Lapply ap ->
-<<<<<<< HEAD
       Lapply{ap with ap_func = simplif ~layout:None ~try_depth ap.ap_func;
                      ap_args = List.map (simplif ~layout:None ~try_depth) ap.ap_args}
   | Lfunction{kind; params; return; mode; region; body = l; attr; loc} ->
      lfunction ~kind ~params ~return ~mode ~region
        ~body:(simplif ~layout:None ~try_depth l) ~attr ~loc
-||||||| merged common ancestors
-      Lapply{ap with ap_func = simplif ~try_depth ap.ap_func;
-                     ap_args = List.map (simplif ~try_depth) ap.ap_args}
-  | Lfunction{kind; params; return; body = l; attr; loc} ->
-     Lfunction{kind; params; return; body = simplif ~try_depth l; attr; loc}
-=======
-      Lapply{ap with ap_func = simplif ~try_depth ap.ap_func;
-                     ap_args = List.map (simplif ~try_depth) ap.ap_args}
-  | Lfunction{kind; params; return; body = l; attr; loc} ->
-     lfunction ~kind ~params ~return ~body:(simplif ~try_depth l) ~attr ~loc
->>>>>>> ocaml/5.1
   | Llet(str, kind, v, l1, l2) ->
       Llet(str, kind, v, simplif ~layout:None ~try_depth l1, simplif ~layout ~try_depth l2)
   | Lmutlet(kind, v, l1, l2) ->
@@ -589,19 +571,9 @@ let simplify_lets lam =
              type of the merged function taking [params @ params'] as
              parameters is the type returned after applying [params']. *)
           let return = return2 in
-<<<<<<< HEAD
           lfunction ~kind ~params:(params @ params') ~return ~body ~attr ~loc ~mode ~region
       | kind, region, body ->
           lfunction ~kind ~params ~return:outer_return ~body ~attr ~loc ~mode ~region
-||||||| merged common ancestors
-          Lfunction{kind; params = params @ params'; return; body; attr; loc}
-      | body ->
-          Lfunction{kind; params; return = return1; body; attr; loc}
-=======
-          lfunction ~kind ~params:(params @ params') ~return ~body ~attr ~loc
-      | body ->
-          lfunction ~kind ~params ~return:return1 ~body ~attr ~loc
->>>>>>> ocaml/5.1
       end
   | Llet(_str, _k, v, Lvar w, l2) when optimize ->
       Hashtbl.add subst v (simplif (Lvar w));
@@ -862,24 +834,13 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body
         let body = Lambda.rename subst body in
         let body = if add_region then Lregion (body, return) else body in
         let inner_fun =
-<<<<<<< HEAD
           lfunction ~kind:(Curried {nlocal=0})
             ~params:new_ids
             ~return ~body ~attr ~loc ~mode ~region:true
-||||||| merged common ancestors
-          Lfunction { kind = Curried;
-            params = List.map (fun id -> id, Pgenval) new_ids;
-            return; body; attr; loc; }
-=======
-          lfunction ~kind:Curried
-            ~params:(List.map (fun id -> id, Pgenval) new_ids)
-            ~return ~body ~attr ~loc
->>>>>>> ocaml/5.1
         in
         (wrapper_body, (inner_id, inner_fun))
   in
   try
-<<<<<<< HEAD
     (* TODO: enable this optimisation even in the presence of local returns *)
     begin match kind with
     | Curried {nlocal} when nlocal > 0 -> raise Exit
@@ -889,23 +850,8 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body
     let body, inner = aux [] false body in
     let attr = { default_stub_attribute with check = attr.check } in
     [(fun_id, lfunction ~kind ~params ~return ~body ~attr ~loc ~mode ~region:true); inner]
-||||||| merged common ancestors
-    let body, inner = aux [] body in
-    let attr = default_stub_attribute in
-    [(fun_id, Lfunction{kind; params; return; body; attr; loc}); inner]
-=======
-    let body, inner = aux [] body in
-    let attr = default_stub_attribute in
-    [(fun_id, lfunction ~kind ~params ~return ~body ~attr ~loc); inner]
->>>>>>> ocaml/5.1
   with Exit ->
-<<<<<<< HEAD
     [(fun_id, lfunction ~kind ~params ~return ~body ~attr ~loc ~mode ~region:orig_region)]
-||||||| merged common ancestors
-    [(fun_id, Lfunction{kind; params; return; body; attr; loc})]
-=======
-    [(fun_id, lfunction ~kind ~params ~return ~body ~attr ~loc)]
->>>>>>> ocaml/5.1
 
 (* Simplify local let-bound functions: if all occurrences are
    fully-applied function calls in the same "tail scope", replace the
@@ -936,13 +882,9 @@ let simplify_local_functions lam =
      by the outermost lambda for which the the current lambda
      is in tail position. *)
   let current_scope = ref lam in
-<<<<<<< HEAD
   let current_region_scope = ref None in
-||||||| merged common ancestors
-=======
   (* PR11383: We will only apply the transformation if we don't have to move
      code across function boundaries *)
->>>>>>> ocaml/5.1
   let current_function_scope = ref lam in
   let check_static lf =
     if lf.attr.local = Always_local then
@@ -968,15 +910,9 @@ let simplify_local_functions lam =
   let rec tail = function
     | Llet (_str, _kind, id, Lfunction lf, cont) when enabled lf.attr ->
         let r =
-<<<<<<< HEAD
-          {func = lf; function_scope = !current_function_scope; scope = None}
-||||||| merged common ancestors
-        let r = {func = lf; scope = None} in
-=======
           { func = lf;
             function_scope = !current_function_scope;
             scope = None }
->>>>>>> ocaml/5.1
         in
         Hashtbl.add slots id r;
         tail cont;
@@ -998,6 +934,7 @@ let simplify_local_functions lam =
             check_static lf;
             (* note: if scope = None, the function is unused *)
             function_definition lf
+            function_definition lf
         end
     | Lapply {ap_func = Lvar id; ap_args; ap_region_close; _} ->
         let curr_scope =
@@ -1015,12 +952,7 @@ let simplify_local_functions lam =
             Hashtbl.remove slots id
         | Some {function_scope = fscope; _}
           when fscope != !current_function_scope ->
-<<<<<<< HEAD
             (* Different function *)
-||||||| merged common ancestors
-=======
-            (* Non local function *)
->>>>>>> ocaml/5.1
             Hashtbl.remove slots id
         | Some ({scope = None; _} as slot) ->
             (* First use of the function: remember the current tail scope *)
@@ -1034,18 +966,12 @@ let simplify_local_functions lam =
     | Lfunction lf ->
         check_static lf;
         function_definition lf
-<<<<<<< HEAD
     | Lregion (lam, _) -> region lam
     | Lexclave lam -> exclave lam
-||||||| merged common ancestors
-        Lambda.shallow_iter ~tail ~non_tail lam
-=======
->>>>>>> ocaml/5.1
     | lam ->
         Lambda.shallow_iter ~tail ~non_tail lam
   and non_tail lam =
     with_scope ~scope:lam lam
-<<<<<<< HEAD
   and region lam =
     let old_tail_scope = !current_region_scope in
     let old_scope = !current_scope in
@@ -1062,9 +988,6 @@ let simplify_local_functions lam =
     tail lam;
     current_region_scope := old_tail_scope;
     current_scope := old_current_scope
-||||||| merged common ancestors
-=======
->>>>>>> ocaml/5.1
   and function_definition lf =
     let old_function_scope = !current_function_scope in
     current_function_scope := lf.body;

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -934,7 +934,6 @@ let simplify_local_functions lam =
             check_static lf;
             (* note: if scope = None, the function is unused *)
             function_definition lf
-            function_definition lf
         end
     | Lapply {ap_func = Lvar id; ap_args; ap_region_close; _} ->
         let curr_scope =

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -897,14 +897,14 @@ let rec choice ctx t =
     | Pisint _ | Pisout
     | Pignore
     | Pcompare_ints | Pcompare_floats | Pcompare_bints _
-    | Punbox_float | Pbox_float _
-    | Punbox_int _ | Pbox_int _
 
     (* we don't handle effect or DLS primitives *)
     | Prunstack | Pperform | Presume | Preperform | Pdls_get
 
     (* we don't handle atomic primitives *)
     | Patomic_exchange | Patomic_cas | Patomic_fetch_add | Patomic_load _
+    | Punbox_float | Pbox_float _
+    | Punbox_int _ | Pbox_int _
 
     (* we don't handle array indices as destinations yet *)
     | (Pmakearray _ | Pduparray _)
@@ -990,17 +990,9 @@ and traverse_binding outer_ctx inner_ctx (var, def) =
       (Debuginfo.Scoped_location.to_location lfun.loc)
       Warnings.Unused_tmc_attribute;
   let direct =
-<<<<<<< HEAD
     let { kind; params; return; body = _; attr; loc; mode; region } = lfun in
     let body = Choice.direct fun_choice in
     lfunction ~kind ~params ~return ~body ~attr ~loc ~mode ~region in
-||||||| merged common ancestors
-    Lfunction { lfun with body = Choice.direct fun_choice } in
-=======
-    let { kind; params; return; body = _; attr; loc } = lfun in
-    let body = Choice.direct fun_choice in
-    lfunction ~kind ~params ~return ~body ~attr ~loc in
->>>>>>> ocaml/5.1
   let dps =
     let dst_param = {
       var = Ident.create_local "dst";
@@ -1008,7 +1000,6 @@ and traverse_binding outer_ctx inner_ctx (var, def) =
       loc = lfun.loc;
     } in
     let dst = { dst_param with offset = Offset (Lvar dst_param.offset) } in
-<<<<<<< HEAD
     let params = add_dst_params dst_param lfun.params in
     let kind =
       match lfun.mode, lfun.kind with
@@ -1030,25 +1021,6 @@ and traverse_binding outer_ctx inner_ctx (var, def) =
       ~loc:lfun.loc
       ~mode:lfun.mode
       ~region:true
-||||||| merged common ancestors
-    Lambda.duplicate @@ Lfunction { lfun with
-      kind =
-        (* Support of Tupled function: see [choice_apply]. *)
-        Curried;
-      params = add_dst_params dst_param lfun.params;
-      body = Choice.dps ~tail:true ~dst:dst fun_choice;
-    } in
-=======
-    Lambda.duplicate @@ lfunction
-      ~kind:
-        (* Support of Tupled function: see [choice_apply]. *)
-        Curried
-      ~params:(add_dst_params dst_param lfun.params)
-      ~return:lfun.return
-      ~body:(Choice.dps ~tail:true ~dst:dst fun_choice)
-      ~attr:lfun.attr
-      ~loc:lfun.loc
->>>>>>> ocaml/5.1
   in
   let dps_var = special.dps_id in
   [(var, direct); (dps_var, dps)]


### PR DESCRIPTION
This was originally #171, but rebased to remove lambda.mli, which was done separately in #183.

@mshinwell is the author of this code, not me.