### PR TITLE
OCaml 5: resolve remaining mli conflicts

### DIFF
--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -68,14 +68,10 @@ type operation =
   | Iopaque
   | Ispecific of Arch.specific_operation
   | Ipoll of { return_label: Cmm.label option }
-<<<<<<< HEAD
   | Iprobe of { name: string; handler_code_sym: string; }
   | Iprobe_is_enabled of { name: string }
   | Ibeginregion | Iendregion
-||||||| merged common ancestors
-=======
   | Idls_get
->>>>>>> ocaml/5.1
 
 type instruction =
   { desc: instruction_desc;

--- a/bytecomp/bytelink.mli
+++ b/bytecomp/bytelink.mli
@@ -17,7 +17,7 @@ open Misc
 
 (* Link .cmo files and produce a bytecode executable. *)
 
-module Dep : Set.OrderedType with type t = modname * modname
+module Dep : Set.OrderedType with type t = string * string
 module DepSet : Set.S with type elt = Dep.t
 
 val link : filepath list -> filepath -> unit
@@ -38,14 +38,8 @@ type error =
   | Cannot_open_dll of filepath
   | Required_module_unavailable of string * Compilation_unit.t
   | Camlheader of string * filepath
-<<<<<<< HEAD
-  | Wrong_link_order of (string * string) list
-||||||| merged common ancestors
-  | Wrong_link_order of (modname * modname) list
-=======
   | Wrong_link_order of DepSet.t
-  | Multiple_definition of modname * filepath * filepath
->>>>>>> ocaml/5.1
+  | Multiple_definition of string * filepath * filepath
 
 exception Error of error
 

--- a/middle_end/flambda/flambda_utils.mli
+++ b/middle_end/flambda/flambda_utils.mli
@@ -69,13 +69,9 @@ val make_closure_declaration
   -> region:bool
   -> body:Flambda.t
   -> params:Parameter.t list
-<<<<<<< HEAD
   -> return_layout:Lambda.layout
   -> free_variables:Lambda.layout Variable.Map.t
-||||||| merged common ancestors
   -> stub:bool
-=======
->>>>>>> ocaml/5.1
   -> Flambda.t
 
 val toplevel_substitution

--- a/middle_end/flambda/flambda_utils.mli
+++ b/middle_end/flambda/flambda_utils.mli
@@ -71,7 +71,6 @@ val make_closure_declaration
   -> params:Parameter.t list
   -> return_layout:Lambda.layout
   -> free_variables:Lambda.layout Variable.Map.t
-  -> stub:bool
   -> Flambda.t
 
 val toplevel_substitution

--- a/ocamltest/ocamltest_config.mli
+++ b/ocamltest/ocamltest_config.mli
@@ -79,19 +79,9 @@ val ocamlsrcdir : string
 val flambda : bool
 (** Whether flambda has been enabled at configure time *)
 
-<<<<<<< HEAD
 val flambda2 : bool
 (** Whether flambda2 has been enabled at configure time *)
 
-val safe_string : bool
-(** Whether the compiler was configured with -safe-string *)
-
-||||||| merged common ancestors
-val safe_string : bool
-(** Whether the compiler was configured with -safe-string *)
-
-=======
->>>>>>> ocaml/5.1
 val flat_float_array : bool
 (* Whether the compiler was configured with --enable-flat-float-array *)
 

--- a/ocamltest/ocamltest_config.mli
+++ b/ocamltest/ocamltest_config.mli
@@ -128,6 +128,10 @@ val function_sections : bool
 val instrumented_runtime : bool
 (** Whether the instrumented runtime is available *)
 
+(* CR ocaml 5 runtime: We should delete this flag, as this option
+   is no longer supported in the OCaml 5 runtime. (We could probably delete
+   it now, but it's hard for me to tell offhand whether any tests use this.)
+ *)
 val naked_pointers : bool
 (** Whether the runtime system supports naked pointers outside the heap *)
 

--- a/ocamltest/ocamltest_config.mli
+++ b/ocamltest/ocamltest_config.mli
@@ -128,7 +128,6 @@ val function_sections : bool
 val instrumented_runtime : bool
 (** Whether the instrumented runtime is available *)
 
-<<<<<<< HEAD
 val naked_pointers : bool
 (** Whether the runtime system supports naked pointers outside the heap *)
 
@@ -140,10 +139,6 @@ val stack_allocation : bool
 
 val poll_insertion : bool
 (** Whether poll insertion is enabled *)
-||||||| merged common ancestors
-val naked_pointers : bool
-(** Whether the runtime system supports naked pointers outside the heap *)
-=======
+
 val frame_pointers : bool
 (** Whether frame-pointers have been enabled at configure time *)
->>>>>>> ocaml/5.1

--- a/otherlibs/systhreads/thread.mli
+++ b/otherlibs/systhreads/thread.mli
@@ -46,7 +46,6 @@ val id : t -> int
    It can be used to build data structures indexed by threads. *)
 
 exception Exit
-<<<<<<< HEAD
 (** Exception that can be raised by user code to initiate termination
     of the current thread.
     Compared to calling the {!Thread.exit} function, raising the
@@ -56,21 +55,6 @@ exception Exit
 
     @since 4.14.0
 *)
-
-val exit : unit -> unit
-(** Terminate prematurely the currently executing thread. *)
-||||||| merged common ancestors
-val exit : unit -> unit
-(** Terminate prematurely the currently executing thread. *)
-=======
-(** Exception raised by user code to initiate termination of the
-    current thread.
-    In a thread created by {!Thread.create} [funct] [arg], if the
-    {!Thread.Exit} exception reaches the top of the application
-    [funct arg], it has the effect of terminating the current thread
-    silently.  In other contexts, there is no implicit handling of the
-    {!Thread.Exit} exception. *)
->>>>>>> ocaml/5.1
 
 val exit : unit -> unit
 [@@ocaml.deprecated "Use 'raise Thread.Exit' instead."]

--- a/toplevel/topcommon.mli
+++ b/toplevel/topcommon.mli
@@ -54,12 +54,7 @@ val record_backtrace : unit -> unit
 
 val find_eval_phrase :
   Typedtree.structure ->
-<<<<<<< HEAD
     (Typedtree.expression * Jkind.sort * Typedtree.attributes * Location.t) option
-||||||| merged common ancestors
-=======
-    (Typedtree.expression * Typedtree.attributes * Location.t) option
->>>>>>> ocaml/5.1
 
 val max_printer_depth: int ref
 val max_printer_steps: int ref


### PR DESCRIPTION
Finish resolving all mli conflicts. I'm not sure if anyone is blocked on these files in particular, but it's nice to just be done resolving mlis so almost everything can be built.

Testing:

I couldn't test `toplevel/topcommon.mli`, `otherlibs/systhreads/thread.mli`, or `ocamltest/ocamltest_config.ml`, as these are built with another dune profile that relies on the compiler being able to build the stdlib. I think the conflict resolutions are simple enough that we should just merge them as-is.

```
# asmcomp/mach.mli
$ dune b --workspace=duneconf/boot.ws _build/default/.ocamloptcomp.objs/byte/mach.cmi

# bytecomp/bytelink.mli
$ dune b --workspace=duneconf/boot.ws _build/default/.ocamlbytecomp.objs/byte/bytelink.cmi

# middle_end/flambda/flambda_utils.mli
$ dune b --workspace=duneconf/boot.ws _build/default/.ocamloptcomp.objs/byte/flambda_utils.cmi
```