### PR TITLE
OCaml5 merge conflicts: `typing/{env,typetexp}.ml`

### DIFF
--- a/jane/build-resolved-files-for-ci
+++ b/jane/build-resolved-files-for-ci
@@ -63,7 +63,8 @@ typing_mls=(
   tast_mapper
   typedecl_variance
   typedtree
-  types)
+  types
+  typetexp)
 
 # ocamlcommon mls
 mls=$(

--- a/jane/build-resolved-files-for-ci
+++ b/jane/build-resolved-files-for-ci
@@ -49,6 +49,7 @@ echo "==========="
 
 typing_mls=(
   datarepr
+  env
   includecore
   mtype
   oprint

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -43,7 +43,6 @@ let module_declarations : unit usage_tbl ref = s_table Types.Uid.Tbl.create 16
 let uid_to_loc : Location.t Types.Uid.Tbl.t ref =
   s_table Types.Uid.Tbl.create 16
 
-<<<<<<< HEAD
 let uid_to_attributes : Parsetree.attribute list Types.Uid.Tbl.t ref =
   s_table Types.Uid.Tbl.create 16
 
@@ -53,12 +52,6 @@ let register_uid uid ~loc ~attributes =
 
 let get_uid_to_loc_tbl () = !uid_to_loc
 let get_uid_to_attributes_tbl () = !uid_to_attributes
-||||||| merged common ancestors
-=======
-let register_uid uid loc = Types.Uid.Tbl.add !uid_to_loc uid loc
-
-let get_uid_to_loc_tbl () = !uid_to_loc
->>>>>>> ocaml/5.1
 
 type constructor_usage = Positive | Pattern | Exported_private | Exported
 type constructor_usages =
@@ -519,6 +512,8 @@ module IdTbl =
             else
               find_all_idents name next ()
         | Map {next; _ } -> find_all_idents name next ()
+        | Lock {mode=_;next} ->
+            find_all_idents name next ()
       in
       Seq.append current next ()
 
@@ -617,13 +612,7 @@ and components_maker = {
   cm_prefixing_subst: Subst.t;
   cm_path: Path.t;
   cm_addr: address_lazy;
-<<<<<<< HEAD
   cm_mty: Subst.Lazy.module_type;
-||||||| merged common ancestors
-  cm_mty: Subst.Lazy.modtype;
-=======
-  cm_mty: Subst.Lazy.modtype;
->>>>>>> ocaml/5.1
   cm_shape: Shape.t;
 }
 
@@ -662,17 +651,9 @@ and address_unforced =
 and address_lazy = (address_unforced, address) Lazy_backtrack.t
 
 and value_data =
-<<<<<<< HEAD
   { vda_description : Subst.Lazy.value_description;
     vda_address : address_lazy;
     vda_mode : Mode.Value.t;
-||||||| merged common ancestors
-  { vda_description : value_description;
-    vda_address : address_lazy }
-=======
-  { vda_description : value_description;
-    vda_address : address_lazy;
->>>>>>> ocaml/5.1
     vda_shape : Shape.t }
 
 and value_entry =
@@ -834,17 +815,11 @@ let is_ext cda =
 
 let is_local_ext cda =
   match cda.cda_description with
-<<<<<<< HEAD
-  | {cstr_tag = Extension (p,_)} -> is_ident p
-||||||| merged common ancestors
-  | {cstr_tag = Cstr_extension(p, _)} -> is_ident p
-=======
-  | {cstr_tag = Cstr_extension(p, _)} -> begin
+  | {cstr_tag = Extension(p, _)} -> begin
       match p with
       | Pident _ -> true
       | Pdot _ | Papply _ | Pextra_ty _ -> false
   end
->>>>>>> ocaml/5.1
   | _ -> false
 
 let diff env1 env2 =
@@ -1019,7 +994,6 @@ let read_sign_of_cmi { Persistent_env.Persistent_signature.cmi; _ } =
   let mda_shape =
     Shape.for_persistent_unit (name |> Compilation_unit.full_path_as_string)
   in
-  let mda_shape = Shape.for_persistent_unit name in
   let mda_components =
     let mty = md.md_type in
     components_of_module ~alerts ~uid:md.md_uid
@@ -1174,16 +1148,8 @@ let find_module path env =
       Subst.Lazy.force_module_decl data.mda_declaration
   | Papply(p1, p2) ->
       let fc = find_functor_components p1 env in
-<<<<<<< HEAD
       md (modtype_of_functor_appl fc p1 p2)
-||||||| merged common ancestors
-      if alias then md (fc.fcomp_res)
-      else md (modtype_of_functor_appl fc p1 p2)
-=======
-      if alias then md (fc.fcomp_res)
-      else md (modtype_of_functor_appl fc p1 p2)
   | Pextra_ty _ -> raise Not_found
->>>>>>> ocaml/5.1
 
 let find_module_lazy ~alias path env =
   match path with
@@ -1249,7 +1215,7 @@ let rec find_type_data path env =
   | decl ->
     {
       tda_declaration = decl;
-      tda_descriptions = Type_abstract;
+      tda_descriptions = Type_abstract Abstract_def;
       tda_shape = Shape.leaf decl.type_uid;
     }
   | exception Not_found -> begin
@@ -1274,7 +1240,7 @@ and find_cstr path name env =
   match tda.tda_descriptions with
   | Type_variant (cstrs, _) ->
       List.find (fun cstr -> cstr.cstr_name = name) cstrs
-  | Type_record _ | Type_abstract | Type_open -> raise Not_found
+  | Type_record _ | Type_abstract _ | Type_open -> raise Not_found
 
 
 
@@ -1284,14 +1250,7 @@ let find_modtype_lazy path env =
   | Pdot(p, s) ->
       let sc = find_structure_components p env in
       (NameMap.find s sc.comp_modtypes).mtda_declaration
-<<<<<<< HEAD
-  | Papply _ -> raise Not_found
-||||||| merged common ancestors
-      NameMap.find s sc.comp_modtypes
-  | Papply _ -> raise Not_found
-=======
   | Papply _ | Pextra_ty _ -> raise Not_found
->>>>>>> ocaml/5.1
 
 let find_modtype path env =
   Subst.Lazy.force_modtype_decl (find_modtype_lazy path env)
@@ -1310,14 +1269,7 @@ let find_cltype path env =
   | Pdot(p, s) ->
       let sc = find_structure_components p env in
       (NameMap.find s sc.comp_cltypes).cltda_declaration
-<<<<<<< HEAD
-  | Papply _ -> raise Not_found
-||||||| merged common ancestors
-      NameMap.find s sc.comp_cltypes
-  | Papply _ -> raise Not_found
-=======
   | Papply _ | Pextra_ty _ -> raise Not_found
->>>>>>> ocaml/5.1
 
 let find_value path env =
   (find_value_full path env).vda_description
@@ -1331,135 +1283,6 @@ let find_ident_constructor id env =
 let find_ident_label id env =
   TycompTbl.find_same id env.labels
 
-<<<<<<< HEAD
-let type_of_cstr path = function
-  | {cstr_inlined = Some decl; _} ->
-      let labels =
-        List.map snd (Datarepr.labels_of_type path decl)
-      in
-      begin match decl.type_kind with
-      | Type_record (_, repr) ->
-        {
-          tda_declaration = decl;
-          tda_descriptions = Type_record (labels, repr);
-          tda_shape = Shape.leaf decl.type_uid;
-        }
-      | _ -> assert false
-      end
-  | _ -> assert false
-
-let find_type_data path env =
-  match Path.constructor_typath path with
-  | Regular p -> begin
-      match Path.Map.find p env.local_constraints with
-      | decl ->
-          {
-            tda_declaration = decl;
-            tda_descriptions = Type_abstract Abstract_def;
-            tda_shape = Shape.leaf decl.type_uid;
-          }
-      | exception Not_found -> find_type_full p env
-    end
-  | Cstr (ty_path, s) ->
-      (* This case corresponds to an inlined record *)
-      let tda =
-        try find_type_full ty_path env
-        with Not_found -> assert false
-      in
-      let cstr =
-        begin match tda.tda_descriptions with
-        | Type_variant (cstrs, _) -> begin
-            try
-              List.find (fun cstr -> cstr.cstr_name = s) cstrs
-            with Not_found -> assert false
-          end
-        | Type_record _ | Type_abstract _ | Type_open -> assert false
-        end
-      in
-      type_of_cstr path cstr
-  | LocalExt id ->
-      let cstr =
-        try (TycompTbl.find_same id env.constrs).cda_description
-        with Not_found -> assert false
-      in
-      type_of_cstr path cstr
-  | Ext (mod_path, s) ->
-      let comps =
-        try find_structure_components mod_path env
-        with Not_found -> assert false
-      in
-      let cstrs =
-        try NameMap.find s comps.comp_constrs
-        with Not_found -> assert false
-      in
-      let exts = List.filter is_ext cstrs in
-      match exts with
-      | [cda] -> type_of_cstr path cda.cda_description
-      | _ -> assert false
-
-||||||| merged common ancestors
-let type_of_cstr path = function
-  | {cstr_inlined = Some decl; _} ->
-      let labels =
-        List.map snd (Datarepr.labels_of_type path decl)
-      in
-      begin match decl.type_kind with
-      | Type_record (_, repr) ->
-        {
-          tda_declaration = decl;
-          tda_descriptions = Type_record (labels, repr);
-        }
-      | _ -> assert false
-      end
-  | _ -> assert false
-
-let find_type_data path env =
-  match Path.constructor_typath path with
-  | Regular p -> begin
-      match Path.Map.find p env.local_constraints with
-      | decl ->
-          { tda_declaration = decl; tda_descriptions = Type_abstract }
-      | exception Not_found -> find_type_full p env
-    end
-  | Cstr (ty_path, s) ->
-      (* This case corresponds to an inlined record *)
-      let tda =
-        try find_type_full ty_path env
-        with Not_found -> assert false
-      in
-      let cstr =
-        begin match tda.tda_descriptions with
-        | Type_variant (cstrs, _) -> begin
-            try
-              List.find (fun cstr -> cstr.cstr_name = s) cstrs
-            with Not_found -> assert false
-          end
-        | Type_record _ | Type_abstract | Type_open -> assert false
-        end
-      in
-      type_of_cstr path cstr
-  | LocalExt id ->
-      let cstr =
-        try (TycompTbl.find_same id env.constrs).cda_description
-        with Not_found -> assert false
-      in
-      type_of_cstr path cstr
-  | Ext (mod_path, s) ->
-      let comps =
-        try find_structure_components mod_path env
-        with Not_found -> assert false
-      in
-      let cstrs =
-        try NameMap.find s comps.comp_constrs
-        with Not_found -> assert false
-      in
-      let exts = List.filter is_ext cstrs in
-      match exts with
-      | [cda] -> type_of_cstr path cda.cda_description
-      | _ -> assert false
-
-=======
->>>>>>> ocaml/5.1
 let find_type p env =
   (find_type_data p env).tda_declaration
 let find_type_descrs p env =
@@ -1522,45 +1345,6 @@ let find_hash_type path env =
       let cltda = NameMap.find name c.comp_cltypes in
       cltda.cltda_declaration.clty_hash_type
   | Papply _ | Pextra_ty _ -> raise Not_found
-
-let find_shape env (ns : Shape.Sig_component_kind.t) id =
-  match ns with
-  | Type ->
-      (IdTbl.find_same id env.types).tda_shape
-  | Extension_constructor ->
-      (TycompTbl.find_same id env.constrs).cda_shape
-  | Value ->
-      begin match IdTbl.find_same id env.values with
-      | Val_bound x -> x.vda_shape
-      | Val_unbound _ -> raise Not_found
-      end
-  | Module ->
-      begin match IdTbl.find_same id env.modules with
-      | Mod_local { mda_shape; _ } -> mda_shape
-      | Mod_persistent -> Shape.for_persistent_unit (Ident.name id)
-      | Mod_unbound _ ->
-          (* Only present temporarily while approximating the environment for
-             recursive modules.
-             [find_shape] is only ever called after the environment gets
-             properly populated. *)
-          assert false
-      | exception Not_found
-        when Ident.persistent id && not (Current_unit_name.is_ident id) ->
-          Shape.for_persistent_unit (Ident.name id)
-      end
-  | Module_type ->
-      (IdTbl.find_same id env.modtypes).mtda_shape
-  | Class ->
-      (IdTbl.find_same id env.classes).clda_shape
-  | Class_type ->
-      (IdTbl.find_same id env.cltypes).cltda_shape
-
-let shape_of_path ~namespace env =
-  Shape.of_path ~namespace ~find_shape:(find_shape env)
-
-let shape_or_leaf uid = function
-  | None -> Shape.leaf uid
-  | Some shape -> shape
 
 let probes = ref String.Set.empty
 let reset_probes () = probes := String.Set.empty
@@ -1983,17 +1767,8 @@ let is_identchar c =
 let rec components_of_module_maker
           {cm_env; cm_prefixing_subst;
            cm_path; cm_addr; cm_mty; cm_shape} : _ result =
-<<<<<<< HEAD
   match !scrape_alias cm_env cm_mty with
     Mty_signature sg ->
-||||||| merged common ancestors
-           cm_path; cm_addr; cm_mty} : _ result =
-  match scrape_alias cm_env cm_mty with
-    MtyL_signature sg ->
-=======
-  match scrape_alias cm_env cm_mty with
-    MtyL_signature sg ->
->>>>>>> ocaml/5.1
       let c =
         { comp_values = NameMap.empty;
           comp_constrs = NameMap.empty;
@@ -2024,14 +1799,8 @@ let rec components_of_module_maker
             in
             let vda_shape = Shape.proj cm_shape (Shape.Item.value id) in
             let vda =
-<<<<<<< HEAD
               { vda_description = decl'; vda_address = addr;
                 vda_mode = Mode.Value.legacy; vda_shape }
-||||||| merged common ancestors
-            let vda = { vda_description = decl'; vda_address = addr } in
-=======
-              { vda_description = decl'; vda_address = addr; vda_shape }
->>>>>>> ocaml/5.1
             in
             c.comp_values <- NameMap.add (Ident.name id) vda c.comp_values;
         | Sig_type(id, decl, _, _) ->
@@ -2078,14 +1847,7 @@ let rec components_of_module_maker
             in
             c.comp_types <- NameMap.add (Ident.name id) tda c.comp_types;
             env := store_type_infos ~tda_shape:shape id decl !env
-<<<<<<< HEAD
         | Sig_typext(id, ext, _, _) ->
-||||||| merged common ancestors
-            env := store_type_infos id decl !env
-        | SigL_typext(id, ext, _, _) ->
-=======
-        | SigL_typext(id, ext, _, _) ->
->>>>>>> ocaml/5.1
             let ext' = Subst.extension_constructor sub ext in
             let descr =
               Datarepr.extension_descr ~current_unit:(get_unit_name ()) path
@@ -2121,16 +1883,8 @@ let rec components_of_module_maker
             in
             let shape = Shape.proj cm_shape (Shape.Item.module_ id) in
             let comps =
-<<<<<<< HEAD
               components_of_module ~alerts ~uid:md.md_uid !env
                 sub path addr md.md_type shape
-||||||| merged common ancestors
-              components_of_module ~alerts ~uid:md.mdl_uid !env
-                sub path addr md.mdl_type
-=======
-              components_of_module ~alerts ~uid:md.mdl_uid !env
-                sub path addr md.mdl_type shape
->>>>>>> ocaml/5.1
             in
             let mda =
               { mda_declaration = md';
@@ -2143,14 +1897,7 @@ let rec components_of_module_maker
             env :=
               store_module ~update_summary:false ~check:None
                 id addr pres md shape !env
-<<<<<<< HEAD
         | Sig_modtype(id, decl, _) ->
-||||||| merged common ancestors
-                id addr pres md !env
-        | SigL_modtype(id, decl, _) ->
-=======
-        | SigL_modtype(id, decl, _) ->
->>>>>>> ocaml/5.1
             let final_decl =
               (* The prefixed items get the same scope as [cm_path], which is
                  the prefix. *)
@@ -2165,15 +1912,7 @@ let rec components_of_module_maker
             c.comp_modtypes <-
               NameMap.add (Ident.name id) mtda c.comp_modtypes;
             env := store_modtype ~update_summary:false id decl shape !env
-<<<<<<< HEAD
         | Sig_class(id, decl, _, _) ->
-||||||| merged common ancestors
-              NameMap.add (Ident.name id) final_decl c.comp_modtypes;
-            env := store_modtype ~update_summary:false id decl !env
-        | SigL_class(id, decl, _, _) ->
-=======
-        | SigL_class(id, decl, _, _) ->
->>>>>>> ocaml/5.1
             let decl' = Subst.class_declaration sub decl in
             let addr = next_address () in
             let shape = Shape.proj cm_shape (Shape.Item.class_ id) in
@@ -2237,14 +1976,8 @@ and check_value_name name loc =
         error (Illegal_value_name(loc, name))
     done
 
-<<<<<<< HEAD
 and store_value ?check mode id addr decl shape env =
   let open Subst.Lazy in
-||||||| merged common ancestors
-and store_value ?check id addr decl env =
-=======
-and store_value ?check id addr decl shape env =
->>>>>>> ocaml/5.1
   check_value_name (Ident.name id) decl.val_loc;
   Builtin_attributes.mark_alerts_used decl.val_attributes;
   Option.iter
@@ -2253,12 +1986,7 @@ and store_value ?check id addr decl shape env =
   let vda =
     { vda_description = decl;
       vda_address = addr;
-<<<<<<< HEAD
       vda_mode = mode;
-||||||| merged common ancestors
-  let vda = { vda_description = decl; vda_address = addr } in
-=======
->>>>>>> ocaml/5.1
       vda_shape = shape }
   in
   { env with
@@ -2292,16 +2020,9 @@ and store_constructor ~check type_decl type_id cstr_id cstr env =
                      (Warnings.Unused_constructor(name, complaint)))
               (constructor_usage_complaint ~rebind:false priv used));
     end;
-<<<<<<< HEAD
-  end;
-  Builtin_attributes.mark_alerts_used cstr.cstr_attributes;
-  Builtin_attributes.mark_warn_on_literal_pattern_used
-    cstr.cstr_attributes;
-||||||| merged common ancestors
-  end;
-=======
   end);
->>>>>>> ocaml/5.1
+  Builtin_attributes.mark_alerts_used cstr.cstr_attributes;
+  Builtin_attributes.mark_warn_on_literal_pattern_used cstr.cstr_attributes;
   let cda_shape = Shape.leaf cstr.cstr_uid in
   { env with
     constrs =
@@ -2333,14 +2054,8 @@ and store_label ~check type_decl type_id lbl_id lbl env =
                    Location.prerr_warning
                      loc (Warnings.Unused_field(name, complaint)))
               (label_usage_complaint priv mut used))
-<<<<<<< HEAD
-  end;
-  Builtin_attributes.mark_alerts_used lbl.lbl_attributes;
-||||||| merged common ancestors
-  end;
-=======
   end);
->>>>>>> ocaml/5.1
+  Builtin_attributes.mark_alerts_used lbl.lbl_attributes;
   { env with
     labels = TycompTbl.add lbl_id lbl env.labels;
   }
@@ -2378,12 +2093,7 @@ and store_type ~check id info shape env =
       tda_descriptions = descrs;
       tda_shape = shape }
   in
-<<<<<<< HEAD
   Builtin_attributes.mark_alerts_used info.type_attributes;
-||||||| merged common ancestors
-  let tda = { tda_declaration = info; tda_descriptions = descrs } in
-=======
->>>>>>> ocaml/5.1
   { env with
     types = IdTbl.add id tda env.types;
     summary = Env_type(env.summary, id, info) }
@@ -2397,13 +2107,7 @@ and store_type_infos ~tda_shape id info env =
   let tda =
     {
       tda_declaration = info;
-<<<<<<< HEAD
       tda_descriptions = Type_abstract Abstract_def;
-||||||| merged common ancestors
-  let tda = { tda_declaration = info; tda_descriptions = Type_abstract } in
-=======
-      tda_descriptions = Type_abstract;
->>>>>>> ocaml/5.1
       tda_shape
     }
   in
@@ -2421,15 +2125,10 @@ and store_extension ~check ~rebind id addr ext shape env =
       cda_address = Some addr;
       cda_shape = shape }
   in
