### PR TITLE
Misc build errors in typing

### DIFF
--- a/jane/build-resolved-files-for-ci
+++ b/jane/build-resolved-files-for-ci
@@ -87,6 +87,7 @@ typing_mls=(
   env
   includecore
   includemod
+  jkind
   mtype
   oprint
   parmatch
@@ -104,7 +105,8 @@ typing_mls=(
   typedecl_variance
   typedtree
   types
-  typetexp)
+  typetexp
+  uniqueness_analysis)
 
 # ocamlcommon mls
 mls=$(

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -636,7 +636,7 @@ end = struct
           | "Location" | "Longident" -> "ocamlcommon"
           | mn ->
             mn |> String.lowercase_ascii |> delete_trailing_double_underscore)
-      | Pident _ | Papply _ -> None
+      | Pident _ | Papply _ | Pextra_ty _ -> None
     in
     Option.iter
       (fprintf ppf "@,Hint: Adding \"%s\" to your dependencies might help.")

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1243,7 +1243,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
       in
       let partial =
         let dummy = Typecore.type_exp val_env (Ast_helper.Exp.unreachable ()) in
-        Typecore.check_partial Modules_rejected val_env pat.pat_type pat.pat_loc
+        Typecore.check_partial val_env pat.pat_type pat.pat_loc
           [{c_lhs = pat; c_guard = None; c_rhs = dummy}]
       in
       let val_env' = Env.add_escape_lock Class val_env' in

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -137,7 +137,7 @@ val type_self_pattern:
         Env.t -> Parsetree.pattern ->
         Typedtree.pattern * pattern_variable list
 val check_partial:
-        ?lev:int -> module_patterns_restriction -> Env.t -> type_expr ->
+        ?lev:int -> Env.t -> type_expr ->
         Location.t -> Typedtree.value Typedtree.case list -> Typedtree.partial
 val type_expect:
         Env.t -> Parsetree.expression -> type_expected -> Typedtree.expression

--- a/typing/uniqueness_analysis.ml
+++ b/typing/uniqueness_analysis.ml
@@ -1111,10 +1111,10 @@ let value_of_ident ienv unique_use occ path =
       Some value)
   (* accessing a module, which is forced by typemod to be shared and many.
      Here we force it again just to be sure *)
-  | Path.Pdot _ | Path.Pextra_ty _ ->
+  | Path.Pdot _ ->
     force_shared_boundary ~reason:Paths_from_mod_class unique_use occ;
     None
-  | Path.Papply _ -> assert false
+  | Path.Papply _ | Path.Pextra_ty _ -> assert false
 
 (* TODO: replace the dirty hack.
    The following functions are dirty hacks and used for modules and classes.

--- a/typing/uniqueness_analysis.ml
+++ b/typing/uniqueness_analysis.ml
@@ -1111,7 +1111,7 @@ let value_of_ident ienv unique_use occ path =
       Some value)
   (* accessing a module, which is forced by typemod to be shared and many.
      Here we force it again just to be sure *)
-  | Path.Pdot _ ->
+  | Path.Pdot _ | Path.Pextra_ty _ ->
     force_shared_boundary ~reason:Paths_from_mod_class unique_use occ;
     None
   | Path.Papply _ -> assert false
@@ -1239,7 +1239,7 @@ let rec check_uniqueness_exp (ienv : Ienv.t) exp : UF.t =
       Array.map
         (fun field ->
           match field with
-          | l, Kept (_, unique_use) ->
+          | l, Kept (_, _, unique_use) ->
             let value =
               Value.implicit_record_field l.lbl_global l.lbl_name value
                 unique_use
@@ -1306,7 +1306,7 @@ let rec check_uniqueness_exp (ienv : Ienv.t) exp : UF.t =
     let uf_body = check_uniqueness_exp ienv body in
     UF.seq uf_mod uf_body
   | Texp_letexception (_, e) -> check_uniqueness_exp ienv e
-  | Texp_assert e -> check_uniqueness_exp ienv e
+  | Texp_assert (e, _) -> check_uniqueness_exp ienv e
   | Texp_lazy e ->
     let uf = check_uniqueness_exp ienv e in
     lift_implicit_borrowing uf


### PR DESCRIPTION
These files didn't have conflicts, so the errors didn't show up until I tried to build everything.

This includes a change in `typecore.mli` that is also present in the `typecore` PR, needed to fix an issue in `typeclass.ml`.