### PR TITLE
Resolving conflicts in bytecomp/

### DIFF
--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -109,15 +109,9 @@ let rec is_tailcall = function
    from the tail call optimization? *)
 
 let preserve_tailcall_for_prim = function
-<<<<<<< HEAD
     Popaque _ | Psequor | Psequand
-  | Pobj_magic _ ->
-||||||| merged common ancestors
-  | Popaque | Psequor | Psequand ->
-=======
-  | Popaque | Psequor | Psequand
+  | Pobj_magic _
   | Prunstack | Pperform | Presume | Preperform ->
->>>>>>> ocaml/5.1
       true
   | Pbytes_to_string | Pbytes_of_string
   | Parray_to_iarray | Parray_of_iarray
@@ -146,16 +140,10 @@ let preserve_tailcall_for_prim = function
   | Pbytes_load_32 _ | Pbytes_load_64 _ | Pbytes_set_16 _ | Pbytes_set_32 _
   | Pbytes_set_64 _ | Pbigstring_load_16 _ | Pbigstring_load_32 _
   | Pbigstring_load_64 _ | Pbigstring_set_16 _ | Pbigstring_set_32 _
-<<<<<<< HEAD
   | Pprobe_is_enabled _ | Pobj_dup
-  | Pbigstring_set_64 _ | Pctconst _ | Pbswap16 | Pbbswap _ | Pint_as_pointer _ ->
-||||||| merged common ancestors
-  | Pbigstring_set_64 _ | Pctconst _ | Pbswap16 | Pbbswap _ | Pint_as_pointer ->
-=======
-  | Pbigstring_set_64 _ | Pctconst _ | Pbswap16 | Pbbswap _ | Pint_as_pointer
+  | Pbigstring_set_64 _ | Pctconst _ | Pbswap16 | Pbbswap _ | Pint_as_pointer _
   | Patomic_exchange | Patomic_cas | Patomic_fetch_add | Patomic_load _
   | Pdls_get ->
->>>>>>> ocaml/5.1
       false
 
 (* Add a Kpop N instruction in front of a continuation *)
@@ -437,16 +425,8 @@ let comp_primitive stack_info p sz args =
   | Pcompare_ints -> Kccall("caml_int_compare", 2)
   | Pcompare_floats -> Kccall("caml_float_compare", 2)
   | Pcompare_bints bi -> comp_bint_primitive bi "compare" args
-<<<<<<< HEAD
-  | Pfield (n, _sem) -> Kgetfield n
+  | Pfield (n, _ptr, _sem) -> Kgetfield n
   | Pfield_computed _sem -> Kgetvectitem
-||||||| merged common ancestors
-  | Pfield n -> Kgetfield n
-  | Pfield_computed -> Kgetvectitem
-=======
-  | Pfield(n, _ptr, _mut) -> Kgetfield n
-  | Pfield_computed -> Kgetvectitem
->>>>>>> ocaml/5.1
   | Psetfield(n, _ptr, _init) -> Ksetfield n
   | Psetfield_computed(_ptr, _init) -> Ksetvectitem
   | Pfloatfield (n, _sem, _mode) -> Kgetfloatfield n
@@ -575,30 +555,20 @@ let comp_primitive stack_info p sz args =
   | Pint_as_pointer _ -> Kccall("caml_int_as_pointer", 1)
   | Pbytes_to_string -> Kccall("caml_string_of_bytes", 1)
   | Pbytes_of_string -> Kccall("caml_bytes_of_string", 1)
-<<<<<<< HEAD
   | Parray_to_iarray -> Kccall("caml_iarray_of_array", 1)
   | Parray_of_iarray -> Kccall("caml_array_of_iarray", 1)
   | Pget_header _ -> Kccall("caml_get_header", 1)
   | Pobj_dup -> Kccall("caml_obj_dup", 1)
-||||||| merged common ancestors
-=======
   | Patomic_load _ -> Kccall("caml_atomic_load", 1)
   | Patomic_exchange -> Kccall("caml_atomic_exchange", 2)
   | Patomic_cas -> Kccall("caml_atomic_cas", 3)
   | Patomic_fetch_add -> Kccall("caml_atomic_fetch_add", 2)
   | Pdls_get -> Kccall("caml_domain_dls_get", 1)