-<<<<<<< HEAD
   Builtin_attributes.mark_alerts_used ext.ext_attributes;
   Builtin_attributes.mark_alerts_used cstr.cstr_attributes;
   Builtin_attributes.mark_warn_on_literal_pattern_used cstr.cstr_attributes;
-||||||| merged common ancestors
-  let cda = { cda_description = cstr; cda_address = Some addr } in
-=======
   Builtin_attributes.warning_scope ext.ext_attributes (fun () ->
->>>>>>> ocaml/5.1
   if check && not loc.Location.loc_ghost &&
     Warnings.is_active (Warnings.Unused_extension ("", false, Unused))
   then begin
@@ -2464,16 +2163,8 @@ and store_module ?(update_summary=true) ~check
     (fun f -> check_usage loc id md.md_uid f !module_declarations) check;
   let alerts = Builtin_attributes.alerts_of_attrs md.md_attributes in
   let comps =
-<<<<<<< HEAD
     components_of_module ~alerts ~uid:md.md_uid
       env Subst.identity (Pident id) addr md.md_type shape
-||||||| merged common ancestors
-    components_of_module ~alerts ~uid:md.mdl_uid
-      env Subst.identity (Pident id) addr md.mdl_type
-=======
-    components_of_module ~alerts ~uid:md.mdl_uid
-      env Subst.identity (Pident id) addr md.mdl_type shape
->>>>>>> ocaml/5.1
   in
   let mda =
     { mda_declaration = md;
@@ -2489,12 +2180,7 @@ and store_module ?(update_summary=true) ~check
     summary }
 
 and store_modtype ?(update_summary=true) id info shape env =
-<<<<<<< HEAD
   Builtin_attributes.mark_alerts_used info.Subst.Lazy.mtd_attributes;
-||||||| merged common ancestors
-and store_modtype ?(update_summary=true) id info env =
-=======
->>>>>>> ocaml/5.1
   let mtda = { mtda_declaration = info; mtda_shape = shape } in
   let summary =
     if not update_summary then env.summary
@@ -2504,13 +2190,7 @@ and store_modtype ?(update_summary=true) id info env =
     summary }
 
 and store_class id addr desc shape env =
-<<<<<<< HEAD
   Builtin_attributes.mark_alerts_used desc.cty_attributes;
-||||||| merged common ancestors
-and store_class id addr desc env =
-  let clda = { clda_declaration = desc; clda_address = addr } in
-=======
->>>>>>> ocaml/5.1
   let clda =
     { clda_declaration = desc;
       clda_address = addr;
@@ -2521,12 +2201,7 @@ and store_class id addr desc env =
     summary = Env_class(env.summary, id, desc) }
 
 and store_cltype id desc shape env =
-<<<<<<< HEAD
   Builtin_attributes.mark_alerts_used desc.clty_attributes;
-||||||| merged common ancestors
-and store_cltype id desc env =
-=======
->>>>>>> ocaml/5.1
   let cltda = { cltda_declaration = desc; cltda_shape = shape } in
   { env with
     cltypes = IdTbl.add id cltda env.cltypes;
@@ -2578,23 +2253,10 @@ let add_functor_arg id env =
    functor_args = Ident.add id () env.functor_args;
    summary = Env_functor_arg (env.summary, id)}
 
-<<<<<<< HEAD
 let add_value_lazy ?check ?shape ?(mode = Mode.Value.legacy) id desc env =
-||||||| merged common ancestors
-let add_value ?check id desc env =
-=======
-let add_value ?check ?shape id desc env =
->>>>>>> ocaml/5.1
   let addr = value_declaration_address env id desc in
-<<<<<<< HEAD
   let shape = shape_or_leaf desc.Subst.Lazy.val_uid shape in
   store_value ?check mode id addr desc shape env
-||||||| merged common ancestors
-  store_value ?check id addr desc env
-=======
-  let shape = shape_or_leaf desc.val_uid shape in
-  store_value ?check id addr desc shape env
->>>>>>> ocaml/5.1
 
 let add_type ~check ?shape id info env =
   let shape = shape_or_leaf info.type_uid shape in
@@ -2605,14 +2267,8 @@ and add_extension ~check ?shape ~rebind id ext env =
   let shape = shape_or_leaf ext.ext_uid shape in
   store_extension ~check ~rebind id addr ext shape env
 
-<<<<<<< HEAD
 and add_module_declaration_lazy
       ~update_summary ?(arg=false) ?shape ~check id presence md env =
-||||||| merged common ancestors
-and add_module_declaration ?(arg=false) ~check id presence md env =
-=======
-and add_module_declaration ?(arg=false) ?shape ~check id presence md env =
->>>>>>> ocaml/5.1
   let check =
     if not check then
       None
@@ -2622,63 +2278,23 @@ and add_module_declaration ?(arg=false) ?shape ~check id presence md env =
       Some (fun s -> Warnings.Unused_module s)
   in
   let addr = module_declaration_address env id presence md in
-<<<<<<< HEAD
   let shape = shape_or_leaf md.Subst.Lazy.md_uid shape in
   let env =
     store_module ~update_summary ~check id addr presence md shape env
   in
