### PR TITLE
OCaml 5 on 4: testsuite changes

### DIFF
--- a/testsuite/tests/c-api/test_c_thread_has_lock.ml
+++ b/testsuite/tests/c-api/test_c_thread_has_lock.ml
@@ -1,7 +1,9 @@
 (* TEST
    modules = "test_c_thread_has_lock_cstubs.c"
-   * bytecode
-   * native
+   * skip
+   reason = "OCaml 5 only"
+   ** bytecode
+   ** native
 *)
 
 external test_with_lock : unit -> bool = "with_lock"

--- a/testsuite/tests/c-api/test_c_thread_has_lock_systhread.ml
+++ b/testsuite/tests/c-api/test_c_thread_has_lock_systhread.ml
@@ -1,9 +1,11 @@
 (* TEST
    modules = "test_c_thread_has_lock_cstubs.c"
-   * hassysthreads
+   * skip
+   reason = "OCaml 5 only"
+   ** hassysthreads
    include systhreads
-   ** bytecode
-   ** native
+   *** bytecode
+   *** native
 *)
 
 external test_with_lock : unit -> bool = "with_lock"

--- a/testsuite/tests/callback/callback_effects_gc.ml
+++ b/testsuite/tests/callback/callback_effects_gc.ml
@@ -1,6 +1,8 @@
 (* TEST
    ocamlrunparam += ",s=512"
-   * native
+   * skip
+   reason = "OCaml 5 only"
+   ** native
 *)
 
 let count = ref 0

--- a/testsuite/tests/effects/marshal.ml
+++ b/testsuite/tests/effects/marshal.ml
@@ -1,6 +1,4 @@
 (* TEST
-   * skip
-
  *)
 
 open Effect

--- a/testsuite/tests/effects/marshal.ml
+++ b/testsuite/tests/effects/marshal.ml
@@ -1,4 +1,6 @@
 (* TEST
+* skip
+reason = "OCaml 5 only"
  *)
 
 open Effect

