### PR TITLE
OCaml 5: Middle-end and ascomp mli resolution

### DIFF
--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -147,26 +147,14 @@ and operation =
   | Cextcall of string * machtype * exttype list * bool
       (** The [machtype] is the machine type of the result.
           The [exttype list] describes the unboxing types of the arguments.
-<<<<<<< HEAD
-          An empty list means "all arguments are machine words [XInt]". *)
-  | Cload of memory_chunk * Asttypes.mutable_flag
-  | Calloc of Lambda.alloc_mode
-  | Cstore of memory_chunk * initialization_or_assignment
-||||||| merged common ancestors
-          An empty list means "all arguments are machine words [XInt]". *)
-  | Cload of memory_chunk * Asttypes.mutable_flag
-  | Calloc
-  | Cstore of memory_chunk * Lambda.initialization_or_assignment
-=======
           An empty list means "all arguments are machine words [XInt]".
           The boolean indicates whether the function may allocate. *)
   | Cload of
       { memory_chunk: memory_chunk
       ; mutability: Asttypes.mutable_flag
       ; is_atomic: bool }
-  | Calloc
-  | Cstore of memory_chunk * Lambda.initialization_or_assignment
->>>>>>> ocaml/5.1
+  | Calloc of Lambda.alloc_mode
+  | Cstore of memory_chunk * initialization_or_assignment
   | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr
   | Ccmpi of integer_comparison
@@ -185,8 +173,8 @@ and operation =
   | Cprobe of { name: string; handler_code_sym: string; }
   | Cprobe_is_enabled of { name: string }
   | Copaque (* Sys.opaque_identity *)
-<<<<<<< HEAD
   | Cbeginregion | Cendregion
+  | Cdls_get
 
 (* This is information used exclusively during construction of cmm terms by
    cmmgen, and thus irrelevant for selectgen. *)
@@ -194,10 +182,6 @@ type kind_for_unboxing =
   | Any (* This may contain anything, including non-scannable things *)
   | Boxed_integer of Lambda.boxed_integer
   | Boxed_float
-||||||| merged common ancestors
-=======
-  | Cdls_get
->>>>>>> ocaml/5.1
 
 (** Every basic block should have a corresponding [Debuginfo.t] for its
     beginning. *)

--- a/file_formats/cmt_format.mli
+++ b/file_formats/cmt_format.mli
@@ -93,13 +93,7 @@ val save_cmt :
   binary_annots ->
   string option ->  (* source file *)
   Env.t -> (* initial env *)
-<<<<<<< HEAD
   Cmi_format.cmi_infos_lazy option -> (* if a .cmi was generated *)
-||||||| merged common ancestors
-  Cmi_format.cmi_infos option -> (* if a .cmi was generated *)
-=======
-  Cmi_format.cmi_infos option -> (* if a .cmi was generated *)
->>>>>>> ocaml/5.1
   Shape.t option ->
   unit
 

--- a/middle_end/clambda.mli
+++ b/middle_end/clambda.mli
@@ -117,11 +117,7 @@ and ufunction = {
   body   : ulambda;
   dbg    : Debuginfo.t;
   env    : Backend_var.t option;
-<<<<<<< HEAD
   mode   : Lambda.alloc_mode;
-||||||| merged common ancestors
-=======
->>>>>>> ocaml/5.1
   poll   : poll_attribute;
 }
 
@@ -139,13 +135,8 @@ type function_description =
     mutable fun_closed: bool;           (* True if environment not used *)
     mutable fun_inline: (Backend_var.With_provenance.t list * ulambda) option;
     mutable fun_float_const_prop: bool; (* Can propagate FP consts *)
-<<<<<<< HEAD
     fun_region: bool;                   (* If false, may locally allocate
                                            in caller's region *)
-||||||| merged common ancestors
-    mutable fun_float_const_prop: bool  (* Can propagate FP consts *)
-=======
->>>>>>> ocaml/5.1
     fun_poll: poll_attribute;           (* Behaviour for polls *)
   }
 

--- a/middle_end/clambda_primitives.mli
+++ b/middle_end/clambda_primitives.mli
@@ -37,17 +37,9 @@ type modify_mode = Lambda.modify_mode
 type primitive =
   | Pread_symbol of string
   (* Operations on heap blocks *)
-<<<<<<< HEAD
   | Pmakeblock of int * mutable_flag * block_shape * alloc_mode
   | Pmakeufloatblock of mutable_flag * alloc_mode
-  | Pfield of int * layout
-||||||| merged common ancestors
-  | Pmakeblock of int * mutable_flag * block_shape
-  | Pfield of int
-=======
-  | Pmakeblock of int * mutable_flag * block_shape
-  | Pfield of int * immediate_or_pointer * mutable_flag
->>>>>>> ocaml/5.1
+  | Pfield of int * layout * immediate_or_pointer * mutable_flag
   | Pfield_computed
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment
   | Psetfield_computed of immediate_or_pointer * initialization_or_assignment
@@ -138,21 +130,14 @@ type primitive =
   | Pbswap16
   | Pbbswap of boxed_integer * alloc_mode
   (* Integer to external pointer *)
-<<<<<<< HEAD
   | Pint_as_pointer of alloc_mode
-||||||| merged common ancestors
-  | Pint_as_pointer
-=======
-  | Pint_as_pointer
   (* Atomic operations *)
   | Patomic_load of {immediate_or_pointer : immediate_or_pointer}
   | Patomic_exchange
   | Patomic_cas
   | Patomic_fetch_add
->>>>>>> ocaml/5.1
   (* Inhibition of optimisation *)
   | Popaque
-<<<<<<< HEAD
   (* Probes *)
   | Pprobe_is_enabled of { name : string }
   | Punbox_float
@@ -160,12 +145,9 @@ type primitive =
   | Punbox_int of boxed_integer
   | Pbox_int of boxed_integer * alloc_mode
   | Pget_header of alloc_mode
-||||||| merged common ancestors
-=======
   (* Fetch domain-local state *)
   | Pdls_get
 
->>>>>>> ocaml/5.1
 
 and integer_comparison = Lambda.integer_comparison =
     Ceq | Cne | Clt | Cgt | Cle | Cge

--- a/middle_end/compilenv.mli
+++ b/middle_end/compilenv.mli
@@ -110,14 +110,8 @@ val read_library_info: string -> library_infos
 type error =
     Not_a_unit_info of string
   | Corrupted_unit_info of string
-<<<<<<< HEAD
   | Illegal_renaming of Compilation_unit.t * Compilation_unit.t * string
-||||||| merged common ancestors
-  | Illegal_renaming of string * string * string
-=======
-  | Illegal_renaming of string * string * string
   | Mismatching_for_pack of string * string * string * string option
->>>>>>> ocaml/5.1
 
 exception Error of error
 


### PR DESCRIPTION
The mli pieces of #172 , plus also `file_formats/` so I can test the build.

Testing:

```
for module in cmm clambda clambda_primitives compilenv; do dune b --workspace=duneconf/boot.ws _build/default/.ocamloptcomp.objs/byte/$module.cmi; done
```