->>>>>>> ocaml/5.1
   (* The cases below are handled in [comp_expr] before the [comp_primitive] call
      (in the order in which they appear below),
      so they should never be reached in this function. *)
-<<<<<<< HEAD
-  | Pignore | Popaque _ | Pobj_magic _
-||||||| merged common ancestors
-  | Pignore | Popaque
-=======
   | Prunstack | Presume | Preperform
-  | Pignore | Popaque
->>>>>>> ocaml/5.1
+  | Pignore | Popaque _ | Pobj_magic _
   | Pnot | Psequand | Psequor
   | Praise _
   | Pmakearray _ | Pduparray _
@@ -654,19 +624,9 @@ let rec comp_expr stack_info env exp sz cont =
       Kconst cst :: cont
   | Lapply{ap_func = func; ap_args = args; ap_region_close = rc} ->
       let nargs = List.length args in
-<<<<<<< HEAD
       if is_tailcall cont && not (is_nontail rc) then begin
-        comp_args env args sz
-          (Kpush :: comp_expr env func (sz + nargs)
-||||||| merged common ancestors
-      if is_tailcall cont then begin
-        comp_args env args sz
-          (Kpush :: comp_expr env func (sz + nargs)
-=======
-      if is_tailcall cont then begin
         comp_args stack_info env args sz
           (Kpush :: comp_expr stack_info env func (sz + nargs)
->>>>>>> ocaml/5.1
             (Kappterm(nargs, sz + nargs) :: discard_dead_code cont))
       end else begin
         if nargs < 4 then
@@ -690,16 +650,8 @@ let rec comp_expr stack_info env exp sz cont =
           Lconst(Const_base(Const_int n)) -> (Kgetpubmet n, obj::args)
         | _ -> (Kgetdynmet, met::obj::args)
       in
-<<<<<<< HEAD
       if is_tailcall cont && not (is_nontail rc) then
-        comp_args env args' sz
-||||||| merged common ancestors
-      if is_tailcall cont then
-        comp_args env args' sz
-=======
-      if is_tailcall cont then
         comp_args stack_info env args' sz
->>>>>>> ocaml/5.1
           (getmethod :: Kappterm(nargs, sz + nargs) :: discard_dead_code cont)
       else
         if nargs < 4 then
@@ -802,20 +754,12 @@ let rec comp_expr stack_info env exp sz cont =
         in
         comp_init env sz decl_size
       end
-<<<<<<< HEAD
   | Lprim((Popaque _ | Pobj_magic _), [arg], _) ->
-      comp_expr env arg sz cont
-  | Lprim((Pbox_float _ | Punbox_float), [arg], _) ->
-      comp_expr env arg sz cont
-  | Lprim((Pbox_int _ | Punbox_int _), [arg], _) ->
-      comp_expr env arg sz cont
-||||||| merged common ancestors
-  | Lprim(Popaque, [arg], _) ->
-      comp_expr env arg sz cont
-=======
-  | Lprim(Popaque, [arg], _) ->
       comp_expr stack_info env arg sz cont
->>>>>>> ocaml/5.1
+  | Lprim((Pbox_float _ | Punbox_float), [arg], _) ->
+      comp_expr stack_info env arg sz cont
+  | Lprim((Pbox_int _ | Punbox_int _), [arg], _) ->
+      comp_expr stack_info env arg sz cont
   | Lprim(Pignore, [arg], _) ->
       comp_expr stack_info env arg sz (add_const_unit cont)
   | Lprim(Pnot, [arg], _) ->
@@ -871,7 +815,8 @@ let rec comp_expr stack_info env exp sz cont =
       (* In bytecode, float# is boxed, so we can treat these two primitives the
          same. *)
       let cont = add_pseudo_event loc !compunit_name cont in
-      comp_args env args sz (Kmakefloatblock (List.length args) :: cont)
+      comp_args stack_info env args sz
+        (Kmakefloatblock (List.length args) :: cont)
   | Lprim(Pmakearray (kind, _, _), args, loc) ->
       let cont = add_pseudo_event loc !compunit_name cont in
       begin match kind with
@@ -910,14 +855,8 @@ let rec comp_expr stack_info env exp sz cont =
   | Lprim (Pduparray (kind, mutability),
            [Lprim (Pmakearray (kind',_,m),args,_)], loc) ->
       assert (kind = kind');
-<<<<<<< HEAD
-      comp_expr env (Lprim (Pmakearray (kind, mutability, m), args, loc)) sz cont
-||||||| merged common ancestors
-      comp_expr env (Lprim (Pmakearray (kind, mutability), args, loc)) sz cont
-=======
       comp_expr stack_info env
-        (Lprim (Pmakearray (kind, mutability), args, loc)) sz cont
->>>>>>> ocaml/5.1
+        (Lprim (Pmakearray (kind, mutability, m), args, loc)) sz cont
   | Lprim (Pduparray _, [arg], loc) ->
       let prim_obj_dup =
         Primitive.simple_on_values ~name:"caml_obj_dup" ~arity:1 ~alloc:true
@@ -946,43 +885,19 @@ let rec comp_expr stack_info env exp sz cont =
         | CFge -> Kccall("caml_ge_float", 2) :: cont
         | CFnge -> Kccall("caml_ge_float", 2) :: Kboolnot :: cont
       in
-<<<<<<< HEAD
-      comp_args env args sz cont
-  | Lprim(Pmakeblock(tag, _mut, _, _), args, loc) ->
-||||||| merged common ancestors
-      comp_args env args sz cont
-  | Lprim(Pmakeblock(tag, _mut, _), args, loc) ->
-=======
       comp_args stack_info env args sz cont
-  | Lprim(Pmakeblock(tag, _mut, _), args, loc) ->
->>>>>>> ocaml/5.1
+  | Lprim(Pmakeblock(tag, _mut, _, _), args, loc) ->
       let cont = add_pseudo_event loc !compunit_name cont in
-<<<<<<< HEAD
-      comp_args env args sz (Kmakeblock(List.length args, tag) :: cont)
-  | Lprim(Pfloatfield (n, _, _), args, loc) ->
-||||||| merged common ancestors
-      comp_args env args sz (Kmakeblock(List.length args, tag) :: cont)
-  | Lprim(Pfloatfield n, args, loc) ->
-=======
       comp_args stack_info env args sz
         (Kmakeblock(List.length args, tag) :: cont)
-  | Lprim(Pfloatfield n, args, loc) ->
->>>>>>> ocaml/5.1
+  | Lprim(Pfloatfield (n, _, _), args, loc) ->
       let cont = add_pseudo_event loc !compunit_name cont in
       comp_args stack_info env args sz (Kgetfloatfield n :: cont)
   | Lprim(p, args, _) ->
-<<<<<<< HEAD
-      comp_args env args sz (comp_primitive p args :: cont)
-  | Lstaticcatch (body, (i, vars) , handler, _) ->
-||||||| merged common ancestors
-      comp_args env args sz (comp_primitive p args :: cont)
-  | Lstaticcatch (body, (i, vars) , handler) ->
-=======
       let nargs = List.length args - 1 in
       comp_args stack_info env args sz
         (comp_primitive stack_info p (sz + nargs - 1) args :: cont)
-  | Lstaticcatch (body, (i, vars) , handler) ->
->>>>>>> ocaml/5.1
+  | Lstaticcatch (body, (i, vars) , handler, _) ->
       let vars = List.map fst vars in
       let nvars = List.length vars in
       let branch1, cont1 = make_branch cont in
@@ -1040,77 +955,29 @@ let rec comp_expr stack_info env exp sz cont =
         { stack_info with try_blocks = sz :: stack_info.try_blocks } in
       let l = comp_expr stack_info env body (sz+4) body_cont in
       Kpushtrap lbl_handler :: l
-<<<<<<< HEAD
   | Lifthenelse(cond, ifso, ifnot, _kind) ->
-      comp_binary_test env cond ifso ifnot sz cont
-||||||| merged common ancestors
-  | Lifthenelse(cond, ifso, ifnot) ->
-      comp_binary_test env cond ifso ifnot sz cont
-=======
-  | Lifthenelse(cond, ifso, ifnot) ->
       comp_binary_test stack_info env cond ifso ifnot sz cont
->>>>>>> ocaml/5.1
   | Lsequence(exp1, exp2) ->
-<<<<<<< HEAD
-      comp_expr env exp1 sz (comp_expr env exp2 sz cont)
-  | Lwhile {wh_cond; wh_body} ->
-||||||| merged common ancestors
-      comp_expr env exp1 sz (comp_expr env exp2 sz cont)
-  | Lwhile(cond, body) ->
-=======
       comp_expr stack_info env exp1 sz (comp_expr stack_info env exp2 sz cont)
-  | Lwhile(cond, body) ->
->>>>>>> ocaml/5.1
+  | Lwhile {wh_cond; wh_body} ->
       let lbl_loop = new_label() in
       let lbl_test = new_label() in
       Kbranch lbl_test :: Klabel lbl_loop :: Kcheck_signals ::
-<<<<<<< HEAD
-        comp_expr env wh_body sz
-||||||| merged common ancestors
-        comp_expr env body sz
-=======
-        comp_expr stack_info env body sz
->>>>>>> ocaml/5.1
+        comp_expr stack_info env wh_body sz
           (Klabel lbl_test ::
-<<<<<<< HEAD
-            comp_expr env wh_cond sz
-              (Kbranchif lbl_loop :: add_const_unit cont))
-  | Lfor {for_id; for_from; for_to; for_dir; for_body} ->
-||||||| merged common ancestors
-            comp_expr env cond sz (Kbranchif lbl_loop :: add_const_unit cont))
-  | Lfor(param, start, stop, dir, body) ->
-=======
-           comp_expr stack_info env cond sz
+           comp_expr stack_info env wh_cond sz
+
              (Kbranchif lbl_loop :: add_const_unit cont))
-  | Lfor(param, start, stop, dir, body) ->
->>>>>>> ocaml/5.1
+  | Lfor {for_id; for_from; for_to; for_dir; for_body} ->
       let lbl_loop = new_label() in
       let lbl_exit = new_label() in
-<<<<<<< HEAD
       let offset = match for_dir with Upto -> 1 | Downto -> -1 in
       let comp = match for_dir with Upto -> Cgt | Downto -> Clt in
-      comp_expr env for_from sz
-        (Kpush :: comp_expr env for_to (sz+1)
-||||||| merged common ancestors
-      let offset = match dir with Upto -> 1 | Downto -> -1 in
-      let comp = match dir with Upto -> Cgt | Downto -> Clt in
-      comp_expr env start sz
-        (Kpush :: comp_expr env stop (sz+1)
-=======
-      let offset = match dir with Upto -> 1 | Downto -> -1 in
-      let comp = match dir with Upto -> Cgt | Downto -> Clt in
-      comp_expr stack_info env start sz
-        (Kpush :: comp_expr stack_info env stop (sz+1)
->>>>>>> ocaml/5.1
+      comp_expr stack_info env for_from sz
+        (Kpush :: comp_expr stack_info env for_to (sz+1)
           (Kpush :: Kpush :: Kacc 2 :: Kintcomp comp :: Kbranchif lbl_exit ::
            Klabel lbl_loop :: Kcheck_signals ::
-<<<<<<< HEAD
-           comp_expr (add_var for_id (sz+1) env) for_body (sz+2)
-||||||| merged common ancestors
-           comp_expr (add_var param (sz+1) env) body (sz+2)
-=======
-           comp_expr stack_info (add_var param (sz+1) env) body (sz+2)
->>>>>>> ocaml/5.1
+           comp_expr stack_info (add_var for_id (sz+1) env) for_body (sz+2)
              (Kacc 1 :: Kpush :: Koffsetint offset :: Kassign 2 ::
               Kacc 1 :: Kintcomp Cne :: Kbranchif lbl_loop ::
               Klabel lbl_exit :: add_const_unit (add_pop 2 cont))))
@@ -1160,20 +1027,10 @@ let rec comp_expr stack_info env exp sz cont =
       for i = sw.sw_numconsts - 1 downto 0 do
         lbl_consts.(i) <- lbls.(act_consts.(i))
       done;
-<<<<<<< HEAD
-      comp_expr env arg sz (Kswitch(lbl_consts, lbl_blocks) :: !c)
-  | Lstringswitch (arg,sw,d,loc, kind) ->
-      comp_expr env (Matching.expand_stringswitch loc kind arg sw d) sz cont
-||||||| merged common ancestors
-      comp_expr env arg sz (Kswitch(lbl_consts, lbl_blocks) :: !c)
-  | Lstringswitch (arg,sw,d,loc) ->
-      comp_expr env (Matching.expand_stringswitch loc arg sw d) sz cont
-=======
       comp_expr stack_info env arg sz (Kswitch(lbl_consts, lbl_blocks) :: !c)
-  | Lstringswitch (arg,sw,d,loc) ->
+  | Lstringswitch (arg,sw,d,loc, kind) ->
       comp_expr stack_info env
-        (Matching.expand_stringswitch loc arg sw d) sz cont
->>>>>>> ocaml/5.1
+        (Matching.expand_stringswitch loc kind arg sw d) sz cont
   | Lassign(id, expr) ->
       begin try
         let pos = Ident.find_same id env.ce_stack in
@@ -1248,17 +1105,11 @@ let rec comp_expr stack_info env exp sz cont =
           end
       end
   | Lifused (_, exp) ->
-<<<<<<< HEAD
-      comp_expr env exp sz cont
-  | Lregion (exp, _) ->
-      comp_expr env exp sz cont
-  | Lexclave exp ->
-      comp_expr env exp sz cont
-||||||| merged common ancestors
-      comp_expr env exp sz cont
-=======
       comp_expr stack_info env exp sz cont
->>>>>>> ocaml/5.1
+  | Lregion (exp, _) ->
+      comp_expr stack_info env exp sz cont
+  | Lexclave exp ->
+      comp_expr stack_info env exp sz cont
 
 (* Compile a list of arguments [e1; ...; eN] to a primitive operation.
    The values of eN ... e2 are pushed on the stack, e2 at top of stack,

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -19,17 +19,14 @@ open Misc
 open Config
 open Cmo_format
 
-<<<<<<< HEAD
 module CU = Compilation_unit
-||||||| merged common ancestors
-=======
+
 module Dep = struct
   type t = string * string
   let compare = compare
 end
 
 module DepSet = Set.Make (Dep)
->>>>>>> ocaml/5.1
 
 type error =
   | File_not_found of filepath
@@ -42,14 +39,8 @@ type error =
   | Cannot_open_dll of filepath
   | Required_module_unavailable of string * Compilation_unit.t
   | Camlheader of string * filepath
-<<<<<<< HEAD
-  | Wrong_link_order of (string * string) list
-||||||| merged common ancestors
-  | Wrong_link_order of (modname * modname) list
-=======
   | Wrong_link_order of DepSet.t
-  | Multiple_definition of modname * filepath * filepath
->>>>>>> ocaml/5.1
+  | Multiple_definition of string * filepath * filepath
 
 exception Error of error
 
@@ -111,7 +102,7 @@ let provided_globals = ref Ident.Set.empty
 let badly_ordered_dependencies : DepSet.t ref = ref DepSet.empty
 
 let record_badly_ordered_dependency (id, compunit) =
-  let dep = ((Ident.name id), compunit.cu_name) in
+  let dep = ((Ident.name id), CU.name_as_string compunit.cu_name) in
   badly_ordered_dependencies := DepSet.add dep !badly_ordered_dependencies
 
 let is_required (rel, _pos) =
@@ -122,20 +113,9 @@ let is_required (rel, _pos) =
 
 let add_required compunit =
   let add id =
-<<<<<<< HEAD
     if Ident.Set.mem id !provided_globals then begin
-      let cu_name = CU.full_path_as_string compunit.cu_name in
-      badly_ordered_dependencies :=
-        ((Ident.name id), cu_name) :: !badly_ordered_dependencies;
+      record_badly_ordered_dependency (id, compunit)
     end;
-||||||| merged common ancestors
-    if Ident.Set.mem id !provided_globals then
-      badly_ordered_dependencies :=
-        ((Ident.name id), compunit.cu_name) :: !badly_ordered_dependencies;
-=======
-    if Ident.Set.mem id !provided_globals then
-      record_badly_ordered_dependency (id, compunit);
->>>>>>> ocaml/5.1
     missing_globals := Ident.Map.add id compunit.cu_name !missing_globals
   in
   let add_unit unit =
@@ -212,39 +192,24 @@ let implementations_defined = ref ([] : (CU.Name.t * string) list)
 
 let check_consistency file_name cu =
   begin try
-<<<<<<< HEAD
+    let source = List.assoc (CU.name cu.cu_name) !implementations_defined in
+    raise (Error (Multiple_definition(cu.cu_name |> CU.full_path_as_string, file_name, source)));
+  with Not_found -> ()
+  end;
+  begin try
     Array.iter
       (fun import ->
         let name = Import_info.name import in
         let crco = Import_info.crc_with_unit import in
-||||||| merged common ancestors
-    List.iter
-      (fun (name, crco) ->
-=======
-    let source = List.assoc cu.cu_name !implementations_defined in
-    raise (Error (Multiple_definition(cu.cu_name, file_name, source)));
-  with Not_found -> ()
-  end;
-  begin try
-    List.iter
-      (fun (name, crco) ->
->>>>>>> ocaml/5.1
         interfaces := name :: !interfaces;
         match crco with
           None -> ()
-<<<<<<< HEAD
         | Some (full_name, crc) ->
             if CU.Name.equal name (CU.name cu.cu_name)
-            then Consistbl.set crc_interfaces name full_name crc file_name
-            else Consistbl.check crc_interfaces name full_name crc file_name)
-||||||| merged common ancestors
-        | Some crc ->
-            if name = cu.cu_name
-            then Consistbl.set crc_interfaces name crc file_name
-            else Consistbl.check crc_interfaces name crc file_name)
-=======
-        | Some crc -> Consistbl.check crc_interfaces name crc file_name)
->>>>>>> ocaml/5.1
+            (* CR mshinwell for lmaurer: please double-check, these two used
+               to be [Consistbl.set] and [Consistbl.check] respectively *)
+            then Consistbl.check crc_interfaces name full_name crc file_name
+            else Consistbl.check_noadd crc_interfaces name full_name crc file_name)
       cu.cu_imports
   with Consistbl.Inconsistency {
       unit_name = name;
@@ -253,26 +218,6 @@ let check_consistency file_name cu =
     } ->
     raise(Error(Inconsistent_import(name, user, auth)))
   end;
-<<<<<<< HEAD
-  begin try
-    let source = List.assoc (CU.name cu.cu_name) !implementations_defined in
-    Location.prerr_warning (Location.in_file file_name)
-      (Warnings.Module_linked_twice(cu.cu_name |> CU.full_path_as_string,
-                                    Location.show_filename file_name,
-                                    Location.show_filename source))
-  with Not_found -> ()
-  end;
-||||||| merged common ancestors
-  begin try
-    let source = List.assoc cu.cu_name !implementations_defined in
-    Location.prerr_warning (Location.in_file file_name)
-      (Warnings.Module_linked_twice(cu.cu_name,
-                                    Location.show_filename file_name,
-                                    Location.show_filename source))
-  with Not_found -> ()
-  end;
-=======
->>>>>>> ocaml/5.1
   implementations_defined :=
     (CU.name cu.cu_name, file_name) :: !implementations_defined
 
@@ -468,16 +413,8 @@ let link_bytecode ?final_name tolink exec_name standalone =
        Symtable.output_global_map outchan;
        Bytesections.record toc_writer SYMB;
        (* CRCs for modules *)
-<<<<<<< HEAD
        output_value outchan ((extract_crc_interfaces() |> Array.of_list));
-       Bytesections.record outchan "CRCS";
-||||||| merged common ancestors
-       output_value outchan (extract_crc_interfaces());
-       Bytesections.record outchan "CRCS";
-=======
-       output_value outchan (extract_crc_interfaces());
        Bytesections.record toc_writer CRCS;
->>>>>>> ocaml/5.1
        (* Debug info *)
        if !Clflags.debug then begin
          output_debug_info outchan;
@@ -592,26 +529,14 @@ let link_bytecode_as_c tolink outfile with_main =
          (Marshal.to_string (Symtable.initial_global_table()) []);
        output_string outchan "\n};\n\n";
        (* The sections *)
-<<<<<<< HEAD
-       let sections =
-         [ "SYMB", Symtable.data_global_map();
-           "PRIM", Obj.repr(Symtable.data_primitive_names());
-           "CRCS", Obj.repr(extract_crc_interfaces() |> Array.of_list) ] in
-||||||| merged common ancestors
-       let sections =
-         [ "SYMB", Symtable.data_global_map();
-           "PRIM", Obj.repr(Symtable.data_primitive_names());
-           "CRCS", Obj.repr(extract_crc_interfaces()) ] in
-=======
        let sections : (string * Obj.t) list =
          [ Bytesections.Name.to_string SYMB,
            Symtable.data_global_map();
            Bytesections.Name.to_string PRIM,
            Obj.repr(Symtable.data_primitive_names());
            Bytesections.Name.to_string CRCS,
-           Obj.repr(extract_crc_interfaces()) ]
+           Obj.repr(extract_crc_interfaces() |> Array.of_list) ]
        in
->>>>>>> ocaml/5.1
        output_string outchan "static char caml_sections[] = {\n";
        output_data_string outchan
          (Marshal.to_string sections []);

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -205,11 +205,7 @@ let check_consistency file_name cu =
         match crco with
           None -> ()
         | Some (full_name, crc) ->
-            if CU.Name.equal name (CU.name cu.cu_name)
-            (* CR mshinwell for lmaurer: please double-check, these two used
-               to be [Consistbl.set] and [Consistbl.check] respectively *)
-            then Consistbl.check crc_interfaces name full_name crc file_name
-            else Consistbl.check_noadd crc_interfaces name full_name crc file_name)
+            Consistbl.check crc_interfaces name full_name crc file_name)
       cu.cu_imports
   with Consistbl.Inconsistency {
       unit_name = name;

--- a/bytecomp/bytelink.mli
+++ b/bytecomp/bytelink.mli
@@ -17,6 +17,7 @@ open Misc
 
 (* Link .cmo files and produce a bytecode executable. *)
 
+(* CR mshinwell: seems like this should use [CU.Name.t] *)
 module Dep : Set.OrderedType with type t = string * string
 module DepSet : Set.S with type elt = Dep.t
 
@@ -39,6 +40,7 @@ type error =
   | Required_module_unavailable of string * Compilation_unit.t
   | Camlheader of string * filepath
   | Wrong_link_order of DepSet.t
+  (* CR mshinwell: seems like [Multiple_definition] should use [CU.t] *)
   | Multiple_definition of string * filepath * filepath
 
 exception Error of error

--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -309,11 +309,17 @@ let emit_instr = function
   | Kgetpubmet tag -> out opGETPUBMET; out_int tag; out_int 0
   | Kgetdynmet -> out opGETDYNMET
   | Kevent ev -> record_event ev
+  (* CR mshinwell: enable for effects support
   | Kperform -> out opPERFORM
   | Kresume -> out opRESUME
   | Kresumeterm n -> out opRESUMETERM; out_int n
   | Kreperformterm n -> out opREPERFORMTERM; out_int n
-  | Kstop -> out opSTOP
+  | Kstop -> out opSTOP *)
+  | Kperform
+  | Kresume
+  | Kresumeterm _
+  | Kreperformterm _
+  | Kstop -> Misc.fatal_error "No effects support provided yet"
 
 (* Emission of a list of instructions. Include some peephole optimization. *)
 
@@ -416,9 +422,11 @@ let to_file outchan unit_name objfile ~required_globals code =
         (Filename.dirname (Location.absolute_path objfile))
         !debug_dirs;
       let p = pos_out outchan in
+      (* CR mshinwell: Compression not supported in the OCaml 4 runtime
       Marshal.(to_channel outchan !events [Compression]);
       Marshal.(to_channel outchan (String.Set.elements !debug_dirs)
                           [Compression]);
+      *)
       (p, pos_out outchan - p)
     end else
       (0, 0) in

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -161,7 +161,7 @@ let rec transl_const = function
       in
       List.iteri transl_field fields;
       block
-  | Const_float_array fields ->
+  | Const_float_block fields | Const_float_array fields ->
       let res = Array.Floatarray.create (List.length fields) in
       List.iteri (fun i f -> Array.Floatarray.set res i (float_of_string f))
         fields;
@@ -240,58 +240,6 @@ let patch_object buff patchlist =
           patch_int buff pos (of_prim name))
     patchlist
 
-<<<<<<< HEAD
-(* Translate structured constants *)
-
-let rec transl_const = function
-    Const_base(Const_int i) -> Obj.repr i
-  | Const_base(Const_char c) -> Obj.repr c
-  | Const_base(Const_string (s, _, _)) -> Obj.repr s
-  | Const_base(Const_float f) -> Obj.repr (float_of_string f)
-  | Const_base(Const_int32 i) -> Obj.repr i
-  | Const_base(Const_int64 i) -> Obj.repr i
-  | Const_base(Const_nativeint i) -> Obj.repr i
-  | Const_immstring s -> Obj.repr s
-  | Const_block(tag, fields) ->
-      let block = Obj.new_block tag (List.length fields) in
-      let pos = ref 0 in
-      List.iter
-        (fun c -> Obj.set_field block !pos (transl_const c); incr pos)
-        fields;
-      block
-  | Const_float_block fields | Const_float_array fields ->
-      let res = Array.Floatarray.create (List.length fields) in
-      List.iteri (fun i f -> Array.Floatarray.set res i (float_of_string f))
-        fields;
-      Obj.repr res
-
-||||||| merged common ancestors
-(* Translate structured constants *)
-
-let rec transl_const = function
-    Const_base(Const_int i) -> Obj.repr i
-  | Const_base(Const_char c) -> Obj.repr c
-  | Const_base(Const_string (s, _, _)) -> Obj.repr s
-  | Const_base(Const_float f) -> Obj.repr (float_of_string f)
-  | Const_base(Const_int32 i) -> Obj.repr i
-  | Const_base(Const_int64 i) -> Obj.repr i
-  | Const_base(Const_nativeint i) -> Obj.repr i
-  | Const_immstring s -> Obj.repr s
-  | Const_block(tag, fields) ->
-      let block = Obj.new_block tag (List.length fields) in
-      let pos = ref 0 in
-      List.iter
-        (fun c -> Obj.set_field block !pos (transl_const c); incr pos)
-        fields;
-      block
-  | Const_float_array fields ->
-      let res = Array.Floatarray.create (List.length fields) in
-      List.iteri (fun i f -> Array.Floatarray.set res i (float_of_string f))
-        fields;
-      Obj.repr res
-
-=======
->>>>>>> ocaml/5.1
 (* Build the initial table of globals *)
 
 let initial_global_table () =
@@ -374,17 +322,9 @@ let init_toplevel () =
     (* Recover CRC infos for interfaces *)
     let crcintfs =
       try
-<<<<<<< HEAD
-        (Obj.magic (sect.read_struct "CRCS") : Import_info.t array)
-      with Not_found -> [| |] in
-||||||| merged common ancestors
-        (Obj.magic (sect.read_struct "CRCS") : (string * Digest.t option) list)
-      with Not_found -> [] in
-=======
         (Obj.magic (sect.read_struct Bytesections.Name.CRCS)
-         : (string * Digest.t option) list)
-      with Not_found -> [] in
->>>>>>> ocaml/5.1
+         : Import_info.t array)
+      with Not_found -> [| |] in
     (* Done *)
     sect.close_reader();
     crcintfs

--- a/jane/build-resolved-files-for-ci
+++ b/jane/build-resolved-files-for-ci
@@ -27,6 +27,8 @@ dune_targets=$(
 # ocamlbytecomp mlis
 mlis=$(
   { echo driver/{errors,compile,maindriver}.mli
+    echo bytecomp/{bytegen,bytelibrarian,bytelink,bytepackager}.mli
+    echo bytecomp/{emitcode,printinstr,instruct}.mli
   } |
     tr ' ' '\n'
 )
@@ -88,6 +90,7 @@ mls=$(
   { echo driver/{compenv,compmisc,main_args}.ml
     echo parsing/parser.ml
     echo {utils,parsing,lambda}/*.ml
+    echo bytecomp/{meta,opcodes,bytesections,dll,symtable}.ml
     for f in "${typing_mls[@]}"; do
         echo "typing/${f}.ml"
     done
@@ -110,6 +113,8 @@ dune_targets=$(
 # ocamlbytecomp mls
 mls=$(
   { echo driver/{errors,compile,maindriver}.ml
+    echo bytecomp/{bytegen,bytelibrarian,bytelink,bytepackager}.ml
+    echo bytecomp/{emitcode,printinstr,instruct}.ml
   } |
     tr ' ' '\n'
 )


### PR DESCRIPTION
@lukemaurer please could you review this, and check carefully - it's likely I've made mistakes here.  One thing you might want to do is to diff the files on this branch directly from the `tip-5` tag, rather than looking directly at this PR's diff.  This shows our changes compared to upstream OCaml 5, so that diff should kind of look like the original symbols patch (plus some other minor modifications for other bytecode files which should be straightforward).  Unfortunately there were changes in OCaml 5 regarding the relocation processing, although it now seems to me that maybe they don't matter too much, since we don't need the renaming of relocations any more (iirc)?