--- a/testsuite/tests/frame-pointers/c_call.ml
+++ b/testsuite/tests/frame-pointers/c_call.ml
@@ -1,7 +1,9 @@
 (* TEST
 
-* frame_pointers
-** native
+* skip
+reason = "OCaml 5 only"
+** frame_pointers
+*** native
 readonly_files = "fp_backtrace.c c_call_.c"
 all_modules = "${readonly_files} c_call.ml"
 

--- a/testsuite/tests/frame-pointers/effects.ml
+++ b/testsuite/tests/frame-pointers/effects.ml
@@ -2,8 +2,10 @@
    * skip
 
 
-* frame_pointers
-** native
+* skip
+reason - "OCaml 5 only"
+** frame_pointers
+*** native
 readonly_files = "fp_backtrace.c"
 all_modules = "${readonly_files} effects.ml"
 

--- a/testsuite/tests/frame-pointers/exception_handler.ml
+++ b/testsuite/tests/frame-pointers/exception_handler.ml
@@ -1,7 +1,9 @@
 (* TEST
 
-* frame_pointers
-** native
+* skip
+reason = "OCaml 5 only"
+** frame_pointers
+*** native
 readonly_files = "fp_backtrace.c"
 all_modules = "${readonly_files} exception_handler.ml"
 

--- a/testsuite/tests/frame-pointers/reperform.ml
+++ b/testsuite/tests/frame-pointers/reperform.ml
@@ -2,8 +2,10 @@
    * skip
 
 
-* frame_pointers
-** native
+* skip
+reason - "OCaml 5 only"
+** frame_pointers
+*** native
 
 readonly_files = "fp_backtrace.c"
 all_modules = "${readonly_files} reperform.ml"

--- a/testsuite/tests/frame-pointers/stack_realloc.ml
+++ b/testsuite/tests/frame-pointers/stack_realloc.ml
@@ -2,8 +2,10 @@
    * skip
 
 
-* frame_pointers
-** native
+* skip
+reason - "OCaml 5 only"
+** frame_pointers
+*** native
 
 readonly_files = "fp_backtrace.c stack_realloc_.c"
 all_modules = "${readonly_files} stack_realloc.ml"

--- a/testsuite/tests/frame-pointers/stack_realloc2.ml
+++ b/testsuite/tests/frame-pointers/stack_realloc2.ml
@@ -2,8 +2,10 @@
    * skip
 
 
-* frame_pointers
-** native
+* skip
+reason - "OCaml 5 only"
+** frame_pointers
+*** native
 
 readonly_files = "fp_backtrace.c stack_realloc_.c"
 all_modules = "${readonly_files} stack_realloc2.ml"

--- a/testsuite/tests/lib-bigarray/bigarrays.ml
+++ b/testsuite/tests/lib-bigarray/bigarrays.ml
@@ -1150,7 +1150,6 @@ let tests () =
   test_structured_io 13 (make_array2 complex32 c_layout 0 100 100 makecomplex);
   test_structured_io 14 (make_array3 complex64 fortran_layout 1 10 20 30
                                      makecomplex);
-
   ()
   [@@inline never]
 

--- a/testsuite/tests/lib-channels/close_in.ml
+++ b/testsuite/tests/lib-channels/close_in.ml
@@ -1,4 +1,7 @@
-(* TEST *)
+(* TEST
+* skip
+reason = "OCaml 5 only"
+ *)
 
 (* Test that inputting bytes from a closed in_channel triggers an exception *)
 

--- a/testsuite/tests/lib-channels/refcounting.ml
+++ b/testsuite/tests/lib-channels/refcounting.ml
@@ -1,5 +1,7 @@
 (* TEST
-   * expect
+   * skip
+   reason = "OCaml 5 only"
+   ** expect
 *)
 
 (* Test the behavior of channel refcounting. *)

--- a/testsuite/tests/lib-format/domains.ml
+++ b/testsuite/tests/lib-format/domains.ml
@@ -1,4 +1,7 @@
-(* TEST *)
+(* TEST
+* skip
+reason = "OCaml 5 only"
+*)
 
 (** Test that domains stdout and stderr are flushed at domain exit *)
 

--- a/testsuite/tests/lib-random/parallel.ml
+++ b/testsuite/tests/lib-random/parallel.ml
@@ -1,8 +1,10 @@
 (* TEST
    include unix
-   * libunix
-   ** bytecode
-   ** native
+   * skip
+   reason = "OCaml 5 only"
+   ** libunix
+   *** bytecode
+   *** native
  *)
 
 let () = Random.init 42

--- a/testsuite/tests/lib-runtime-events/test_caml_counters.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml_counters.ml
@@ -1,5 +1,7 @@
 (* TEST
 include runtime_events
+* skip
+reason = "OCaml 5 only"
 *)
 open Runtime_events
 

--- a/testsuite/tests/lib-runtime-events/test_caml_runparams.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml_runparams.ml
@@ -1,6 +1,8 @@
 (* TEST
 include runtime_events
 ocamlrunparam += ",e=4"
+* skip
+reason = "OCaml 5 only"
 *)
 
 (* We set the ring buffer size smaller and witness that we do indeed

--- a/testsuite/tests/lib-runtime-events/test_dropped_events.ml
+++ b/testsuite/tests/lib-runtime-events/test_dropped_events.ml
@@ -2,9 +2,11 @@
    include runtime_events
    include unix
    set OCAMLRUNPARAM = "e=6"
-   * libunix
-   ** native
-   ** bytecode
+   * skip
+   reason = "OCaml 5 only"
+   ** libunix
+   *** native
+   *** bytecode
 *)
 
 type Runtime_events.User.tag += Ev

--- a/testsuite/tests/lib-runtime-events/test_external_preserve.ml
+++ b/testsuite/tests/lib-runtime-events/test_external_preserve.ml
@@ -2,9 +2,11 @@
   include runtime_events
   include unix
   set OCAML_RUNTIME_EVENTS_PRESERVE = "1"
-  * libunix
-  ** bytecode
-  ** native *)
+  * skip
+  reason = "OCaml 5 only"
+  ** libunix
+  *** bytecode
+  *** native *)
 
   (* this tests the preservation of ring buffers after termination *)
 

