### PR TITLE
Resolve conflicts in ocamldoc

### DIFF
--- a/jane/build-resolved-files-for-ci
+++ b/jane/build-resolved-files-for-ci
@@ -179,6 +179,27 @@ dune_targets=$(
     echo _build/default/.ocamloptcomp.objs/native/$cmx.cmx
   done
 )
+
+#ocamldoc
+ocamldoc=_build/default/ocamldoc/.odoc_lib.objs/
+mls=$(
+  GLOBIGNORE="ocamldoc/odoc.ml"
+  echo ocamldoc/*.ml |
+    tr ' ' '\n'
+  unset GLOBIGNORE
+)
+echo "$mls"
+dune_targets=$(
+  echo $dune_targets
+  for ml in $mls; do
+    cmx=$(basename ${ml%.ml})
+    echo _build/default/ocamldoc/.odoc_lib.objs/native/$cmx.cmx
+    echo _build/default/ocamldoc/.odoc_lib.objs/byte/$cmx.cmi
+  done
+  echo _build/default/ocamldoc/.odoc_native.eobjs/byte/odoc_native.cmi
+  echo _build/default/ocamldoc/.odoc_byte.eobjs/byte/odoc_byte.cmi
+)
+
 mls=$(
   { echo debugger/*.ml
   } |

--- a/jane/build-resolved-files-for-ci
+++ b/jane/build-resolved-files-for-ci
@@ -198,6 +198,8 @@ dune_targets=$(
   done
   echo _build/default/ocamldoc/.odoc_native.eobjs/byte/odoc_native.cmi
   echo _build/default/ocamldoc/.odoc_byte.eobjs/byte/odoc_byte.cmi
+  echo _build/default/ocamldoc/.odoc_native.eobjs/native/odoc_native.cmx
+  echo _build/default/ocamldoc/.odoc_byte.eobjs/native/odoc_byte.cmx
 )
 
 mls=$(

--- a/ocamldoc/.depend
+++ b/ocamldoc/.depend
@@ -6,13 +6,8 @@ odoc.cmo : \
     odoc_config.cmi \
     odoc_args.cmi \
     odoc_analyse.cmi \
-<<<<<<< HEAD
-    ../utils/language_extension.cmi
-||||||| merged common ancestors
-    odoc_analyse.cmi
-=======
+    ../utils/language_extension.cmi \
     odoc.cmi
->>>>>>> ocaml/5.1
 odoc.cmx : \
     odoc_messages.cmx \
     odoc_info.cmx \
@@ -21,14 +16,9 @@ odoc.cmx : \
     odoc_config.cmx \
     odoc_args.cmx \
     odoc_analyse.cmx \
-<<<<<<< HEAD
-    ../utils/language_extension.cmx
-||||||| merged common ancestors
-    odoc_analyse.cmx
-=======
+    ../utils/language_extension.cmx \
     odoc.cmi
 odoc.cmi :
->>>>>>> ocaml/5.1
 odoc_analyse.cmo : \
     ../utils/warnings.cmi \
     ../typing/types.cmi \

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -63,17 +63,9 @@ INCLUDES_NODEP = $(addprefix -I $(ROOTDIR)/,\
 OC_OCAMLDEPDIRS = $(INCLUDE_DIRS)
 INCLUDES=$(INCLUDES_DEP) $(INCLUDES_NODEP)
 
-<<<<<<< HEAD
-COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-40-41-42-44-45-48-70 -warn-error +A \
-  -safe-string -strict-sequence -strict-formats -bin-annot -principal
-||||||| merged common ancestors
-COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-41-42-44-45-48-70 -warn-error +A \
-  -safe-string -strict-sequence -strict-formats -bin-annot -principal
-=======
 COMPFLAGS = \
-  -g $(INCLUDES) -absname -w +a-4-9-41-42-44-45-48 -warn-error +A \
+  -g $(INCLUDES) -absname -w +a-4-9-40-41-42-44-45-48 -warn-error +A \
   -strict-sequence -strict-formats -bin-annot -principal
->>>>>>> ocaml/5.1
 
 LINKFLAGS = $(INCLUDES)
 


### PR DESCRIPTION
Resolve the conflicts in OCamldoc. 
They were limited to Makefile / .depend -- an even if I thought this Makefile got merged with the main Makefile in OCaml 5 the commit actually doing it was done after the 5.1 tagging