-||||||| merged common ancestors
-  let env = store_module ~check id addr presence md env in
-=======
-  let shape = shape_or_leaf md.mdl_uid shape in
-  let env = store_module ~check id addr presence md shape env in
->>>>>>> ocaml/5.1
   if arg then add_functor_arg id env else env
 
-<<<<<<< HEAD
 let add_module_declaration ?(arg=false) ?shape ~check id presence md env =
   add_module_declaration_lazy ~update_summary:true ~arg ?shape ~check id
     presence (Subst.Lazy.of_module_decl md) env
-||||||| merged common ancestors
-and add_module_declaration_lazy ~update_summary id presence md env =
-  let addr = module_declaration_address env id presence md in
-  let env = store_module ~update_summary ~check:None id addr presence md env in
-  env
-=======
-and add_module_declaration_lazy ~update_summary id presence md env =
-  let addr = module_declaration_address env id presence md in
-  let shape = Shape.leaf md.Subst.Lazy.mdl_uid in
-  let env =
-    store_module ~update_summary ~check:None id addr presence md shape env
-  in
-  env
->>>>>>> ocaml/5.1
 
-<<<<<<< HEAD
 and add_modtype_lazy ~update_summary ?shape id info env =
   let shape = shape_or_leaf info.Subst.Lazy.mtd_uid shape in
   store_modtype ~update_summary id info shape env
-||||||| merged common ancestors
-and add_modtype id info env =
-  store_modtype id (Subst.Lazy.of_modtype_decl info) env
-=======
-and add_modtype ?shape id info env =
-  let shape = shape_or_leaf info.mtd_uid shape in
-  store_modtype id (Subst.Lazy.of_modtype_decl info) shape env
->>>>>>> ocaml/5.1
 
-<<<<<<< HEAD
 let add_modtype ?shape id info env =
   add_modtype_lazy ~update_summary:true ?shape id
     (Subst.Lazy.of_modtype_decl info) env
-||||||| merged common ancestors
-and add_modtype_lazy ~update_summary id info env =
-  store_modtype ~update_summary id info env
-=======
-and add_modtype_lazy ~update_summary id info env =
-  let shape = Shape.leaf info.Subst.Lazy.mtdl_uid in
-  store_modtype ~update_summary id info shape env
->>>>>>> ocaml/5.1
 
 and add_class ?shape id ty env =
   let addr = class_declaration_address env id ty in
@@ -2689,7 +2305,6 @@ and add_cltype ?shape id ty env =
   let shape = shape_or_leaf ty.clty_uid shape in
   store_cltype id ty shape env
 
