### PR TITLE
Fix for optcompile

### DIFF
--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -49,8 +49,9 @@ let compile i ~backend ~middle_end ~transl_style
             ~backend
             ~prefixname:i.output_prefix
             ~middle_end
-            ~ppf_dump:i.ppf_dump;
-       Compilenv.save_unit_info (cmx i))
+            ~ppf_dump:i.ppf_dump
+            lambda;
+       Compilenv.save_unit_info (cmx i)))
 
 let flambda i backend typed =
   compile i typed ~backend ~transl_style:Plain_block


### PR DESCRIPTION
For some reason this file can't be built by the script or using the recommended command line invocation, but it does get built while moving further down the path of building the whole compiler, which is how I noticed this issue.