### PR TITLE
Add lambda mls to build script and ci

### DIFF
--- a/jane/build-resolved-files-for-ci
+++ b/jane/build-resolved-files-for-ci
@@ -87,8 +87,7 @@ typing_mls=(
 mls=$(
   { echo driver/{compenv,compmisc,main_args}.ml
     echo parsing/parser.ml
-    echo {utils,parsing}/*.ml
-    echo lambda/{lambda,tmc,simplif}.ml
+    echo {utils,parsing,lambda}/*.ml
     for f in "${typing_mls[@]}"; do
         echo "typing/${f}.ml"
     done
@@ -96,7 +95,9 @@ mls=$(
     tr ' ' '\n' |
     grep -v "utils/config.common.ml" |
     grep -v "utils/config.fixed.ml" |
-    grep -v "utils/config.generated.ml"
+    grep -v "utils/config.generated.ml" |
+    grep -v "lambda/matching.ml" | # need Obj.forcing_tag in stdlib
+    cat;
 )
 echo "$mls"
 dune_targets=$(

--- a/lambda/transl_array_comprehension.ml
+++ b/lambda/transl_array_comprehension.ml
@@ -209,7 +209,7 @@ end = struct
     let slot =
       transl_extension_path
         loc
-        (Lazy.force Env.initial_safe_string)
+        (Lazy.force Env.initial)
         Predef.path_invalid_argument
     in
     (* CR-someday aspectorzabusky: We might want to raise an event here for


### PR DESCRIPTION
Adds `lambda/*.ml` to the build script, and fix a build error relating to that. I forgot to in #179, which predated the CI.

The only one I have to exempt is `matching.ml` because it relies on `Obj.forcing_tag` in the stdlib.

Review: @mshinwell ?