### PR TITLE
OCaml 5 on runtime4: bytecomp and debugger

### DIFF
--- a/bytecomp/dll.ml
+++ b/bytecomp/dll.ml
@@ -19,7 +19,11 @@ type dll_handle
 type dll_address
 type dll_mode = For_checking | For_execution
 
+(* BACKPORT BEGIN
 external dll_open: string -> dll_handle = "caml_dynlink_open_lib"
+*)
+external dll_open: dll_mode -> string -> dll_handle = "caml_dynlink_open_lib"
+(* BACKPORT END *)
 external dll_close: dll_handle -> unit = "caml_dynlink_close_lib"
 external dll_sym: dll_handle -> string -> dll_address
                 = "caml_dynlink_lookup_symbol"
@@ -81,7 +85,11 @@ let open_dll mode name =
           failwith (fullname ^ ": " ^ Binutils.error_to_string err)
       end
   | (None | Some (Checking _) as current), For_execution ->
+(* BACKPORT BEGIN
       begin match dll_open fullname with
+*)
+      begin match dll_open For_execution fullname with
+(* BACKPORT END *)
       | dll ->
           let opened = match current with
             | None -> List.remove_assoc fullname !opened_dlls

--- a/debugger/debugcom.ml
+++ b/debugger/debugcom.ml
@@ -52,6 +52,7 @@ type pc =
 module Sp = struct
 
   (* Position in the debuggee's stack. *)
+(* BACKPORT BEGIN
   type t = {
     block : int;
     offset : int;
@@ -65,6 +66,13 @@ module Sp = struct
     match Stdlib.compare sp1.block sp2.block with
     | 0 -> Stdlib.compare sp1.offset sp2.offset
     | x -> x
+*)
+  type t = int
+
+  let null = 0
+  let base _ _ = assert false
+  let compare = Int.compare
+(* BACKPORT END *)
 
 end
 
@@ -72,7 +80,11 @@ end
    Numbering starts at 1 and the runtime registers 2 fragments before
    the main program: one for uncaught exceptions and one for callbacks.
 *)
+(* BACKPOR BEGIN
 let main_frag = 3
+*)
+let main_frag = 0
+(* BACKPORT END *)
 
 let set_event {frag; pos} =
   output_char !conn.io_out 'e';
@@ -137,13 +149,21 @@ let do_go_smallint n =
          |  c  -> Misc.fatal_error (Printf.sprintf "Debugcom.do_go %c" c)
        in
        let event_counter = input_binary_int !conn.io_in in
+(* BACKPORT BEGIN
        let block = input_binary_int !conn.io_in in
        let offset = input_binary_int !conn.io_in in
+*)
+       let rep_stack_pointer = input_binary_int !conn.io_in in
+(* BACKPORT END *)
        let frag = input_binary_int !conn.io_in in
        let pos = input_binary_int !conn.io_in in
        { rep_type = summary;
          rep_event_count = Int64.of_int event_counter;
+(* BACKPORT BEGIN
          rep_stack_pointer = Sp.{block; offset};
+*)
+         rep_stack_pointer;
+(* BACKPORT END *)
          rep_program_pointer = {frag; pos} })
 
 let rec do_go n =
@@ -192,11 +212,19 @@ let wait_child chan =
 let initial_frame () =
   output_char !conn.io_out '0';
   flush !conn.io_out;
+(* BACKPORT BEGIN
   let block = input_binary_int !conn.io_in in
   let offset = input_binary_int !conn.io_in in
+*)
+  let stack_pos = input_binary_int !conn.io_in in
+(* BACKPORT END *)
   let frag = input_binary_int !conn.io_in in
   let pos = input_binary_int !conn.io_in in
+(* BACKPORT BEGIN
   (Sp.{block; offset}, {frag; pos})
+*)
+  (stack_pos, {frag; pos})
+(* BACKPOR END *)
 
 let set_initial_frame () =
   ignore(initial_frame ())
@@ -209,9 +237,14 @@ let up_frame stacksize =
   output_char !conn.io_out 'U';
   output_binary_int !conn.io_out stacksize;
   flush !conn.io_out;
+(* BACKPORT BEGIN
   let block = input_binary_int !conn.io_in in
   let offset = input_binary_int !conn.io_in in
+*)
+  let stack_pos = input_binary_int !conn.io_in in
+(* BACKPORT END *)
   let frag, pos =
+(* BACKPORT BEGIN
     if block = -1 then
     begin
       assert (offset = -1);
@@ -221,31 +254,56 @@ let up_frame stacksize =
       let pos = input_binary_int !conn.io_in in
       frag, pos
     end
+*)
+    if stack_pos = -1
+    then 0, 0
+    else let frag = input_binary_int !conn.io_in in
+         let pos = input_binary_int !conn.io_in in
+         frag, pos
+(* BACKPORT END *)
   in
+(* BACKPORT BEGIN
   (Sp.{block; offset}, { frag; pos })
+*)
+  (stack_pos, { frag; pos })
+(* BACKPORT END *)
 
 (* Get and set the current frame position *)
 
 let get_frame () =
   output_char !conn.io_out 'f';
   flush !conn.io_out;
+  let stack_pos = input_binary_int !conn.io_in in
+(*
   let block = input_binary_int !conn.io_in in
   let offset = input_binary_int !conn.io_in in
+*)
   let frag = input_binary_int !conn.io_in in
   let pos = input_binary_int !conn.io_in in
+(*
   (Sp.{block; offset}, {frag; pos})
+*)
+  (stack_pos, {frag; pos})
 
 let set_frame stack_pos =
   output_char !conn.io_out 'S';
