### PR TITLE
Build OCaml 5 files in CI

### DIFF
--- a/.github/workflows/jane_ocaml5.yml
+++ b/.github/workflows/jane_ocaml5.yml
@@ -13,11 +13,54 @@ jobs:
         working-directory: ocaml-jst
         run: |
           ./configure --prefix=$GITHUB_WORKSPACE/ocaml-5/_install
+      - name: Cache OCaml 4.14 and dune
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: ${{ github.workspace }}/ocaml-414/_install
+          key: ${{ matrix.os }}-cache-ocaml-414-dune-361
+
+      - name: Checkout OCaml 4.14
+        uses: actions/checkout@master
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          repository: 'ocaml/ocaml'
+          path: 'ocaml-414'
+          ref: '4.14'
+
+      - name: Build OCaml 4.14
+        if: steps.cache.outputs.cache-hit != 'true'
+        working-directory: ocaml-414
+        run: |
+          ./configure --prefix=$GITHUB_WORKSPACE/ocaml-414/_install
+          make -j $J world.opt
+          make install
+          # Remove unneeded parts to shrink cache file
+          rm -rf $GITHUB_WORKSPACE/ocaml-414/_install/{lib/ocaml/expunge,bin/*.byte}
+
+      - name: Checkout dune github repo
+        uses: actions/checkout@master
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          repository: 'ocaml/dune'
+          ref: '3.6.1'
+          path: 'dune'
+
+      - name: Build dune
+        working-directory: dune
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          PATH=$GITHUB_WORKSPACE/ocaml-414/_install/bin:$PATH make release
+          cp _boot/dune.exe $GITHUB_WORKSPACE/ocaml-414/_install/bin/dune
+
       - name: Build _bootinstall
         working-directory: ocaml-jst
         run: |
+          export PATH=$GITHUB_WORKSPACE/ocaml-414/_install/bin:$PATH
           make -f Makefile.jst _build/_bootinstall
+
       - name: Check that resolved files build
         working-directory: ocaml-jst
         run: |
+          export PATH=$GITHUB_WORKSPACE/ocaml-414/_install/bin:$PATH
           jane/build-resolved-files-for-ci

--- a/.github/workflows/jane_ocaml5.yml
+++ b/.github/workflows/jane_ocaml5.yml
@@ -5,14 +5,6 @@ jobs:
     name: Check that resolved files build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout the ocaml-jst repo
-        uses: actions/checkout@master
-        with:
-          path: 'ocaml-jst'
-      - name: Configure
-        working-directory: ocaml-jst
-        run: |
-          ./configure --prefix=$GITHUB_WORKSPACE/ocaml-5/_install
       - name: Cache OCaml 4.14 and dune
         uses: actions/cache@v2
         id: cache
@@ -52,6 +44,16 @@ jobs:
         run: |
           PATH=$GITHUB_WORKSPACE/ocaml-414/_install/bin:$PATH make release
           cp _boot/dune.exe $GITHUB_WORKSPACE/ocaml-414/_install/bin/dune
+
+      - name: Checkout the ocaml-jst repo
+        uses: actions/checkout@master
+        with:
+          path: 'ocaml-jst'
+
+      - name: Configure
+        working-directory: ocaml-jst
+        run: |
+          ./configure --prefix=$GITHUB_WORKSPACE/ocaml-5/_install --with-dune=$GITHUB_WORKSPACE/ocaml-414/_install/bin/dune
 
       - name: Build _bootinstall
         working-directory: ocaml-jst

--- a/.github/workflows/jane_ocaml5.yml
+++ b/.github/workflows/jane_ocaml5.yml
@@ -75,12 +75,6 @@ jobs:
         run: |
           ./configure --prefix=$GITHUB_WORKSPACE/ocaml-5/_install --with-dune=$GITHUB_WORKSPACE/ocaml-414/_install/bin/dune
 
-      - name: Build _bootinstall
-        working-directory: ocaml-jst
-        run: |
-          export PATH=$GITHUB_WORKSPACE/ocaml-414/_install/bin:$PATH
-          make -f Makefile.jst _build/_bootinstall
-
       - name: Check that resolved files build
         working-directory: ocaml-jst
         run: |

--- a/.github/workflows/jane_ocaml5.yml
+++ b/.github/workflows/jane_ocaml5.yml
@@ -5,12 +5,12 @@ jobs:
     name: Check that resolved files build
     runs-on: ubuntu-latest
     steps:
-      - name: Cache OCaml 4.14 and dune
+      - name: Cache OCaml 4.14, dune, and menhir
         uses: actions/cache@v2
         id: cache
         with:
           path: ${{ github.workspace }}/ocaml-414/_install
-          key: ${{ matrix.os }}-cache-ocaml-414-dune-361
+          key: ocaml-414-dune-361-menhir-20210419--v1
 
       - name: Checkout OCaml 4.14
         uses: actions/checkout@master
@@ -44,6 +44,26 @@ jobs:
         run: |
           PATH=$GITHUB_WORKSPACE/ocaml-414/_install/bin:$PATH make release
           cp _boot/dune.exe $GITHUB_WORKSPACE/ocaml-414/_install/bin/dune
+
+      - name: Checkout menhir github repo
+        uses: actions/checkout@master
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          repository: 'LexiFi/menhir'
+          ref: '20210419'
+          path: 'menhir'
+
+      - name: Build menhir
+        working-directory: menhir
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          PATH=$GITHUB_WORKSPACE/ocaml-414/_install/bin:$PATH dune build
+          cp _build/install/default/bin/menhir $GITHUB_WORKSPACE/ocaml-414/_install/bin/menhir
+          # Our dune rule uses `menhirLib.mli`, which we can't simply `cp`
+          # because it's a symbolic link to a relative path.
+          export TARGET_FILE=$GITHUB_WORKSPACE/ocaml-414/_install/lib/menhirLib/menhirLib.mli
+          mkdir -p $(dirname $TARGET_FILE)
+          cat _build/install/default/lib/menhirLib/menhirLib.mli > $TARGET_FILE
 
       - name: Checkout the ocaml-jst repo
         uses: actions/checkout@master

--- a/.github/workflows/jane_ocaml5.yml
+++ b/.github/workflows/jane_ocaml5.yml
@@ -1,0 +1,23 @@
+name: jane_ocaml5
+on: [push, pull_request]
+jobs:
+  jane_ocaml5:
+    name: Check that resolved files build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the ocaml-jst repo
+        uses: actions/checkout@master
+        with:
+          path: 'ocaml-jst'
+      - name: Configure
+        working-directory: ocaml-jst
+        run: |
+          ./configure --prefix=$GITHUB_WORKSPACE/ocaml-5/_install
+      - name: Build _bootinstall
+        working-directory: ocaml-jst
+        run: |
+          make -f Makefile.jst _build/_bootinstall
+      - name: Check that resolved files build
+        working-directory: ocaml-jst
+        run: |
+          jane/build-resolved-files-for-ci

--- a/jane/build-resolved-files-for-ci
+++ b/jane/build-resolved-files-for-ci
@@ -1,1 +1,14 @@
- dune b --workspace=duneconf/boot.ws _build/default/.ocamlcommon.objs/native/matching.cmx
+#!/bin/bash
+
+set -euo pipefail
+
+# build parser.mli from parser.mly
+dune b --workspace=duneconf/boot.ws _build/default/.ocamlcommon.objs/byte/parser.cmi
+
+# ocamlcommon mlis
+for mli in {utils,typing,parsing,lambda}/*.mli; do
+  cmi=$(basename ${mli%.mli})
+  dune b --workspace=duneconf/boot.ws _build/default/.ocamlcommon.objs/byte/$cmi.cmi
+done
+
+

--- a/jane/build-resolved-files-for-ci
+++ b/jane/build-resolved-files-for-ci
@@ -1,0 +1,1 @@
+ dune b --workspace=duneconf/boot.ws _build/default/.ocamlcommon.objs/native/matching.cmx

--- a/jane/build-resolved-files-for-ci
+++ b/jane/build-resolved-files-for-ci
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+make -f Makefile.jst _build/_bootinstall
+
 echo "==========="
 echo "Testing mlis"
 echo "==========="

--- a/jane/build-resolved-files-for-ci
+++ b/jane/build-resolved-files-for-ci
@@ -8,7 +8,9 @@ echo "==========="
 
 # ocamlcommon mlis
 mlis=$(
-  echo {utils,typing,parsing,lambda}/*.mli |
+  { echo parsing/parser.mli
+    echo {utils,typing,parsing,lambda}/*.mli
+  } |
     tr ' ' '\n'
 )
 echo "$mlis"
@@ -28,7 +30,9 @@ echo "==========="
 
 # ocamlcommon mls
 mls=$(
-  echo {utils,parsing}/*.ml |
+  { echo parsing/parser.ml
+    echo {utils,parsing}/*.ml
+  } |
     tr ' ' '\n' |
     grep -v "utils/config.common.ml" |
     grep -v "utils/config.fixed.ml" |

--- a/jane/build-resolved-files-for-ci
+++ b/jane/build-resolved-files-for-ci
@@ -2,13 +2,45 @@
 
 set -euo pipefail
 
-# build parser.mli from parser.mly
-dune b --workspace=duneconf/boot.ws _build/default/.ocamlcommon.objs/byte/parser.cmi
+echo "==========="
+echo "Testing mlis"
+echo "==========="
 
 # ocamlcommon mlis
-for mli in {utils,typing,parsing,lambda}/*.mli; do
-  cmi=$(basename ${mli%.mli})
-  dune b --workspace=duneconf/boot.ws _build/default/.ocamlcommon.objs/byte/$cmi.cmi
-done
+mlis=$(
+  echo {utils,typing,parsing,lambda}/*.mli |
+    tr ' ' '\n'
+)
+echo "$mlis"
+dune_targets=$(
+  for mli in $mlis; do
+    cmi=$(basename ${mli%.mli})
+    echo _build/default/.ocamlcommon.objs/byte/$cmi.cmi
+  done
+)
+echo "Dune targets:"
+echo "$dune_targets"
+dune b --workspace=duneconf/boot.ws $dune_targets
 
+echo "==========="
+echo "Testing mls"
+echo "==========="
 
+# ocamlcommon mls
+mls=$(
+  echo {utils,parsing}/*.ml |
+    tr ' ' '\n' |
+    grep -v "utils/config.common.ml" |
+    grep -v "utils/config.fixed.ml" |
+    grep -v "utils/config.generated.ml"
+)
+echo "$mls"
+dune_targets=$(
+  for ml in $mls; do
+    cmx=$(basename ${ml%.ml})
+    echo _build/default/.ocamlcommon.objs/native/$cmx.cmx
+  done
+)
+echo "Dune targets:"
+echo "$dune_targets"
+dune b --workspace=duneconf/boot.ws $dune_targets


### PR DESCRIPTION
Add two things:
  * A script that tries to build individual ml/mli files. The intention is that you can edit it in your PR to (1) provide evidence to your reviewer that your changes work, and (2) preserve that evidence for future runners of the script.
  * A CI job that runs the script.

I think the first thing is very useful and the second thing is marginally useful.

Rigging up CI was tricky because it requires menhir in addition to the dune/OCaml setup from existing CI jobs.

The builds of these things (OCaml, dune, menhir) are cached, so it should take less than a minute per CI run. (See [this run](https://github.com/ocaml-flambda/ocaml-jst/actions/runs/6580127292/job/17877459123) for evidence of the caching.)

But, if we find that the CI job takes too long to run and is blocking merging, I think we should get rid of the job. The script is useful enough on its own. I'll add documentation for it in a common place (+ nudge people to use it).