-<<<<<<< HEAD
 let add_module_lazy ~update_summary id presence mty env =
   let md = Subst.Lazy.{md_type = mty;
                        md_attributes = [];
@@ -2700,21 +2315,6 @@ let add_module_lazy ~update_summary id presence mty env =
 
 let add_module ?arg ?shape id presence mty env =
   add_module_declaration ~check:false ?arg ?shape id presence (md mty) env
-||||||| merged common ancestors
-let add_module ?arg id presence mty env =
-  add_module_declaration ~check:false ?arg id presence (md mty) env
-=======
-let add_module ?arg ?shape id presence mty env =
-  add_module_declaration ~check:false ?arg ?shape id presence (md mty) env
-
-let add_module_lazy ~update_summary id presence mty env =
-  let md = Subst.Lazy.{mdl_type = mty;
-                       mdl_attributes = [];
-                       mdl_loc = Location.none;
-                       mdl_uid = Uid.internal_not_actually_unique}
-  in
-  add_module_declaration_lazy ~update_summary id presence md env
->>>>>>> ocaml/5.1
 
 let add_local_type path info env =
   { env with
@@ -2726,13 +2326,10 @@ let enter_value ?check name desc env =
   let id = Ident.create_local name in
   let desc = Subst.Lazy.of_value_description desc in
   let addr = value_declaration_address env id desc in
-<<<<<<< HEAD
-  let env = store_value ?check (Mode.Value.legacy) id addr desc (Shape.leaf desc.val_uid) env in
-||||||| merged common ancestors
-  let env = store_value ?check id addr desc env in
-=======
-  let env = store_value ?check id addr desc (Shape.leaf desc.val_uid) env in
->>>>>>> ocaml/5.1
+  let env =
+    store_value ?check Mode.Value.legacy id addr desc (Shape.leaf desc.val_uid)
+      env
+  in
   (id, env)
 
 let enter_type ~scope name info env =
@@ -2794,59 +2391,13 @@ let add_unboxed_lock env =
 
 (* Insertion of all components of a signature *)
 
-<<<<<<< HEAD
 let proj_shape map mod_shape item =
   match mod_shape with
   | None -> map, None
   | Some mod_shape ->
       let shape = Shape.proj mod_shape item in
       Shape.Map.add map item shape, Some shape
-||||||| merged common ancestors
-let add_item comp env =
-  match comp with
-    Sig_value(id, decl, _)    -> add_value id decl env
-  | Sig_type(id, decl, _, _)  -> add_type ~check:false id decl env
-  | Sig_typext(id, ext, _, _) ->
-      add_extension ~check:false ~rebind:false id ext env
-  | Sig_module(id, presence, md, _, _) ->
-      add_module_declaration ~check:false id presence md env
-  | Sig_modtype(id, decl, _)  -> add_modtype id decl env
-  | Sig_class(id, decl, _, _) -> add_class id decl env
-  | Sig_class_type(id, decl, _, _) -> add_cltype id decl env
-=======
-let add_item (map, mod_shape) comp env =
-  let proj_shape item =
-    match mod_shape with
-    | None -> map, None
-    | Some mod_shape ->
-        let shape = Shape.proj mod_shape item in
-        Shape.Map.add map item shape, Some shape
-  in
-  match comp with
-  | Sig_value(id, decl, _) ->
-      let map, shape = proj_shape (Shape.Item.value id) in
-      map, add_value ?shape id decl env
-  | Sig_type(id, decl, _, _) ->
-      let map, shape = proj_shape (Shape.Item.type_ id) in
-      map, add_type ~check:false ?shape id decl env
-  | Sig_typext(id, ext, _, _) ->
-      let map, shape = proj_shape (Shape.Item.extension_constructor id) in
-      map, add_extension ~check:false ?shape ~rebind:false id ext env
-  | Sig_module(id, presence, md, _, _) ->
-      let map, shape = proj_shape (Shape.Item.module_ id) in
-      map, add_module_declaration ~check:false ?shape id presence md env
-  | Sig_modtype(id, decl, _)  ->
-      let map, shape = proj_shape (Shape.Item.module_type id) in
-      map, add_modtype ?shape id decl env
-  | Sig_class(id, decl, _, _) ->
-      let map, shape = proj_shape (Shape.Item.class_ id) in
-      map, add_class ?shape id decl env
-  | Sig_class_type(id, decl, _, _) ->
-      let map, shape = proj_shape (Shape.Item.class_type id) in
-      map, add_cltype ?shape id decl env
->>>>>>> ocaml/5.1
 
-<<<<<<< HEAD
 module Add_signature(T : Types.Wrapped)(M : sig
   val add_value: ?shape:Shape.t -> Ident.t -> T.value_description -> t -> t
   val add_module_declaration: ?arg:bool -> ?shape:Shape.t -> check:bool
@@ -2854,21 +2405,7 @@ module Add_signature(T : Types.Wrapped)(M : sig
   val add_modtype: ?shape:Shape.t -> Ident.t -> T.modtype_declaration -> t -> t
 end) = struct
   open T
-||||||| merged common ancestors
-let rec add_signature sg env =
-  match sg with
-    [] -> env
-  | comp :: rem -> add_signature rem (add_item comp env)
-=======
-let rec add_signature (map, mod_shape) sg env =
-  match sg with
-      [] -> map, env
-  | comp :: rem ->
-      let map, env = add_item (map, mod_shape) comp env in
-      add_signature (map, mod_shape) rem env
->>>>>>> ocaml/5.1
 
-<<<<<<< HEAD
   let add_item map mod_shape comp env =
     match comp with
     | Sig_value(id, decl, _) ->
@@ -2921,13 +2458,8 @@ let add_signature_lazy =
   in
   M.add_signature
 
-||||||| merged common ancestors
-let enter_signature ~scope sg env =
-=======
->>>>>>> ocaml/5.1
 let enter_signature_and_shape ~scope ~parent_shape mod_shape sg env =
   let sg = Subst.signature (Rescope scope) Subst.identity sg in
-<<<<<<< HEAD
   let shape, env = add_signature parent_shape mod_shape sg env in
   sg, shape, env
 
@@ -2957,31 +2489,6 @@ let add_signature sg env =
   env
 let add_signature_lazy sg env =
   let _, env = add_signature_lazy Shape.Map.empty None sg env in
-||||||| merged common ancestors
-  sg, add_signature sg env
-=======
-  let shape, env = add_signature (parent_shape, mod_shape) sg env in
-  sg, shape, env
-
-let enter_signature ?mod_shape ~scope sg env =
-  let sg, _, env =
-    enter_signature_and_shape ~scope ~parent_shape:Shape.Map.empty
-      mod_shape sg env
-  in
-  sg, env
-
-let enter_signature_and_shape ~scope ~parent_shape mod_shape sg env =
-  enter_signature_and_shape ~scope ~parent_shape (Some mod_shape) sg env
-
-let add_value = add_value ?shape:None
-let add_type = add_type ?shape:None
-let add_extension = add_extension ?shape:None
-let add_class = add_class ?shape:None
-let add_cltype = add_cltype ?shape:None
-let add_modtype = add_modtype ?shape:None
-let add_signature sg env =
-  let _, env = add_signature (Shape.Map.empty, None) sg env in
->>>>>>> ocaml/5.1
   env
 
 (* Add "unbound" bindings *)
@@ -3202,16 +2709,8 @@ let save_signature_with_imports ~alerts sg modname filename imports =
   save_signature_with_transform with_imports
     ~alerts sg modname filename
 
-<<<<<<< HEAD
 (* Make the initial environment, without language extensions *)
-let (initial_safe_string, initial_unsafe_string) =
-||||||| merged common ancestors
-(* Make the initial environment *)
-let (initial_safe_string, initial_unsafe_string) =
-=======
-(* Make the initial environment *)
 let initial =
->>>>>>> ocaml/5.1
   Predef.build_initial_env
     (add_type ~check:false)
     (add_extension ~check:false ~rebind:false)
@@ -3228,11 +2727,10 @@ let add_language_extension_types env =
    turned on.  We can't do this at startup because command line flags haven't
    been parsed yet. So, we make the initial environment lazy.
 
-   If language extensions are adjusted after [initial_safe_string] and
-   [initial_unsafe_string] are forced, these environments may be inaccurate.
+   If language extensions are adjusted after [initial] is forced, these
+   environments may be inaccurate.
 *)
-let initial_safe_string = add_language_extension_types initial_safe_string
-let initial_unsafe_string = add_language_extension_types initial_unsafe_string
+let initial = add_language_extension_types initial
 
 (* Tracking usage *)
 
@@ -3786,13 +3284,7 @@ let lookup_all_dot_constructors ~errors ~use ~loc usage l s env =
   | Longident.Lident "*predef*" ->
       (* Hack to support compilation of default arguments *)
       lookup_all_ident_constructors
-<<<<<<< HEAD
-        ~errors ~use ~loc usage s (Lazy.force initial_safe_string)
-||||||| merged common ancestors
-        ~errors ~use ~loc usage s initial_safe_string
-=======
-        ~errors ~use ~loc usage s initial
->>>>>>> ocaml/5.1
+        ~errors ~use ~loc usage s (Lazy.force initial)
   | _ ->
       let (_, comps) = lookup_structure_components ~errors ~use ~loc l env in
       match NameMap.find s comps.comp_constrs with

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -97,7 +97,6 @@ module TyVarEnv : sig
   val with_univars : poly_univars -> (unit -> 'a) -> 'a
   (* evaluate with a locally extended set of univars *)
 
-<<<<<<< HEAD
   val make_poly_univars : string Location.loc list -> poly_univars
   (* a version of [make_poly_univars_jkinds] that doesn't take jkinds *)
 
@@ -120,273 +119,6 @@ module TyVarEnv : sig
   val new_anon_var : Location.t -> Env.t -> Jkind.t -> policy -> type_expr
     (* create a new variable to represent a _; fails for fixed_policy *)
   val new_var : ?name:string -> Jkind.t -> policy -> type_expr
-    (* create a new variable according to the given policy *)
-
-  val add_pre_univar : type_expr -> policy -> unit
-    (* remember that a variable might become a univar if it isn't unified;
-       used for checking method types *)
-
-  val collect_univars : (unit -> 'a) -> 'a * type_expr list
-    (* collect univars during a computation; returns the univars.
-       The wrapped computation should use [univars_policy].
-       postcondition: the returned type_exprs are all Tunivar *)
-
-  val reset_locals : ?univars:poly_univars -> unit -> unit
-    (* clear out the local type variable env't; call this when starting
-       a new e.g. type signature. Optionally pass some univars that
-       are in scope. *)
-
-  val lookup_local : string -> type_expr
-    (* look up a local type variable; throws Not_found if it isn't in scope *)
-
-  val remember_used : string -> type_expr -> Location.t -> unit
-    (* remember that a given name is bound to a given type *)
-
-  val globalize_used_variables : policy -> Env.t -> unit -> unit
-   (* after finishing with a type signature, used variables are unified to the
-      corresponding global type variables if they exist. Otherwise, in function
-      of the policy, fresh used variables are either
-        - added to the global type variable scope if they are not longer
-        variables under the {!fixed_policy}
-        - added to the global type variable scope under the {!extensible_policy}
-        - expected to be collected later by a call to `collect_univar` under the
-        {!universal_policy}
-   *)
-
-end = struct
-  (** Map indexed by type variable names. *)
-  module TyVarMap = Misc.Stdlib.String.Map
-
-  let not_generic v = get_level v <> Btype.generic_level
-
-  (* These are the type variables that were in scope before
-     we started processing the current type.
-  *)
-  let type_variables = ref (TyVarMap.empty : type_expr TyVarMap.t)
-
-  (* These are variables that have been used in the currently-being-checked
-     type, possibly including the variables in [type_variables].
-  *)
-  let used_variables =
-    ref (TyVarMap.empty : (type_expr * Location.t) TyVarMap.t)
-
-  (* These are variables that will become univars when we're done with the
-     current type. Used to force free variables in method types to become
-     univars.
-  *)
-  let pre_univars = ref ([] : type_expr list)
-
-  let reset () =
-    reset_global_level ();
-    Ctype.reset_reified_var_counter ();
-    type_variables := TyVarMap.empty
-
-  let is_in_scope name =
-    TyVarMap.mem name !type_variables
-
-  let add name v =
-    assert (not_generic v);
-    type_variables := TyVarMap.add name v !type_variables
-
-  let narrow () =
-    (increase_global_level (), !type_variables)
-
-  let widen (gl, tv) =
-    restore_global_level gl;
-    type_variables := tv
-
-  let with_local_scope f =
-   let context = narrow () in
-   Fun.protect
-     f
-     ~finally:(fun () -> widen context)
-
-  (* throws Not_found if the variable is not in scope *)
-  let lookup_global_type_variable name =
-    TyVarMap.find name !type_variables
-
-  let get_in_scope_names () =
-    let add_name name _ l = if name = "_" then l else ("'" ^ name) :: l in
-    TyVarMap.fold add_name !type_variables []
-
-  (*****)
-  type poly_univars = (string * type_expr * jkind_info) list
-
-  (* These are variables we expect to become univars (they were introduced with
-     e.g. ['a .]), but we need to make sure they don't unify first.  Why not
-     just birth them as univars? Because they might successfully unify with a
-     row variable in the ['a. < m : ty; .. > as 'a] idiom.  They are like the
-     [used_variables], but will not be globalized in [globalize_used_variables].
-  *)
-  let univars = ref ([] : poly_univars)
-  let assert_not_generic uvs =
-    assert (List.for_all (fun (_name, v, _lay) -> not_generic v) uvs)
-
-  let rec find_poly_univars name = function
-    | [] -> raise Not_found
-    | (n, t, _) :: rest ->
-      if String.equal name n
-      then t
-      else find_poly_univars name rest
-
-  let with_univars new_ones f =
-    assert_not_generic new_ones;
-    let old_univars = !univars in
-    univars := new_ones @ !univars;
-    Fun.protect
-      f
-      ~finally:(fun () -> univars := old_univars)
-
-  let mk_poly_univars_triple_with_jkind ~context var jkind =
-    let name = var.txt in
-    let original_jkind = Jkind.of_annotation ~context:(context name) jkind in
-    let jkind_info = { original_jkind; defaulted = false } in
-    name, newvar ~name original_jkind, jkind_info
-
-  let mk_poly_univars_triple_without_jkind var =
-    let name = var.txt in
-    let original_jkind = Jkind.value ~why:Univar in
-    let jkind_info = { original_jkind; defaulted = true } in
-    name, newvar ~name original_jkind, jkind_info
-
-  let make_poly_univars vars =
-    List.map mk_poly_univars_triple_without_jkind vars
-
-  let make_poly_univars_jkinds ~context vars_jkinds =
-    let mk_trip = function
-        | (v, None) -> mk_poly_univars_triple_without_jkind v
-        | (v, Some l) -> mk_poly_univars_triple_with_jkind ~context v l
-    in
-    List.map mk_trip vars_jkinds
-
-  let check_poly_univars env loc vars =
-    vars |> List.iter (fun (_, v, _) -> generalize v);
-    vars |> List.map (fun (name, ty1,
-                           ({ original_jkind; _ } as jkind_info)) ->
-      let v = Btype.proxy ty1 in
-      let cant_quantify reason =
-        raise (Error (loc, env, Cannot_quantify(name, reason)))
-      in
-      begin match get_desc v with
-      | Tvar { jkind } when not (Jkind.equate jkind original_jkind) ->
-        let reason =
-          Bad_univar_jkind { name; jkind_info; inferred_jkind = jkind }
-        in
-        raise (Error (loc, env, reason))
-      | Tvar _ when get_level v <> Btype.generic_level ->
-          cant_quantify Scope_escape
-      | Tvar { name; jkind } ->
-         set_type_desc v (Tunivar { name; jkind })
-      | Tunivar _ ->
-         cant_quantify Univar
-      | _ ->
-         cant_quantify (Unified v)
-      end;
-      v)
-
-  let instance_poly_univars env loc vars =
-    let vs = check_poly_univars env loc vars in
-    vs |> List.iter (fun v ->
-      match get_desc v with
-      | Tunivar { name; jkind } ->
-         set_type_desc v (Tvar { name; jkind })
-      | _ -> assert false);
-    vs
-
-  (*****)
-  let reset_locals ?univars:(uvs=[]) () =
-    assert_not_generic uvs;
-    univars := uvs;
-    used_variables := TyVarMap.empty
-
-  (* throws Not_found if the variable is not in scope *)
-  let lookup_local name =
-    try
-      find_poly_univars name !univars
-    with Not_found ->
-      instance (fst (TyVarMap.find name !used_variables))
-      (* This call to instance might be redundant; all variables
-         inserted into [used_variables] are non-generic, but some
-         might get generalized. *)
-
-  let remember_used name v loc =
-    assert (not_generic v);
-    used_variables := TyVarMap.add name (v, loc) !used_variables
-
-
-  type flavor = Unification | Universal
-  type extensibility = Extensible | Fixed
-  type policy = { flavor : flavor; extensibility : extensibility }
-
-  let fixed_policy = { flavor = Unification; extensibility = Fixed }
-  let extensible_policy = { flavor = Unification; extensibility = Extensible }
-  let univars_policy = { flavor = Universal; extensibility = Extensible }
-
-  let add_pre_univar tv = function
-    | { flavor = Universal } ->
-      assert (not_generic tv);
-      pre_univars := tv :: !pre_univars
-    | _ -> ()
-
-  let collect_univars f =
-    pre_univars := [];
-    let result = f () in
-    let univs =
-      List.fold_left
-        (fun acc v ->
-           match get_desc v with
-           | Tvar { name; jkind } when get_level v = Btype.generic_level ->
-               set_type_desc v (Tunivar { name; jkind });
-               v :: acc
-           | _ -> acc)
-        [] !pre_univars in
-    result, univs
-
-  let new_var ?name jkind policy =
-    let tv = Ctype.newvar ?name jkind in
-    add_pre_univar tv policy;
-    tv
-
-  let new_anon_var loc env jkind = function
-    | { extensibility = Fixed } -> raise(Error(loc, env, No_type_wildcards))
-    | policy -> new_var jkind policy
-
-  let globalize_used_variables { flavor; extensibility } env =
-    let r = ref [] in
-    TyVarMap.iter
-      (fun name (ty, loc) ->
-        if flavor = Unification || is_in_scope name then
-          let v = new_global_var (Jkind.any ~why:Dummy_jkind) in
-          let snap = Btype.snapshot () in
-          if try unify env v ty; true with _ -> Btype.backtrack snap; false
-          then try
-            r := (loc, v, lookup_global_type_variable name) :: !r
-          with Not_found ->
-            if extensibility = Fixed && Btype.is_Tvar ty then
-              raise(Error(loc, env,
-                          Unbound_type_variable ("'"^name,
-                                                 get_in_scope_names ())));
-            let v2 = new_global_var (Jkind.any ~why:Dummy_jkind) in
-||||||| merged common ancestors
-type variable_context = int * type_expr TyVarMap.t
-=======
-  val make_poly_univars : string list -> poly_univars
-  (* see mli file *)
-
-  val check_poly_univars : Env.t -> Location.t -> poly_univars -> type_expr list
-  (* see mli file *)
-
-  val instance_poly_univars :
-     Env.t -> Location.t -> poly_univars -> type_expr list
-  (* see mli file *)
-
-  type policy
-  val fixed_policy : policy (* no wildcards allowed *)
-  val extensible_policy : policy (* common case *)
-  val univars_policy : policy (* fresh variables are univars (in methods) *)
-  val new_any_var : Location.t -> Env.t -> policy -> type_expr
-    (* create a new variable to represent a _; fails for fixed_policy *)
-  val new_var : ?name:string -> policy -> type_expr
     (* create a new variable according to the given policy *)
 
   val add_pre_univar : type_expr -> policy -> unit
@@ -433,27 +165,10 @@ end = struct
   let type_variables = ref (TyVarMap.empty : type_expr TyVarMap.t)
 
   (* These are variables that have been used in the currently-being-checked
-     type.
+     type, possibly including the variables in [type_variables].
   *)
   let used_variables =
     ref (TyVarMap.empty : (type_expr * Location.t) TyVarMap.t)
-
-  (* These are variables we expect to become univars (they were introduced with
-     e.g. ['a .]), but we need to make sure they don't unify first.  Why not
-     just birth them as univars? Because they might successfully unify with a
-     row variable in the ['a. < m : ty; .. > as 'a] idiom.  They are like the
-     [used_variables], but will not be globalized in [globalize_used_variables].
-  *)
-  type pending_univar = {
-    univar: type_expr  (** the univar itself *);
-    mutable associated: type_expr option ref list
-     (** associated references to row variables that we want to generalize
-       if possible *)
-  }
-
-  let univars = ref ([] : (string * pending_univar) list)
-  let assert_univars uvs =
-    assert (List.for_all (fun (_name, v) -> not_generic v.univar) uvs)
 
   (* These are variables that will become univars when we're done with the
      current type. Used to force free variables in method types to become
@@ -494,7 +209,31 @@ end = struct
     TyVarMap.fold add_name !type_variables []
 
   (*****)
-  type poly_univars = (string * pending_univar) list
+  (* These are variables we expect to become univars (they were introduced with
+     e.g. ['a .]), but we need to make sure they don't unify first.  Why not
+     just birth them as univars? Because they might successfully unify with a
+     row variable in the ['a. < m : ty; .. > as 'a] idiom.  They are like the
+     [used_variables], but will not be globalized in [globalize_used_variables].
+  *)
+  type pending_univar = {
+    univar: type_expr  (** the univar itself *);
+    mutable associated: type_expr option ref list
+     (** associated references to row variables that we want to generalize
+       if possible *)
+  }
+
+  type poly_univars = (string * pending_univar * jkind_info) list
+
+  let univars = ref ([] : poly_univars)
+  let assert_univars uvs =
+    assert (List.for_all (fun (_name, v, _lay) -> not_generic v.univar) uvs)
+
+  let rec find_poly_univars name = function
+    | [] -> raise Not_found
+    | (n, t, _) :: rest ->
+      if String.equal name n
+      then t
+      else find_poly_univars name rest
 
   let with_univars new_ones f =
     assert_univars new_ones;
@@ -504,31 +243,65 @@ end = struct
       f
       ~finally:(fun () -> univars := old_univars)
 
+  let mk_pending_univar name jkind =
+    { univar = newvar ~name jkind; associated = [] }
+
+  let mk_poly_univars_triple_with_jkind ~context var jkind =
+    let name = var.txt in
+    let original_jkind = Jkind.of_annotation ~context:(context name) jkind in
+    let jkind_info = { original_jkind; defaulted = false } in
+    name, mk_pending_univar name original_jkind, jkind_info
+
+  let mk_poly_univars_triple_without_jkind var =
+    let name = var.txt in
+    let original_jkind = Jkind.value ~why:Univar in
+    let jkind_info = { original_jkind; defaulted = true } in
+    name, mk_pending_univar name original_jkind, jkind_info
+
   let make_poly_univars vars =
-    let make name = { univar=newvar ~name (); associated = [] } in
-    List.map (fun name -> name, make name ) vars
+    List.map mk_poly_univars_triple_without_jkind vars
+
+  let make_poly_univars_jkinds ~context vars_jkinds =
+    let mk_trip = function
+        | (v, None) -> mk_poly_univars_triple_without_jkind v
+        | (v, Some l) -> mk_poly_univars_triple_with_jkind ~context v l
+    in
+    List.map mk_trip vars_jkinds
 
   let promote_generics_to_univars promoted vars =
       List.fold_left
         (fun acc v ->
            match get_desc v with
-           | Tvar name when get_level v = Btype.generic_level ->
-               set_type_desc v (Tunivar name);
+           | Tvar { name; jkind } when get_level v = Btype.generic_level ->
+               set_type_desc v (Tunivar { name; jkind });
                v :: acc
            | _ -> acc
         )
         promoted vars
 
   let check_poly_univars env loc vars =
-    vars |> List.iter (fun (_, p) -> generalize p.univar);
+    vars |> List.iter (fun (_, p, _) -> generalize p.univar);
     let univars =
-      vars |> List.map (fun (name, {univar=ty1; _ }) ->
+      vars |> List.map (fun (name, {univar=ty1; _ },
+                             ({ original_jkind; _ } as jkind_info)) ->
       let v = Btype.proxy ty1 in
+      let cant_quantify reason =
+        raise (Error (loc, env, Cannot_quantify(name, reason)))
+      in
       begin match get_desc v with
-      | Tvar name when get_level v = Btype.generic_level ->
-         set_type_desc v (Tunivar name)
+      | Tvar { jkind } when not (Jkind.equate jkind original_jkind) ->
+        let reason =
+          Bad_univar_jkind { name; jkind_info; inferred_jkind = jkind }
+        in
+        raise (Error (loc, env, reason))
+      | Tvar _ when get_level v <> Btype.generic_level ->
+          cant_quantify Scope_escape
+      | Tvar { name; jkind } ->
+         set_type_desc v (Tunivar { name; jkind })
+      | Tunivar _ ->
+         cant_quantify Univar
       | _ ->
-         raise (Error (loc, env, Cannot_quantify(name, v)))
+         cant_quantify (Unified v)
       end;
       v)
     in
@@ -537,7 +310,7 @@ end = struct
        multiple univars we will promote it once, when checking the nearest
        univar associated to this row variable.
     *)
-    let promote_associated acc (_,v) =
+    let promote_associated acc (_,v,_) =
       let enclosed_rows = List.filter_map (!) v.associated in
       promote_generics_to_univars acc enclosed_rows
     in
@@ -547,8 +320,8 @@ end = struct
     let vs = check_poly_univars env loc vars in
     vs |> List.iter (fun v ->
       match get_desc v with
-      | Tunivar name ->
-         set_type_desc v (Tvar name)
+      | Tunivar { name; jkind } ->
+         set_type_desc v (Tvar { name; jkind })
       | _ -> assert false);
     vs
 
@@ -565,7 +338,7 @@ end = struct
   (* throws Not_found if the variable is not in scope *)
   let lookup_local ~row_context name =
     try
-      let p = List.assoc name !univars in
+      let p = find_poly_univars name !univars in
       associate row_context p;
       p.univar
     with Not_found ->
@@ -599,21 +372,21 @@ end = struct
     let univs = promote_generics_to_univars [] !pre_univars in
     result, univs
 
-  let new_var ?name policy =
-    let tv = Ctype.newvar ?name () in
+  let new_var ?name jkind policy =
+    let tv = Ctype.newvar ?name jkind in
     add_pre_univar tv policy;
     tv
 
-  let new_any_var loc env = function
+  let new_anon_var loc env jkind = function
     | { extensibility = Fixed } -> raise(Error(loc, env, No_type_wildcards))
-    | policy -> new_var policy
+    | policy -> new_var jkind policy
 
   let globalize_used_variables { flavor; extensibility } env =
     let r = ref [] in
     TyVarMap.iter
       (fun name (ty, loc) ->
         if flavor = Unification || is_in_scope name then
-          let v = new_global_var () in
+          let v = new_global_var (Jkind.any ~why:Dummy_jkind) in
           let snap = Btype.snapshot () in
           if try unify env v ty; true with _ -> Btype.backtrack snap; false
           then try
@@ -623,8 +396,7 @@ end = struct
               raise(Error(loc, env,
                           Unbound_type_variable ("'"^name,
                                                  get_in_scope_names ())));
-            let v2 = new_global_var () in
->>>>>>> ocaml/5.1
+            let v2 = new_global_var (Jkind.any ~why:Dummy_jkind) in
             r := (loc, v, v2) :: !r;
             add name v2)
       !used_variables;
@@ -669,29 +441,8 @@ let create_package_mty loc p l =
 
 (* Translation of type expressions *)
 
-<<<<<<< HEAD
-||||||| merged common ancestors
-let type_variables = ref (TyVarMap.empty : type_expr TyVarMap.t)
-let univars        = ref ([] : (string * type_expr) list)
-let pre_univars    = ref ([] : type_expr list)
-let used_variables = ref (TyVarMap.empty : (type_expr * Location.t) TyVarMap.t)
-
-let reset_type_variables () =
-  reset_global_level ();
-  Ctype.reset_reified_var_counter ();
-  type_variables := TyVarMap.empty
-
-let narrow () =
-  (increase_global_level (), !type_variables)
-
-let widen (gl, tv) =
-  restore_global_level gl;
-  type_variables := tv
-
-=======
 let generalize_ctyp typ = generalize typ.ctyp_type
 
->>>>>>> ocaml/5.1
 let strict_ident c = (c = '_' || c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z')
 
 let validate_name = function
@@ -699,29 +450,10 @@ let validate_name = function
   | Some name as s ->
       if name <> "" && strict_ident name.[0] then s else None
 
-<<<<<<< HEAD
 let new_global_var ?name jkind =
   new_global_var ?name:(validate_name name) jkind
 let newvar ?name jkind =
   newvar ?name:(validate_name name) jkind
-||||||| merged common ancestors
-let new_global_var ?name () =
-  new_global_var ?name:(validate_name name) ()
-let newvar ?name () =
-  newvar ?name:(validate_name name) ()
-
-let type_variable loc name =
-  try
-    TyVarMap.find name !type_variables
-  with Not_found ->
-    raise(Error(loc, Env.empty, Unbound_type_variable ("'" ^ name)))
-
-=======
-let new_global_var ?name () =
-  new_global_var ?name:(validate_name name) ()
-let newvar ?name () =
-  newvar ?name:(validate_name name) ()
->>>>>>> ocaml/5.1
 
 let valid_tyvar_name name =
   name <> "" && name.[0] <> '_'
@@ -769,35 +501,7 @@ let transl_type_param env path styp =
   match styp.ptyp_desc with
     Ptyp_any -> transl_type_param_var env loc attrs None jkind None
   | Ptyp_var name ->
-<<<<<<< HEAD
     transl_type_param_var env loc attrs (Some name) jkind None
-||||||| merged common ancestors
-      let ty =
-        try
-          if not (valid_tyvar_name name) then
-            raise (Error (loc, Env.empty, Invalid_variable_name ("'" ^ name)));
-          ignore (TyVarMap.find name !type_variables);
-          raise Already_bound
-        with Not_found ->
-          let v = new_global_var ~name () in
-            type_variables := TyVarMap.add name v !type_variables;
-            v
-      in
-        { ctyp_desc = Ttyp_var name; ctyp_type = ty; ctyp_env = env;
-          ctyp_loc = loc; ctyp_attributes = styp.ptyp_attributes; }
-=======
-      let ty =
-          if not (valid_tyvar_name name) then
-            raise (Error (loc, Env.empty, Invalid_variable_name ("'" ^ name)));
-          if TyVarEnv.is_in_scope name then
-            raise Already_bound;
-          let v = new_global_var ~name () in
-          TyVarEnv.add name v;
-          v
-      in
-        { ctyp_desc = Ttyp_var name; ctyp_type = ty; ctyp_env = env;
-          ctyp_loc = loc; ctyp_attributes = styp.ptyp_attributes; }
->>>>>>> ocaml/5.1
   | _ -> assert false
 
 let transl_type_param env path styp =
@@ -806,7 +510,6 @@ let transl_type_param env path styp =
   Builtin_attributes.warning_scope styp.ptyp_attributes
     (fun () -> transl_type_param env path styp)
 
-<<<<<<< HEAD
 let get_type_param_jkind path styp =
   match Jane_syntax.Core_type.of_ast styp with
   | None -> Jkind.of_new_sort ~why:Unannotated_type_parameter
@@ -882,60 +585,11 @@ let transl_bound_vars : (_, _) Either.t -> _ =
                           TyVarEnv.make_poly_univars_jkinds
                             ~context:(fun v -> Univar v) vars_jkinds
 
-let rec transl_type env policy mode styp =
-||||||| merged common ancestors
-
-let new_pre_univar ?name () =
-  let v = newvar ?name () in pre_univars := v :: !pre_univars; v
-
-type poly_univars = (string * type_expr) list
-let make_poly_univars vars =
-  List.map (fun name -> name, newvar ~name ()) vars
-
-let check_poly_univars env loc vars =
-  vars |> List.iter (fun (_, v) -> generalize v);
-  vars |> List.map (fun (name, ty1) ->
-    let v = Btype.proxy ty1 in
-    begin match get_desc v with
-    | Tvar name when get_level v = Btype.generic_level ->
-       set_type_desc v (Tunivar name)
-    | _ ->
-       raise (Error (loc, env, Cannot_quantify(name, v)))
-    end;
-    v)
-
-let instance_poly_univars env loc vars =
-  let vs = check_poly_univars env loc vars in
-  vs |> List.iter (fun v ->
-    match get_desc v with
-    | Tunivar name ->
-       set_type_desc v (Tvar name)
-    | _ -> assert false);
-  vs
-
-
-type policy = Fixed | Extensible | Univars
-
-let rec transl_type env policy styp =
-=======
-let rec transl_type env ~policy ?(aliased=false) ~row_context styp =
->>>>>>> ocaml/5.1
+let rec transl_type env ~policy ?(aliased=false) ~row_context mode styp =
   Builtin_attributes.warning_scope styp.ptyp_attributes
-<<<<<<< HEAD
-    (fun () -> transl_type_aux env policy mode styp)
-||||||| merged common ancestors
-    (fun () -> transl_type_aux env policy styp)
-=======
-    (fun () -> transl_type_aux env ~policy ~aliased ~row_context styp)
->>>>>>> ocaml/5.1
+    (fun () -> transl_type_aux env ~policy ~aliased ~row_context mode styp)
 
-<<<<<<< HEAD
-and transl_type_aux env policy mode styp =
-||||||| merged common ancestors
-and transl_type_aux env policy styp =
-=======
-and transl_type_aux env ~row_context ~aliased ~policy styp =
->>>>>>> ocaml/5.1
+and transl_type_aux env ~row_context ~aliased ~policy mode styp =
   let loc = styp.ptyp_loc in
   let ctyp ctyp_desc ctyp_type =
     { ctyp_desc; ctyp_type; ctyp_env = env;
@@ -943,31 +597,21 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
   in
   match Jane_syntax.Core_type.of_ast styp with
   | Some (etyp, attrs) ->
-    let desc, typ = transl_type_aux_jst env policy mode attrs loc etyp in
+    let desc, typ =
+      transl_type_aux_jst env ~policy ~row_context mode attrs loc etyp
+    in
     ctyp desc typ
   | None ->
   match styp.ptyp_desc with
     Ptyp_any ->
-<<<<<<< HEAD
      let ty =
        TyVarEnv.new_anon_var loc env (Jkind.any ~why:Wildcard) policy
      in
      ctyp (Ttyp_var (None, None)) ty
-||||||| merged common ancestors
-      let ty =
-        if policy = Univars then new_pre_univar () else
-          if policy = Fixed then
-            raise (Error (styp.ptyp_loc, env, Unbound_type_variable "_"))
-          else newvar ()
-      in
-      ctyp Ttyp_any ty
-=======
-      let ty = TyVarEnv.new_any_var styp.ptyp_loc env policy in
-      ctyp Ttyp_any ty
->>>>>>> ocaml/5.1
   | Ptyp_var name ->
-<<<<<<< HEAD
-      let desc, typ = transl_type_var env policy styp.ptyp_loc name None in
+      let desc, typ =
+        transl_type_var env ~policy ~row_context styp.ptyp_loc name None
+      in
       ctyp desc typ
   | Ptyp_arrow _ ->
       let args, ret, ret_mode = extract_params styp in
@@ -975,7 +619,7 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
         match args with
         | (l, arg_mode, arg) :: rest ->
           check_arg_type arg;
-          let arg_cty = transl_type env policy arg_mode arg in
+          let arg_cty = transl_type env ~policy ~row_context arg_mode arg in
           let acc_mode =
             Alloc.Const.join
               (Alloc.Const.close_over arg_mode)
@@ -1027,64 +671,14 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
             newty (Tarrow(arrow_desc, arg_ty, ret_cty.ctyp_type, commu_ok))
           in
           ctyp (Ttyp_arrow (l, arg_cty, ret_cty)) ty
-        | [] -> transl_type env policy ret_mode ret
+        | [] -> transl_type env ~policy ~row_context ret_mode ret
       in
       loop mode args
-||||||| merged common ancestors
-    let ty =
-      if not (valid_tyvar_name name) then
-        raise (Error (styp.ptyp_loc, env, Invalid_variable_name ("'" ^ name)));
-      begin try
-        instance (List.assoc name !univars)
-      with Not_found -> try
-        instance (fst (TyVarMap.find name !used_variables))
-      with Not_found ->
-        let v =
-          if policy = Univars then new_pre_univar ~name () else newvar ~name ()
-        in
-        used_variables := TyVarMap.add name (v, styp.ptyp_loc) !used_variables;
-        v
-      end
-    in
-    ctyp (Ttyp_var name) ty
-  | Ptyp_arrow(l, st1, st2) ->
-    let cty1 = transl_type env policy st1 in
-    let cty2 = transl_type env policy st2 in
-    let ty1 = cty1.ctyp_type in
-    let ty1 =
-      if Btype.is_optional l
-      then newty (Tconstr(Predef.path_option,[ty1], ref Mnil))
-      else ty1 in
-    let ty = newty (Tarrow(l, ty1, cty2.ctyp_type, commu_ok)) in
-    ctyp (Ttyp_arrow (l, cty1, cty2)) ty
-=======
-    let ty =
-      if not (valid_tyvar_name name) then
-        raise (Error (styp.ptyp_loc, env, Invalid_variable_name ("'" ^ name)));
-      begin try
-        TyVarEnv.lookup_local ~row_context:row_context name
-      with Not_found ->
-        let v = TyVarEnv.new_var ~name policy in
-        TyVarEnv.remember_used name v styp.ptyp_loc;
-        v
-      end
-    in
-    ctyp (Ttyp_var name) ty
-  | Ptyp_arrow(l, st1, st2) ->
-    let cty1 = transl_type env ~policy ~row_context st1 in
-    let cty2 = transl_type env ~policy ~row_context st2 in
-    let ty1 = cty1.ctyp_type in
-    let ty1 =
-      if Btype.is_optional l
-      then newty (Tconstr(Predef.path_option,[ty1], ref Mnil))
-      else ty1 in
-    let ty = newty (Tarrow(l, ty1, cty2.ctyp_type, commu_ok)) in
-    ctyp (Ttyp_arrow (l, cty1, cty2)) ty
->>>>>>> ocaml/5.1
   | Ptyp_tuple stl ->
     assert (List.length stl >= 2);
-<<<<<<< HEAD
-    let ctys = List.map (transl_type env policy Alloc.Const.legacy) stl in
+    let ctys =
+      List.map (transl_type env ~policy ~row_context Alloc.Const.legacy) stl
+    in
     List.iter (fun {ctyp_type; ctyp_loc} ->
       (* CR layouts v5: remove value requirement *)
       match
@@ -1096,11 +690,6 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
         raise (Error(ctyp_loc, env,
                      Non_value {vloc = Tuple; err = e; typ = ctyp_type})))
       ctys;
-||||||| merged common ancestors
-    let ctys = List.map (transl_type env policy) stl in
-=======
-    let ctys = List.map (transl_type env ~policy ~row_context) stl in
->>>>>>> ocaml/5.1
     let ty = newty (Ttuple (List.map (fun ctyp -> ctyp.ctyp_type) ctys)) in
     ctyp (Ttyp_tuple ctys) ty
   | Ptyp_constr(lid, stl) ->
@@ -1115,13 +704,9 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
         raise(Error(styp.ptyp_loc, env,
                     Type_arity_mismatch(lid.txt, decl.type_arity,
                                         List.length stl)));
-<<<<<<< HEAD
-      let args = List.map (transl_type env policy Alloc.Const.legacy) stl in
-||||||| merged common ancestors
-      let args = List.map (transl_type env policy) stl in
-=======
-      let args = List.map (transl_type env ~policy ~row_context) stl in
->>>>>>> ocaml/5.1
+      let args =
+        List.map (transl_type env ~policy ~row_context Alloc.Const.legacy) stl
+      in
       let params = instance_list decl.type_params in
       let unify_param =
         match decl.type_manifest with
@@ -1151,17 +736,11 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
         raise(Error(styp.ptyp_loc, env,
                     Type_arity_mismatch(lid.txt, decl.type_arity,
                                         List.length stl)));
-<<<<<<< HEAD
-      let args = List.map (transl_type env policy Alloc.Const.legacy) stl in
-      let params = instance_list decl.type_params in
-||||||| merged common ancestors
-      let args = List.map (transl_type env policy) stl in
-      let params = instance_list decl.type_params in
-=======
-      let args = List.map (transl_type env ~policy ~row_context) stl in
+      let args =
+        List.map (transl_type env ~policy ~row_context Alloc.Const.legacy) stl
+      in
       let body = Option.get decl.type_manifest in
       let (params, body) = instance_parameterized_type decl.type_params body in
->>>>>>> ocaml/5.1
       List.iter2
         (fun (sty, cty) ty' ->
            try unify_var env ty' cty.ctyp_type with Unify err ->
@@ -1172,141 +751,19 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
       let ty_args = List.map (fun ctyp -> ctyp.ctyp_type) args in
       let ty = Ctype.apply ~use_current_level:true env params body ty_args in
       let ty = match get_desc ty with
-<<<<<<< HEAD
-        Tvariant row ->
-          let fields =
-            List.map
-              (fun (l,f) -> l,
-                match row_field_repr f with
-                | Rpresent oty -> rf_either_of oty
-                | _ -> f)
-              (row_fields row)
-          in
-          (* NB: row is always non-static here; more is thus never Tnil *)
-          let more =
-            TyVarEnv.new_var (Jkind.value ~why:Row_variable) policy
-          in
-          let row =
-            create_row ~fields ~more
-              ~closed:true ~fixed:None ~name:(Some (path, ty_args))
-          in
-          newty (Tvariant row)
-      | Tobject (fi, _) ->
-          let _, tv = flatten_fields fi in
-          TyVarEnv.add_pre_univar tv policy;
-          ty
-      | _ ->
-          assert false
-||||||| merged common ancestors
-        Tvariant row ->
-          let fields =
-            List.map
-              (fun (l,f) -> l,
-                match row_field_repr f with
-                | Rpresent oty -> rf_either_of oty
-                | _ -> f)
-              (row_fields row)
-          in
-          (* NB: row is always non-static here; more is thus never Tnil *)
-          let more =
-            if policy = Univars then new_pre_univar () else newvar () in
-          let row =
-            create_row ~fields ~more
-              ~closed:true ~fixed:None ~name:(Some (path, ty_args)) in
-          newty (Tvariant row)
-      | Tobject (fi, _) ->
-          let _, tv = flatten_fields fi in
-          if policy = Univars then pre_univars := tv :: !pre_univars;
-          ty
-      | _ ->
-          assert false
-=======
         | Tobject (fi, _) ->
             let _, tv = flatten_fields fi in
             TyVarEnv.add_pre_univar tv policy;
             ty
         | _ ->
             assert false
->>>>>>> ocaml/5.1
       in
       ctyp (Ttyp_class (path, lid, args)) ty
   | Ptyp_alias(st, alias) ->
-<<<<<<< HEAD
-    let desc, typ = transl_type_alias env policy mode loc st (Some alias) None in
+    let desc, typ =
+      transl_type_alias env ~policy ~row_context mode loc st (Some alias) None
+    in
     ctyp desc typ
-||||||| merged common ancestors
-      let cty =
-        try
-          let t =
-            try List.assoc alias !univars
-            with Not_found ->
-              instance (fst(TyVarMap.find alias !used_variables))
-          in
-          let ty = transl_type env policy st in
-          begin try unify_var env t ty.ctyp_type with Unify err ->
-            let err = Errortrace.swap_unification_error err in
-            raise(Error(styp.ptyp_loc, env, Alias_type_mismatch err))
-          end;
-          ty
-        with Not_found ->
-          if !Clflags.principal then begin_def ();
-          let t = newvar () in
-          used_variables :=
-            TyVarMap.add alias (t, styp.ptyp_loc) !used_variables;
-          let ty = transl_type env policy st in
-          begin try unify_var env t ty.ctyp_type with Unify err ->
-             let err = Errortrace.swap_unification_error err in
-            raise(Error(styp.ptyp_loc, env, Alias_type_mismatch err))
-          end;
-          if !Clflags.principal then begin
-            end_def ();
-            generalize_structure t;
-          end;
-          let t = instance t in
-          let px = Btype.proxy t in
-          begin match get_desc px with
-          | Tvar None -> set_type_desc px (Tvar (Some alias))
-          | Tunivar None -> set_type_desc px (Tunivar (Some alias))
-          | _ -> ()
-          end;
-          { ty with ctyp_type = t }
-      in
-      ctyp (Ttyp_alias (cty, alias)) cty.ctyp_type
-=======
-      let cty =
-        try
-          let t = TyVarEnv.lookup_local ~row_context alias in
-          let ty = transl_type env ~policy ~aliased:true ~row_context st in
-          begin try unify_var env t ty.ctyp_type with Unify err ->
-            let err = Errortrace.swap_unification_error err in
-            raise(Error(styp.ptyp_loc, env, Alias_type_mismatch err))
-          end;
-          ty
-        with Not_found ->
-          let t, ty =
-            with_local_level_if_principal begin fun () ->
-              let t = newvar () in
-              TyVarEnv.remember_used alias t styp.ptyp_loc;
-              let ty = transl_type env ~policy ~row_context st in
-              begin try unify_var env t ty.ctyp_type with Unify err ->
-                let err = Errortrace.swap_unification_error err in
-                raise(Error(styp.ptyp_loc, env, Alias_type_mismatch err))
-              end;
-              (t, ty)
-            end
-            ~post: (fun (t, _) -> generalize_structure t)
-          in
-          let t = instance t in
-          let px = Btype.proxy t in
-          begin match get_desc px with
-          | Tvar None -> set_type_desc px (Tvar (Some alias))
-          | Tunivar None -> set_type_desc px (Tunivar (Some alias))
-          | _ -> ()
-          end;
-          { ty with ctyp_type = t }
-      in
-      ctyp (Ttyp_alias (cty, alias)) cty.ctyp_type
->>>>>>> ocaml/5.1
   | Ptyp_variant(fields, closed, present) ->
       let name = ref None in
       let mkfield l f =
@@ -1336,14 +793,10 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
             name := None;
             let tl =
               Builtin_attributes.warning_scope rf_attributes
-<<<<<<< HEAD
                 (fun () ->
-                   List.map (transl_type env policy Alloc.Const.legacy) stl)
-||||||| merged common ancestors
-                (fun () -> List.map (transl_type env policy) stl)
-=======
-                (fun () -> List.map (transl_type env ~policy ~row_context) stl)
->>>>>>> ocaml/5.1
+                   List.map
+                     (transl_type env ~policy ~row_context Alloc.Const.legacy)
+                     stl)
             in
             List.iter (fun {ctyp_type; ctyp_loc} ->
               (* CR layouts: at some point we'll allow different jkinds in
@@ -1372,13 +825,9 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
             add_typed_field styp.ptyp_loc l.txt f;
               Ttag (l,c,tl)
         | Rinherit sty ->
-<<<<<<< HEAD
-          let cty = transl_type env policy Alloc.Const.legacy sty in
-||||||| merged common ancestors
-            let cty = transl_type env policy sty in
-=======
-            let cty = transl_type env ~policy ~row_context sty in
->>>>>>> ocaml/5.1
+            let cty =
+              transl_type env ~policy ~row_context Alloc.Const.legacy sty
+            in
             let ty = cty.ctyp_type in
             let nm =
               match get_desc cty.ctyp_type with
@@ -1428,65 +877,21 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
         create_row ~fields ~more ~closed:(closed = Closed) ~fixed:None ~name
       in
       let more =
-<<<<<<< HEAD
         if Btype.static_row
              (make_row (newvar (Jkind.value ~why:Row_variable)))
         then newty Tnil
         else TyVarEnv.new_var (Jkind.value ~why:Row_variable) policy
-||||||| merged common ancestors
-        if Btype.static_row (make_row (newvar ())) then newty Tnil else
-        if policy = Univars then new_pre_univar () else newvar ()
-=======
-        if Btype.static_row (make_row (newvar ())) then newty Tnil else
-           TyVarEnv.new_var policy
->>>>>>> ocaml/5.1
       in
       more_slot := Some more;
       let ty = newty (Tvariant (make_row more)) in
       ctyp (Ttyp_variant (tfields, closed, present)) ty
   | Ptyp_poly(vars, st) ->
-<<<<<<< HEAD
       let desc, typ =
-        transl_type_poly env policy mode styp.ptyp_loc (Either.Left vars) st
+        transl_type_poly env ~policy ~row_context mode styp.ptyp_loc
+          (Either.Left vars) st
       in
       ctyp desc typ
-||||||| merged common ancestors
-      let vars = List.map (fun v -> v.txt) vars in
-      begin_def();
-      let new_univars = make_poly_univars vars in
-      let old_univars = !univars in
-      univars := new_univars @ !univars;
-      let cty = transl_type env policy st in
-      let ty = cty.ctyp_type in
-      univars := old_univars;
-      end_def();
-      generalize ty;
-      let ty_list = check_poly_univars env styp.ptyp_loc new_univars in
-      let ty_list = List.filter (fun v -> deep_occur v ty) ty_list in
-      let ty' = Btype.newgenty (Tpoly(ty, ty_list)) in
-      unify_var env (newvar()) ty';
-      ctyp (Ttyp_poly (vars, cty)) ty'
-=======
-      let vars = List.map (fun v -> v.txt) vars in
-      let new_univars, cty =
-        with_local_level begin fun () ->
-          let new_univars = TyVarEnv.make_poly_univars vars in
-          let cty = TyVarEnv.with_univars new_univars begin fun () ->
-            transl_type env ~policy ~row_context st
-          end in
-          (new_univars, cty)
-        end
-        ~post:(fun (_,cty) -> generalize_ctyp cty)
-      in
-      let ty = cty.ctyp_type in
-      let ty_list = TyVarEnv.check_poly_univars env styp.ptyp_loc new_univars in
-      let ty_list = List.filter (fun v -> deep_occur v ty) ty_list in
-      let ty' = Btype.newgenty (Tpoly(ty, ty_list)) in
-      unify_var env (newvar()) ty';
-      ctyp (Ttyp_poly (vars, cty)) ty'
->>>>>>> ocaml/5.1
   | Ptyp_package (p, l) ->
-<<<<<<< HEAD
     (* CR layouts: right now we're doing a real gross hack where we demand
        everything in a package type with constraint be value.
 
@@ -1497,30 +902,16 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
     *)
     (* CR layouts: and in the long term, rewrite all of this to eliminate
        the [create_package_mty] hack that constructs fake source code. *)
-      let l, mty = create_package_mty true styp.ptyp_loc env (p, l) in
-      let mty = TyVarEnv.with_local_scope (fun () -> !transl_modtype env mty) in
-||||||| merged common ancestors
-      let l, mty = create_package_mty true styp.ptyp_loc env (p, l) in
-      let z = narrow () in
-      let mty = !transl_modtype env mty in
-      widen z;
-=======
       let loc = styp.ptyp_loc in
       let l = sort_constraints_no_duplicates loc env l in
       let mty = create_package_mty loc p l in
       let mty =
         TyVarEnv.with_local_scope (fun () -> !transl_modtype env mty) in
->>>>>>> ocaml/5.1
-      let ptys = List.map (fun (s, pty) ->
-<<<<<<< HEAD
-                             s, transl_type env policy Alloc.Const.legacy pty
-||||||| merged common ancestors
-                             s, transl_type env policy pty
-=======
-                             s, transl_type env ~policy ~row_context pty
->>>>>>> ocaml/5.1
-                          ) l in
-<<<<<<< HEAD
+      let ptys =
+        List.map (fun (s, pty) ->
+          s, transl_type env ~policy ~row_context Alloc.Const.legacy pty
+        ) l
+      in
       List.iter (fun (s,{ctyp_type=ty}) ->
         match
           Ctype.constrain_type_jkind env ty (Jkind.value ~why:Package_hack)
@@ -1530,12 +921,7 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
           raise (Error(s.loc,env,
                        Non_value {vloc=Package_constraint; typ=ty; err=e})))
         ptys;
-      let path = !transl_modtype_longident styp.ptyp_loc env p.txt in
-||||||| merged common ancestors
-      let path = !transl_modtype_longident styp.ptyp_loc env p.txt in
-=======
       let path = !transl_modtype_longident loc env p.txt in
->>>>>>> ocaml/5.1
       let ty = newty (Tpackage (path,
                        List.map (fun (s, cty) -> (s.txt, cty.ctyp_type)) ptys))
       in
@@ -1548,31 +934,33 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
   | Ptyp_extension ext ->
       raise (Error_forward (Builtin_attributes.error_of_extension ext))
 
-<<<<<<< HEAD
-and transl_type_aux_jst env policy mode _attrs loc :
+and transl_type_aux_jst env ~policy ~row_context mode _attrs loc :
       Jane_syntax.Core_type.t -> _ = function
-  | Jtyp_layout typ -> transl_type_aux_jst_layout env policy mode loc typ
+  | Jtyp_layout typ ->
+    transl_type_aux_jst_layout env ~policy ~row_context mode loc typ
 
-and transl_type_aux_jst_layout env policy mode loc :
+and transl_type_aux_jst_layout env ~policy ~row_context mode loc :
       Jane_syntax.Layouts.core_type -> _ = function
   | Ltyp_var { name = None; jkind } ->
     let tjkind = Jkind.of_annotation ~context:(Type_wildcard loc) jkind in
     Ttyp_var (None, Some jkind.txt),
     TyVarEnv.new_anon_var loc env tjkind policy
   | Ltyp_var { name = Some name; jkind } ->
-    transl_type_var env policy loc name (Some jkind)
+    transl_type_var env ~policy ~row_context loc name (Some jkind)
   | Ltyp_poly { bound_vars; inner_type } ->
-    transl_type_poly env policy mode loc (Either.Right bound_vars) inner_type
+    transl_type_poly env ~policy ~row_context mode loc (Either.Right bound_vars)
+      inner_type
   | Ltyp_alias { aliased_type; name; jkind } ->
-    transl_type_alias env policy mode loc aliased_type name (Some jkind)
+    transl_type_alias env ~policy ~row_context mode loc aliased_type name
+      (Some jkind)
 
-and transl_type_var env policy loc name jkind_annot_opt =
+and transl_type_var env ~policy ~row_context loc name jkind_annot_opt =
   let print_name = "'" ^ name in
   if not (valid_tyvar_name name) then
     raise (Error (loc, env, Invalid_variable_name print_name));
   let of_annot = Jkind.of_annotation ~context:(Type_variable print_name) in
   let ty = try
-      let ty = TyVarEnv.lookup_local name in
+      let ty = TyVarEnv.lookup_local ~row_context name in
       begin match jkind_annot_opt with
       | None -> ()
       | Some jkind_annot ->
@@ -1594,27 +982,34 @@ and transl_type_var env policy loc name jkind_annot_opt =
   in
   Ttyp_var (Some name, Option.map Location.get_txt jkind_annot_opt), ty
 
-and transl_type_poly env policy mode loc (vars : (_, _) Either.t) st =
-  begin_def();
-  let typed_vars, new_univars = transl_bound_vars vars in
-  let cty = TyVarEnv.with_univars new_univars begin fun () ->
-    transl_type env policy mode st
-  end in
+and transl_type_poly env ~policy ~row_context mode loc (vars : (_, _) Either.t)
+      st =
+  let typed_vars, new_univars, cty =
+    with_local_level begin fun () ->
+      let typed_vars, new_univars = transl_bound_vars vars in
+      let cty = TyVarEnv.with_univars new_univars begin fun () ->
+        transl_type env ~policy ~row_context mode st
+      end in
+      (typed_vars, new_univars, cty)
+    end
+      ~post:(fun (_,_,cty) -> generalize_ctyp cty)
+  in
   let ty = cty.ctyp_type in
-  end_def();
-  generalize ty;
   let ty_list = TyVarEnv.check_poly_univars env loc new_univars in
   let ty_list = List.filter (fun v -> deep_occur v ty) ty_list in
   let ty' = Btype.newgenty (Tpoly(ty, ty_list)) in
   unify_var env (newvar (Jkind.any ~why:Dummy_jkind)) ty';
   Ttyp_poly (typed_vars, cty), ty'
 
-and transl_type_alias env policy mode alias_loc styp name_opt jkind_annot_opt =
+and transl_type_alias env ~row_context ~policy mode alias_loc styp name_opt
+      jkind_annot_opt =
   let cty = match name_opt with
     | Some alias ->
       begin try
-        let t = TyVarEnv.lookup_local alias in
-        let cty = transl_type env policy mode styp in
+        let t = TyVarEnv.lookup_local ~row_context alias in
+        let cty =
+          transl_type env ~policy ~aliased:true ~row_context mode styp
+        in
         begin try unify_var env t cty.ctyp_type with Unify err ->
           let err = Errortrace.swap_unification_error err in
           raise(Error(alias_loc, env, Alias_type_mismatch err))
@@ -1633,24 +1028,25 @@ and transl_type_alias env policy mode alias_loc styp name_opt jkind_annot_opt =
         end;
         cty
       with Not_found ->
-        if !Clflags.principal then begin_def ();
-        let jkind =
-          Jkind.(of_annotation_option_default
-            ~default:(any ~why:Dummy_jkind)
-            ~context:(Type_variable alias)
-            jkind_annot_opt)
+        let t, ty =
+          with_local_level_if_principal begin fun () ->
+            let jkind =
+              Jkind.(of_annotation_option_default
+                ~default:(any ~why:Dummy_jkind)
+                ~context:(Type_variable alias)
+                jkind_annot_opt)
+            in
+            let t = newvar jkind in
+            TyVarEnv.remember_used alias t alias_loc;
+            let ty = transl_type env ~policy ~row_context mode styp in
+            begin try unify_var env t ty.ctyp_type with Unify err ->
+              let err = Errortrace.swap_unification_error err in
+              raise(Error(alias_loc, env, Alias_type_mismatch err))
+            end;
+            (t, ty)
+          end
+          ~post: (fun (t, _) -> generalize_structure t)
         in
-        let t = newvar jkind in
-        TyVarEnv.remember_used alias t alias_loc;
-        let cty = transl_type env policy mode styp in
-        begin try unify_var env t cty.ctyp_type with Unify err ->
-          let err = Errortrace.swap_unification_error err in
-          raise(Error(alias_loc, env, Alias_type_mismatch err))
-        end;
-        if !Clflags.principal then begin
-          end_def ();
-          generalize_structure t;
-        end;
         let t = instance t in
         let px = Btype.proxy t in
         begin match get_desc px with
@@ -1660,10 +1056,10 @@ and transl_type_alias env policy mode alias_loc styp name_opt jkind_annot_opt =
            set_type_desc px (Tunivar {name = Some alias; jkind})
         | _ -> ()
         end;
-        { cty with ctyp_type = t }
+        { ty with ctyp_type = t }
       end
     | None ->
-      let cty = transl_type env policy mode styp in
+      let cty = transl_type env ~policy ~row_context mode styp in
       let cty_expr = cty.ctyp_type in
       let jkind_annot = match jkind_annot_opt with
         | None -> Misc.fatal_error "anonymous alias without layout annotation"
@@ -1684,12 +1080,7 @@ and transl_type_alias env policy mode alias_loc styp name_opt jkind_annot_opt =
   Ttyp_alias (cty, name_opt, Option.map Location.get_txt jkind_annot_opt),
   cty.ctyp_type
 
-and transl_fields env policy o fields =
-||||||| merged common ancestors
-and transl_fields env policy o fields =
-=======
 and transl_fields env ~policy ~row_context o fields =
->>>>>>> ocaml/5.1
   let hfields = Hashtbl.create 17 in
   let add_typed_field loc l ty =
     try
@@ -1707,16 +1098,8 @@ and transl_fields env ~policy ~row_context o fields =
     | Otag (s, ty1) -> begin
         let ty1 =
           Builtin_attributes.warning_scope of_attributes
-<<<<<<< HEAD
-            (fun () ->
-               transl_type env policy Alloc.Const.legacy
-                 (Ast_helper.Typ.force_poly ty1))
-||||||| merged common ancestors
-            (fun () -> transl_type env policy (Ast_helper.Typ.force_poly ty1))
-=======
-            (fun () -> transl_type env ~policy ~row_context
+            (fun () -> transl_type env ~policy ~row_context Alloc.Const.legacy
                 (Ast_helper.Typ.force_poly ty1))
->>>>>>> ocaml/5.1
         in
         begin
           match
@@ -1734,13 +1117,7 @@ and transl_fields env ~policy ~row_context o fields =
         field
       end
     | Oinherit sty -> begin
-<<<<<<< HEAD
-        let cty = transl_type env policy Alloc.Const.legacy sty in
-||||||| merged common ancestors
-        let cty = transl_type env policy sty in
-=======
-        let cty = transl_type env ~policy ~row_context sty in
->>>>>>> ocaml/5.1
+        let cty = transl_type env ~policy ~row_context Alloc.Const.legacy sty in
         let nm =
           match get_desc cty.ctyp_type with
             Tconstr(p, _, _) -> Some p
@@ -1774,16 +1151,7 @@ and transl_fields env ~policy ~row_context o fields =
   let ty_init =
      match o with
      | Closed -> newty Tnil
-<<<<<<< HEAD
      | Open -> TyVarEnv.new_var (Jkind.value ~why:Row_variable) policy
-||||||| merged common ancestors
-     match o, policy with
-     | Closed, _ -> newty Tnil
-     | Open, Univars -> new_pre_univar ()
-     | Open, _ -> newvar () in
-=======
-     | Open -> TyVarEnv.new_var policy
->>>>>>> ocaml/5.1
   in
   let ty = List.fold_left (fun ty (s, ty') ->
       newty (Tfield (s, field_public, ty', ty))) ty_init fields in
@@ -1813,145 +1181,42 @@ let rec make_fixed_univars ty =
         Btype.iter_type_expr make_fixed_univars ty
     end
 
-let transl_type env policy styp =
-  transl_type env ~policy ~row_context:[] styp
+let transl_type env policy mode styp =
+  transl_type env ~policy ~row_context:[] mode styp
 
 let make_fixed_univars ty =
   make_fixed_univars ty;
   Btype.unmark_type ty
 
-<<<<<<< HEAD
-let create_package_mty = create_package_mty false
-
 let transl_simple_type env ?univars ~closed mode styp =
   TyVarEnv.reset_locals ?univars ();
   let policy = TyVarEnv.(if closed then fixed_policy else extensible_policy) in
   let typ = transl_type env policy mode styp in
-||||||| merged common ancestors
-let create_package_mty = create_package_mty false
-
-let globalize_used_variables env fixed =
-  let r = ref [] in
-  TyVarMap.iter
-    (fun name (ty, loc) ->
-      let v = new_global_var () in
-      let snap = Btype.snapshot () in
-      if try unify env v ty; true with _ -> Btype.backtrack snap; false
-      then try
-        r := (loc, v,  TyVarMap.find name !type_variables) :: !r
-      with Not_found ->
-        if fixed && Btype.is_Tvar ty then
-          raise(Error(loc, env, Unbound_type_variable ("'"^name)));
-        let v2 = new_global_var () in
-        r := (loc, v, v2) :: !r;
-        type_variables := TyVarMap.add name v2 !type_variables)
-    !used_variables;
-  used_variables := TyVarMap.empty;
-  fun () ->
-    List.iter
-      (function (loc, t1, t2) ->
-        try unify env t1 t2 with Unify err ->
-          raise (Error(loc, env, Type_mismatch err)))
-      !r
-
-let transl_simple_type env ?univars:(uvs=[]) fixed styp =
-  univars := uvs; used_variables := TyVarMap.empty;
-  let typ = transl_type env (if fixed then Fixed else Extensible) styp in
-  globalize_used_variables env fixed ();
-=======
-let transl_simple_type env ?univars ~closed styp =
-  TyVarEnv.reset_locals ?univars ();
-  let policy = TyVarEnv.(if closed then fixed_policy else extensible_policy) in
-  let typ = transl_type env policy styp in
->>>>>>> ocaml/5.1
   TyVarEnv.globalize_used_variables policy env ();
   make_fixed_univars typ.ctyp_type;
   typ
 
 let transl_simple_type_univars env styp =
   TyVarEnv.reset_locals ();
-<<<<<<< HEAD
-  let typ, univs = TyVarEnv.collect_univars begin fun () ->
-    begin_def ();
-    let policy = TyVarEnv.univars_policy in
-    let typ = transl_type env policy Alloc.Const.legacy styp in
-    TyVarEnv.globalize_used_variables policy env ();
-    end_def ();
-    generalize typ.ctyp_type;
-    typ
-||||||| merged common ancestors
-  univars := []; used_variables := TyVarMap.empty; pre_univars := [];
-  begin_def ();
-  let typ = transl_type env Univars styp in
-  (* Only keep already global variables in used_variables *)
-  let new_variables = !used_variables in
-  used_variables := TyVarMap.empty;
-  TyVarMap.iter
-    (fun name p ->
-      if TyVarMap.mem name !type_variables then
-        used_variables := TyVarMap.add name p !used_variables)
-    new_variables;
-  globalize_used_variables env false ();
-  end_def ();
-  generalize typ.ctyp_type;
-  let univs =
-    List.fold_left
-      (fun acc v ->
-        match get_desc v with
-          Tvar name when get_level v = Btype.generic_level ->
-            set_type_desc v (Tunivar name); v :: acc
-        | _ -> acc)
-      [] !pre_univars
-  in
-=======
   let typ, univs =
     TyVarEnv.collect_univars begin fun () ->
       with_local_level ~post:generalize_ctyp begin fun () ->
         let policy = TyVarEnv.univars_policy in
-        let typ = transl_type env policy styp in
+        let typ = transl_type env policy Alloc.Const.legacy styp in
         TyVarEnv.globalize_used_variables policy env ();
         typ
       end
->>>>>>> ocaml/5.1
   end in
   make_fixed_univars typ.ctyp_type;
     { typ with ctyp_type =
         instance (Btype.newgenty (Tpoly (typ.ctyp_type, univs))) }
 
-<<<<<<< HEAD
 let transl_simple_type_delayed env mode styp =
-  TyVarEnv.reset_locals ();
-  begin_def ();
-  let policy = TyVarEnv.extensible_policy in
-  let typ = transl_type env policy mode styp in
-  end_def ();
-  make_fixed_univars typ.ctyp_type;
-  (* This brings the used variables to the global level, but doesn't link them
-     to their other occurrences just yet. This will be done when [force] is
-     called. *)
-  let force = TyVarEnv.globalize_used_variables policy env in
-  (* Generalizes everything except the variables that were just globalized. *)
-  generalize typ.ctyp_type;
-||||||| merged common ancestors
-let transl_simple_type_delayed env styp =
-  univars := []; used_variables := TyVarMap.empty;
-  begin_def ();
-  let typ = transl_type env Extensible styp in
-  end_def ();
-  make_fixed_univars typ.ctyp_type;
-  (* This brings the used variables to the global level, but doesn't link them
-     to their other occurrences just yet. This will be done when [force] is
-     called. *)
-  let force = globalize_used_variables env false in
-  (* Generalizes everything except the variables that were just globalized. *)
-  generalize typ.ctyp_type;
-=======
-let transl_simple_type_delayed env styp =
   TyVarEnv.reset_locals ();
   let typ, force =
     with_local_level begin fun () ->
       let policy = TyVarEnv.extensible_policy in
-      let typ = transl_type env policy styp in
+      let typ = transl_type env policy mode styp in
       make_fixed_univars typ.ctyp_type;
       (* This brings the used variables to the global level, but doesn't link
          them to their other occurrences just yet. This will be done when
@@ -1962,29 +1227,36 @@ let transl_simple_type_delayed env styp =
     (* Generalize everything except the variables that were just globalized. *)
     ~post:(fun (typ,_) -> generalize_ctyp typ)
   in
->>>>>>> ocaml/5.1
   (typ, instance typ.ctyp_type, force)
 
 let transl_type_scheme_mono env styp =
-  begin_def();
-  let typ = transl_simple_type env ~closed:false Alloc.Const.legacy styp in
-  end_def();
+  let typ =
+    with_local_level begin fun () ->
+      TyVarEnv.reset ();
+      transl_simple_type env ~closed:false Alloc.Const.legacy styp
+    end
+    ~post:generalize_ctyp
+  in
   (* This next line is very important: it stops [val] and [external]
      declarations from having undefaulted jkind variables. Without
      this line, we might accidentally export a jkind-flexible definition
      from a compilation unit, which would lead to miscompilation. *)
   remove_mode_and_jkind_variables typ.ctyp_type;
-  generalize typ.ctyp_type;
   typ
 
 let transl_type_scheme_poly env attrs loc vars inner_type =
-  begin_def();
-  let typed_vars, univars = transl_bound_vars vars in
-  let typ =
-    transl_simple_type env ~univars ~closed:true Alloc.Const.legacy inner_type
+  let typed_vars, univars, typ =
+    with_local_level begin fun () ->
+      TyVarEnv.reset ();
+      let typed_vars, univars = transl_bound_vars vars in
+      let typ =
+        transl_simple_type env ~univars ~closed:true Alloc.Const.legacy
+          inner_type
+      in
+      (typed_vars, univars, typ)
+    end
+    ~post:(fun (_,_,typ) -> generalize_ctyp typ)
   in
-  end_def();
-  generalize typ.ctyp_type;
   let _ = TyVarEnv.instance_poly_univars env loc univars in
   { ctyp_desc = Ttyp_poly (typed_vars, typ);
     ctyp_type = typ.ctyp_type;
@@ -2000,68 +1272,16 @@ let transl_type_scheme_jst env styp attrs loc : Jane_syntax.Core_type.t -> _ =
     transl_type_scheme_mono env styp
 
 let transl_type_scheme env styp =
-<<<<<<< HEAD
-  TyVarEnv.reset ();
   match Jane_syntax.Core_type.of_ast styp with
   | Some (etyp, attrs) ->
     transl_type_scheme_jst env styp attrs styp.ptyp_loc etyp
   | None ->
-||||||| merged common ancestors
-  reset_type_variables();
-=======
->>>>>>> ocaml/5.1
   match styp.ptyp_desc with
   | Ptyp_poly (vars, st) ->
-<<<<<<< HEAD
     transl_type_scheme_poly env styp.ptyp_attributes
       styp.ptyp_loc (Either.Left vars) st
-||||||| merged common ancestors
-     begin_def();
-     let vars = List.map (fun v -> v.txt) vars in
-     let univars = make_poly_univars vars in
-     let typ = transl_simple_type env ~univars true st in
-     end_def();
-     generalize typ.ctyp_type;
-     let _ = instance_poly_univars env styp.ptyp_loc univars in
-     { ctyp_desc = Ttyp_poly (vars, typ);
-       ctyp_type = typ.ctyp_type;
-       ctyp_env = env;
-       ctyp_loc = styp.ptyp_loc;
-       ctyp_attributes = styp.ptyp_attributes }
-=======
-     let vars = List.map (fun v -> v.txt) vars in
-     let univars, typ =
-       with_local_level begin fun () ->
-         TyVarEnv.reset ();
-         let univars = TyVarEnv.make_poly_univars vars in
-         let typ = transl_simple_type env ~univars ~closed:true st in
-         (univars, typ)
-       end
-       ~post:(fun (_,typ) -> generalize_ctyp typ)
-     in
-     let _ = TyVarEnv.instance_poly_univars env styp.ptyp_loc univars in
-     { ctyp_desc = Ttyp_poly (vars, typ);
-       ctyp_type = typ.ctyp_type;
-       ctyp_env = env;
-       ctyp_loc = styp.ptyp_loc;
-       ctyp_attributes = styp.ptyp_attributes }
->>>>>>> ocaml/5.1
   | _ ->
-<<<<<<< HEAD
     transl_type_scheme_mono env styp
-||||||| merged common ancestors
-     begin_def();
-     let typ = transl_simple_type env false styp in
-     end_def();
-     generalize typ.ctyp_type;
-     typ
-
-=======
-      with_local_level
-        (fun () -> TyVarEnv.reset (); transl_simple_type env ~closed:false styp)
-        ~post:generalize_ctyp
-
->>>>>>> ocaml/5.1
 
 (* Error report *)
 


### PR DESCRIPTION
Nothing particularly notable.
- Most `typetexp` conflicts are due to upstream refactors that have been half backported (plus modes).
- Most `env` conflicts are due to laziness changes on lines where we also backported shape changes.

Review: @lpw25 