### PR TITLE
Resolve conflicts in file_formats/

### DIFF
--- a/file_formats/cmi_format.ml
+++ b/file_formats/cmi_format.ml
@@ -42,7 +42,7 @@ exception Error of error
   (again, shallowly) representation can be found. When deserializing, we read
   the entire data block into memory as one blob and then deserialize from it as
   needed when values are forced.
-  
+
   Note that we are deliberately using int for offsets here because int64 is more
   expensive. On 32 bits architectures, this imposes a constraint on the size of
   .cmi files. *)
@@ -150,7 +150,6 @@ let read_cmi_lazy filename =
 let output_cmi filename oc cmi =
 (* beware: the provided signature must have been substituted for saving *)
   output_string oc Config.cmi_magic_number;
-<<<<<<< HEAD
   let output_int64 oc n =
     let buf = Bytes.create 8 in
     Bytes.set_int64_ne buf 0 n;
@@ -167,12 +166,10 @@ let output_cmi filename oc cmi =
   let len = Int64.sub val_pos data_pos in
   output_int64 oc len;
   Out_channel.seek oc val_pos;
+  (* BACKPORT BEGIN *)
+  (* mshinwell: upstream uses [Compression] here *)
   output_value oc ((cmi.cmi_name, sign) : header);
-||||||| merged common ancestors
-  output_value oc ((cmi.cmi_name, cmi.cmi_sign) : header);
-=======
-  Marshal.(to_channel oc ((cmi.cmi_name, cmi.cmi_sign) : header) [Compression]);
->>>>>>> ocaml/5.1
+  (* BACKPORT END *)
   flush oc;
   let crc = Digest.file filename in
   let crcs =

--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -109,7 +109,10 @@ let input_cmt ic = (input_value ic : cmt_infos)
 
 let output_cmt oc cmt =
   output_string oc Config.cmt_magic_number;
-  Marshal.(to_channel oc (cmt : cmt_infos) [Compression])
+  (* BACKPORT BEGIN *)
+  (* mshinwell: upstream uses [Compression] here *)
+  Marshal.(to_channel oc (cmt : cmt_infos) [])
+  (* BACKPORT END *)
 
 let read filename =
 (*  Printf.fprintf stderr "Cmt_format.read %s\n%!" filename; *)

--- a/jane/build-resolved-files-for-ci
+++ b/jane/build-resolved-files-for-ci
@@ -11,6 +11,7 @@ echo "==========="
 # ocamlcommon mlis
 mlis=$(
   { echo driver/{compenv,compmisc,main_args}.mli
+    echo file_formats/{cmi,cmo,cms,cmt}_format.mli
     echo parsing/parser.mli
     echo {utils,typing,parsing,lambda}/*.mli
   } |
@@ -45,6 +46,7 @@ dune_targets=$(
 mlis=$(
   { echo middle_end/{,closure,flambda}/*.mli
     echo asmcomp/*.mli
+    echo file_formats/{cmx,cmxs,linear}_format.mli
   } |
     tr ' ' '\n' |
     sed "s/CSE/cSE/"
@@ -89,6 +91,7 @@ typing_mls=(
 # ocamlcommon mls
 mls=$(
   { echo driver/{compenv,compmisc,main_args}.ml
+    echo file_formats/{cmi,cms,cmt}_format.ml
     echo parsing/parser.ml
     echo {utils,parsing,lambda}/*.ml
     echo bytecomp/{meta,opcodes,bytesections,dll,symtable}.ml
@@ -133,6 +136,7 @@ mls=$(
   { echo middle_end/{,closure,flambda}/*.ml
     echo asmcomp/*.ml
     echo asmcomp/amd64/*.ml
+    echo file_formats/linear_format.ml
   } |
     tr ' ' '\n' |
     sed "s/CSE/cSE/"


### PR DESCRIPTION
This also makes the necessary changes required for the OCaml 4 runtime, namely that compressed marshalling is not supported.