--- a/testsuite/tests/lib-runtime-events/test_user_event.ml
+++ b/testsuite/tests/lib-runtime-events/test_user_event.ml
@@ -1,5 +1,7 @@
 (* TEST
 include runtime_events
+* skip
+reason = "OCaml 5 only"
 *)
 open Runtime_events
 

--- a/testsuite/tests/lib-runtime-events/test_user_event_unknown.ml
+++ b/testsuite/tests/lib-runtime-events/test_user_event_unknown.ml
@@ -2,9 +2,11 @@
    include runtime_events
    include unix
    set OCAML_RUNTIME_EVENTS_PRESERVE = "1"
-   * libunix
-   ** bytecode
-   ** native
+   * skip
+   reason = "OCaml 5 only"
+   ** libunix
+   *** bytecode
+   *** native
 *)
 open Runtime_events
 

--- a/testsuite/tests/lib-systhreads/boundscheck.ml
+++ b/testsuite/tests/lib-systhreads/boundscheck.ml
@@ -1,9 +1,11 @@
 (* TEST
 
 include systhreads
-* hassysthreads
-** bytecode
-** native
+* skip
+reason = "OCaml 5 only"
+** hassysthreads
+*** bytecode
+*** native
 
 *)
 

--- a/testsuite/tests/memory-model/forbidden.ml
+++ b/testsuite/tests/memory-model/forbidden.ml
@@ -1,8 +1,10 @@
 (* TEST
   modules="opt.ml barrier.ml hist.ml shared.ml run.ml outcome.ml"
-  * not-bsd
-  ** bytecode
-  ** native
+  * skip
+  reason = "OCaml 5 only"
+  ** not-bsd
+  *** bytecode
+  *** native
 *)
 
 (* Memory model test:

--- a/testsuite/tests/memory-model/publish.ml
+++ b/testsuite/tests/memory-model/publish.ml
@@ -1,9 +1,11 @@
 (* TEST
   modules="opt.ml barrier.ml hist.ml shared.ml run.ml outcome.ml"
-  * not-bsd
-  ** not-windows
-  *** bytecode
-  ** native
+  * skip
+  reason = "OCaml 5 only"
+  ** not-bsd
+  *** not-windows
+  **** bytecode
+  *** native
 *)
 
 (* Memory model: test the _publish idiom *)

--- a/testsuite/tests/parallel/domain_parallel_spawn_burn_gc_set.ml
+++ b/testsuite/tests/parallel/domain_parallel_spawn_burn_gc_set.ml
@@ -1,4 +1,6 @@
 (* TEST
+* skip
+reason = "OCaml 5 only"
 *)
 
 open Domain

--- a/testsuite/tests/parallel/recommended_domain_count.ml
+++ b/testsuite/tests/parallel/recommended_domain_count.ml
@@ -1,5 +1,7 @@
 (* TEST
 modules = "recommended_domain_count_cstubs.c"
+* skip
+reason = "OCaml 5 only"
 *)
 
 external get_max_domains : unit -> int = "caml_get_max_domains"

--- a/testsuite/tests/parallel/recommended_domain_count_unix.ml
+++ b/testsuite/tests/parallel/recommended_domain_count_unix.ml
@@ -1,8 +1,10 @@
 (* TEST
-* hasunix
+* skip
+reason = "OCaml 5 only"
+** hasunix
 include unix
-** bytecode
-** native
+*** bytecode
+*** native
 *)
 
 let try_ext cmd =

--- a/testsuite/tests/parallel/test_issue_11094.ml
+++ b/testsuite/tests/parallel/test_issue_11094.ml
@@ -1,6 +1,8 @@
 (* TEST
-* bytecode
-* native
+* skip
+reason = "OCaml 5 only"
+** bytecode
+** native
 *)
 
 open Effect

--- a/testsuite/tests/weak-ephe-final/weaktest_par_load.ml
+++ b/testsuite/tests/weak-ephe-final/weaktest_par_load.ml
@@ -1,4 +1,7 @@
-(* TEST *)
+(* TEST
+* skip
+reason = "OCaml 5 only"
+*)
 
 (* Testing unsynchronized, parallel Weak usage *)
 


### PR DESCRIPTION
Reviewer: @mshinwell ?

Cherry-pick commits from https://github.com/dra27/ocaml for disabling tests that rely on the OCaml 5 runtime.