+(* BACKPORT BEGIN
   output_binary_int !conn.io_out stack_pos.Sp.block;
   output_binary_int !conn.io_out stack_pos.Sp.offset
+*)
+  output_binary_int !conn.io_out stack_pos
+(* BACKPORT END *)
 
 (* Set the trap barrier to given stack position. *)
 
 let set_trap_barrier pos =
   output_char !conn.io_out 'b';
+(* BACKPORT BEGIN
   output_binary_int !conn.io_out pos.Sp.block;
   output_binary_int !conn.io_out pos.Sp.offset
+*)
+  output_binary_int !conn.io_out pos
+(* BACKPORT END *)
 
 (* Handling of remote values *)
 

--- a/debugger/debugcom.mli
+++ b/debugger/debugcom.mli
@@ -17,7 +17,11 @@
 (* Low-level communication with the debuggee *)
 
 module Sp : sig
+(* BACKPORT BEGIN
   type t
+*)
+  type t = int
+(* BACKPORT END *)
   val null : t
   val base : t -> int -> t
   val compare : t -> t -> int

--- a/debugger/frames.ml
+++ b/debugger/frames.ml
@@ -53,7 +53,11 @@ let selected_event_is_before () =
 let rec move_up frame_count event =
   if frame_count <= 0 then event else begin
     let (sp, pc) = up_frame event.ev_ev.ev_stacksize in
+(* BACKPORT BEGIN
     if sp = Sp.null then raise Not_found;
+*)
+    if sp < Sp.null then raise Not_found;
+(* BACKPORT END *)
     move_up (frame_count - 1) (any_event_at_pc pc)
   end
 
@@ -113,7 +117,11 @@ let do_backtrace action =
       begin try
         while action (Some !event) do
           let (sp, pc) = up_frame !event.ev_ev.ev_stacksize in
+(* BACKPORT BEGIN
           if sp = Sp.null then raise Exit;
+*)
+          if sp < Sp.null then raise Exit;
+(* BACKPORT END *)
           event := any_event_at_pc pc
         done
       with Exit -> ()

--- a/debugger/time_travel.ml
+++ b/debugger/time_travel.ml
@@ -555,7 +555,11 @@ let finish () =
   | Some {ev_ev={ev_stacksize}} ->
       set_initial_frame();
       let (frame, pc) = up_frame ev_stacksize in
+(* BACKPORT BEGIN
       if frame = Sp.null then begin
+*)
+      if frame < Sp.null then begin
+(* BACKPORT END *)
         prerr_endline "`finish' not meaningful in outermost frame.";
         raise Toplevel
       end;
@@ -598,9 +602,14 @@ let next_1 () =
         | Some {ev_ev={ev_stacksize=ev_stacksize2}} ->
             let (frame2, _pc2) = initial_frame() in
             (* Call `finish' if we've entered a function. *)
+(* BACKPORT BEGIN
             if frame1 <> Sp.null && frame2 <> Sp.null &&
                Sp.(compare (base frame2 ev_stacksize2)
                      (base frame1 ev_stacksize1)) > 0
+*)
+            if frame1 >= 0 && frame2 >= 0 &&
+               frame2 - ev_stacksize2 > frame1 - ev_stacksize1
+(* BACKPORT END *)
             then finish()
       end
 
@@ -623,7 +632,11 @@ let start () =
   | Some {ev_ev={ev_stacksize}} ->
       let (frame, _) = initial_frame() in
       let (frame', pc) = up_frame ev_stacksize in
+(* BACKPORT BEGIN
       if frame' = Sp.null then begin
+*)
+      if frame' < Sp.null then begin
+(* BACKPORT END *)
         prerr_endline "`start not meaningful in outermost frame.";
         raise Toplevel
       end;
@@ -645,7 +658,11 @@ let start () =
             step _minus1;
             (not !interrupted)
               &&
+(* BACKPORT BEGIN
             Sp.(compare (base frame' nargs) (base frame ev_stacksize)) > 0
+*)
+            (frame' - nargs > frame - ev_stacksize)
+(* BACKPORT END *)
         | _ ->
             false
       do
@@ -667,9 +684,14 @@ let previous_1 () =
         | Some {ev_ev={ev_stacksize=ev_stacksize2}} ->
             let (frame2, _pc2) = initial_frame() in
             (* Call `start' if we've entered a function. *)
+(* BACKPORT BEGIN
             if frame1 <> Sp.null && frame2 <> Sp.null &&
               Sp.(compare (base frame2 ev_stacksize2)
                     (base frame1 ev_stacksize1)) > 0
+*)
+            if frame1 >= 0 && frame2 >= 0 &&
+               frame2 - ev_stacksize2 > frame1 - ev_stacksize1
+(* BACKPORT END *)
             then start()
       end
 


### PR DESCRIPTION
```
d35a2bfb18 [BACKPORT] Adapt to 4.14 runtime
 bytecomp/dll.ml | 8 ++++++++
 1 file changed, 8 insertions(+)

4e8d83046b [BACKPORT] Adapt to 4.14 runtime
 debugger/debugcom.ml    | 58 +++++++++++++++++++++++++++++++++++++++++++++++++
 debugger/debugcom.mli   |  4 ++++
 debugger/frames.ml      |  8 +++++++
 debugger/time_travel.ml | 22 +++++++++++++++++++
 4 files changed, 92 insertions(+)
```
These were cherry-picked verbatim from David Allsopp's repo.

There is also a fix to the temporary build script so it works on the bash provided with macOS.