### PR TITLE
Ocaml 5 on runtime4: stdlib (except 46aea8c924)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -142,6 +142,7 @@ testsuite/tests/lib-dynlink-domains/main.ml  typo.very-long-line
 testsuite/tests/tool-ocamltest/norm*.reference binary
 
 tools/magic                       typo.missing-header
+tools/eventlog_metadata.in        typo.missing-header
 
 # TODO we should fix the long-line errors in yacc/*.c
 /yacc/*.[ch]         typo.very-long-line=may

--- a/Makefile
+++ b/Makefile
@@ -625,6 +625,7 @@ runtime_COMMON_C_SOURCES = \
   debugger \
   domain \
   dynlink \
+  eventlog \
   extern \
   fiber \
   finalise \
@@ -652,8 +653,6 @@ runtime_COMMON_C_SOURCES = \
   printexc \
   prng \
   roots \
-  runtime_events \
-  shared_heap \
   signals \
   skiplist \
   startup_aux \
@@ -1075,7 +1074,9 @@ clean::
 
 # Dependencies
 
-subdirs = stdlib $(addprefix otherlibs/, $(ALL_OTHERLIBS)) \
+subdirs = \
+  stdlib $(addprefix otherlibs/, \
+    $(filter-out runtime_events, $(ALL_OTHERLIBS))) \
   debugger ocamldoc ocamltest
 
 .PHONY: alldepend

--- a/configure
+++ b/configure
@@ -3391,6 +3391,8 @@ ac_config_files="$ac_config_files ocamltest/ocamltest_config.ml"
 
 ac_config_files="$ac_config_files utils/config.generated.ml"
 
+ac_config_files="$ac_config_files tools/eventlog_metadata"
+
 ac_config_headers="$ac_config_headers runtime/caml/m.h"
 
 ac_config_headers="$ac_config_headers runtime/caml/s.h"
@@ -13616,9 +13618,7 @@ case $host in #(
     exeext='' ;;
 esac
 
-otherlibraries="dynlink runtime_events"
-lib_dynlink=true
-lib_runtime_events=true
+otherlibraries="dynlink"
 if test x"$enable_unix_lib" != "xno"
 then :
   enable_unix_lib=yes
@@ -21222,6 +21222,7 @@ do
     "manual/src/html_processing/src/common.ml") CONFIG_FILES="$CONFIG_FILES manual/src/html_processing/src/common.ml" ;;
     "ocamltest/ocamltest_config.ml") CONFIG_FILES="$CONFIG_FILES ocamltest/ocamltest_config.ml" ;;
     "utils/config.generated.ml") CONFIG_FILES="$CONFIG_FILES utils/config.generated.ml" ;;
+    "tools/eventlog_metadata") CONFIG_FILES="$CONFIG_FILES tools/eventlog_metadata" ;;
     "runtime/caml/m.h") CONFIG_HEADERS="$CONFIG_HEADERS runtime/caml/m.h" ;;
     "runtime/caml/s.h") CONFIG_HEADERS="$CONFIG_HEADERS runtime/caml/s.h" ;;
     "runtime/caml/version.h") CONFIG_HEADERS="$CONFIG_HEADERS runtime/caml/version.h" ;;

--- a/configure.ac
+++ b/configure.ac
@@ -656,6 +656,7 @@ AS_CASE([$host],
 
 dnl otherlibraries="dynlink runtime_events"
 otherlibraries="dynlink"
+lib_dynlink=true
 AS_IF([test x"$enable_unix_lib" != "xno"],
   [enable_unix_lib=yes
   AC_CONFIG_FILES([otherlibs/unix/META])

--- a/configure.ac
+++ b/configure.ac
@@ -234,6 +234,7 @@ AC_CONFIG_FILES([manual/src/version.tex])
 AC_CONFIG_FILES([manual/src/html_processing/src/common.ml])
 AC_CONFIG_FILES([ocamltest/ocamltest_config.ml])
 AC_CONFIG_FILES([utils/config.generated.ml])
+AC_CONFIG_FILES([tools/eventlog_metadata])
 AC_CONFIG_HEADERS([runtime/caml/m.h])
 AC_CONFIG_HEADERS([runtime/caml/s.h])
 AC_CONFIG_HEADERS([runtime/caml/version.h])
@@ -653,9 +654,8 @@ AS_CASE([$host],
     [exeext=".exe"],
   [exeext=''])
 
-otherlibraries="dynlink runtime_events"
-lib_dynlink=true
-lib_runtime_events=true
+dnl otherlibraries="dynlink runtime_events"
+otherlibraries="dynlink"
 AS_IF([test x"$enable_unix_lib" != "xno"],
   [enable_unix_lib=yes
   AC_CONFIG_FILES([otherlibs/unix/META])

--- a/configure.ac
+++ b/configure.ac
@@ -654,9 +654,12 @@ AS_CASE([$host],
     [exeext=".exe"],
   [exeext=''])
 
+dnl CR ocaml 5 runtime:
 dnl otherlibraries="dynlink runtime_events"
 otherlibraries="dynlink"
 lib_dynlink=true
+dnl CR ocaml 5 runtime:
+dnl lib_runtime_events = true
 AS_IF([test x"$enable_unix_lib" != "xno"],
   [enable_unix_lib=yes
   AC_CONFIG_FILES([otherlibs/unix/META])

--- a/otherlibs/unix/fork.c
+++ b/otherlibs/unix/fork.c
@@ -17,11 +17,16 @@
 
 #include <caml/mlvalues.h>
 #include <caml/debugger.h>
+#if 0 /* BACKPORT BEGIN */
 #include <caml/runtime_events.h>
+#endif
+#include <caml/eventlog.h>
+/* BACKPORT END */
 #include "unixsupport.h"
 #include <caml/domain.h>
 #include <caml/fail.h>
 
+#if 0 /* BACKPORT */
 /* Post-fork tasks to be carried out in the parent */
 void caml_atfork_parent(pid_t child_pid) {
   CAML_EV_LIFECYCLE(EV_FORK_PARENT, child_pid);
@@ -32,6 +37,7 @@ void caml_atfork_child(void) {
   caml_runtime_events_post_fork();
   CAML_EV_LIFECYCLE(EV_FORK_CHILD, 0);
 }
+#endif
 
 CAMLprim value caml_unix_fork(value unit)
 {
@@ -41,10 +47,15 @@ CAMLprim value caml_unix_fork(value unit)
       ("Unix.fork may not be called while other domains were created");
   }
 
+/* BACKPORT BEGIN */
+  CAML_EV_FLUSH();
+/* BACKPORT END */
+
   ret = fork();
 
   if (ret == -1) caml_uerror("fork", Nothing);
 
+#if 0 /* BACKPORT BEGIN */
   if (ret == 0) {
     caml_atfork_child();
     /* the following hook can be redefined in other places */
@@ -52,6 +63,12 @@ CAMLprim value caml_unix_fork(value unit)
   } else {
     caml_atfork_parent(ret);
   }
+#endif
+  CAML_EVENTLOG_DO({
+      if (ret == 0)
+        caml_eventlog_disable();
+  });
+/* BACKPORT END */
 
   if (caml_debugger_in_use)
     if ((caml_debugger_fork_mode && ret == 0) ||

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -69,10 +69,6 @@ STDLIB_MODULE_BASENAMES = \
   stack \
   queue \
   buffer \
-  mutex \
-  condition \
-  semaphore \
-  domain \
   camlinternalFormat \
   printf \
   arg \
@@ -102,8 +98,7 @@ STDLIB_MODULE_BASENAMES = \
   stdLabels \
   in_channel \
   out_channel \
-  camlinternalComprehensions \
-  effect
+  camlinternalComprehensions
 
 STDLIB_PREFIXED_MODULES = \
   $(filter-out stdlib camlinternal%, $(STDLIB_MODULE_BASENAMES))

--- a/stdlib/atomic.ml
+++ b/stdlib/atomic.ml
@@ -12,6 +12,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(* BACKPORT BEGIN
 type !'a t
 
 external make : 'a -> 'a t = "%makemutable"
@@ -19,8 +20,53 @@ external get : 'a t -> 'a = "%atomic_load"
 external exchange : 'a t -> 'a -> 'a = "%atomic_exchange"
 external compare_and_set : 'a t -> 'a -> 'a -> bool = "%atomic_cas"
 external fetch_and_add : int t -> int -> int = "%atomic_fetch_add"
+*)
+external ( == ) : 'a -> 'a -> bool = "%eq"
+external ( + ) : int -> int -> int = "%addint"
+(* BACKPORT END *)
 external ignore : 'a -> unit = "%ignore"
 
+(* BACKPORT BEGIN *)
+(* We are not reusing ('a ref) directly to make it easier to reason
+   about atomicity if we wish to: even in a sequential implementation,
+   signals and other asynchronous callbacks might break atomicity. *)
+type 'a t = {mutable v: 'a}
+
+let make v = {v}
+let get r = r.v
+let set r v = r.v <- v
+
+(* The following functions are set to never be inlined: Flambda is
+   allowed to move surrounding code inside the critical section,
+   including allocations. *)
+
+let[@inline never] exchange r v =
+  (* BEGIN ATOMIC *)
+  let cur = r.v in
+  r.v <- v;
+  (* END ATOMIC *)
+  cur
+
+let[@inline never] compare_and_set r seen v =
+  (* BEGIN ATOMIC *)
+  let cur = r.v in
+  if cur == seen then (
+    r.v <- v;
+    (* END ATOMIC *)
+    true
+  ) else
+    false
+
+let[@inline never] fetch_and_add r n =
+  (* BEGIN ATOMIC *)
+  let cur = r.v in
+  r.v <- (cur + n);
+  (* END ATOMIC *)
+  cur
+
+(* BACKPORT END *)
+(* BACKPORT
 let set r x = ignore (exchange r x)
+*)
 let incr r = ignore (fetch_and_add r 1)
 let decr r = ignore (fetch_and_add r (-1))

--- a/stdlib/bigarray.ml
+++ b/stdlib/bigarray.ml
@@ -50,7 +50,6 @@ type ('a, 'b) kind =
   | Complex32 : (Complex.t, complex32_elt) kind
   | Complex64 : (Complex.t, complex64_elt) kind
   | Char : (char, int8_unsigned_elt) kind
-  | Float16 : (float, float16_elt) kind
 
 type c_layout = C_layout_typ
 type fortran_layout = Fortran_layout_typ (**)

--- a/stdlib/bigarray.ml
+++ b/stdlib/bigarray.ml
@@ -37,7 +37,7 @@ type complex32_elt = Complex32_elt
 type complex64_elt = Complex64_elt
 
 type ('a, 'b) kind =
-    Float32 : (float, float32_elt) kind
+  | Float32 : (float, float32_elt) kind
   | Float64 : (float, float64_elt) kind
   | Int8_signed : (int, int8_signed_elt) kind
   | Int8_unsigned : (int, int8_unsigned_elt) kind
@@ -50,6 +50,7 @@ type ('a, 'b) kind =
   | Complex32 : (Complex.t, complex32_elt) kind
   | Complex64 : (Complex.t, complex64_elt) kind
   | Char : (char, int8_unsigned_elt) kind
+  | Float16 : (float, float16_elt) kind
 
 type c_layout = C_layout_typ
 type fortran_layout = Fortran_layout_typ (**)

--- a/stdlib/bigarray.mli
+++ b/stdlib/bigarray.mli
@@ -107,7 +107,7 @@ type complex32_elt = Complex32_elt
 type complex64_elt = Complex64_elt
 
 type ('a, 'b) kind =
-    Float32 : (float, float32_elt) kind
+  | Float32 : (float, float32_elt) kind
   | Float64 : (float, float64_elt) kind
   | Int8_signed : (int, int8_signed_elt) kind
   | Int8_unsigned : (int, int8_unsigned_elt) kind
@@ -120,6 +120,7 @@ type ('a, 'b) kind =
   | Complex32 : (Complex.t, complex32_elt) kind
   | Complex64 : (Complex.t, complex64_elt) kind
   | Char : (char, int8_unsigned_elt) kind (**)
+  | Float16 : (float, float16_elt) kind
 (** To each element kind is associated an OCaml type, which is
    the type of OCaml values that can be stored in the Bigarray
    or read back from it.  This type is not necessarily the same

--- a/stdlib/bigarray.mli
+++ b/stdlib/bigarray.mli
@@ -120,7 +120,6 @@ type ('a, 'b) kind =
   | Complex32 : (Complex.t, complex32_elt) kind
   | Complex64 : (Complex.t, complex64_elt) kind
   | Char : (char, int8_unsigned_elt) kind (**)
-  | Float16 : (float, float16_elt) kind
 (** To each element kind is associated an OCaml type, which is
    the type of OCaml values that can be stored in the Bigarray
    or read back from it.  This type is not necessarily the same

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -341,6 +341,18 @@ let temp_file_name temp_dir prefix suffix =
   let rnd = (Random.State.bits random_state) land 0xFFFFFF in
   concat temp_dir (Printf.sprintf "%s%06x%s" prefix rnd suffix)
 
+(* BACKPORT BEGIN *)
+module Domain = struct
+  module DLS = struct
+    let new_key ~split_from_parent:_ f =
+      ref (f ())
+
+    let get = (!)
+    let set = (:=)
+  end
+end
+(* BACKPORT END *)
+
 let current_temp_dir_name =
   Domain.DLS.new_key ~split_from_parent:Fun.id (fun () -> temp_dir_name)
 

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -135,6 +135,11 @@ let delete_alarm a = Atomic.set a false
 
 module Memprof =
   struct
+(* BACKPORT BEGIN
+    type t
+*)
+    type t = unit
+(* BACKPORT END *)
     type allocation_source = Normal | Marshal | Custom
     type allocation =
       { n_samples : int;
@@ -169,4 +174,10 @@ module Memprof =
       c_start sampling_rate callstack_size tracker
 
     external stop : unit -> unit = "caml_memprof_stop"
+
+(* BACKPORT BEGIN
+    external discard : t -> unit = "caml_memprof_discard"
+*)
+    let discard _ = failwith "4.x memprof doesn't support discard"
+(* BACKPORT END *)
   end

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -463,6 +463,13 @@ external eventlog_resume : unit -> unit = "caml_eventlog_resume"
    notice. *)
 module Memprof :
   sig
+(* BACKPORT BEGIN
+    type t
+*)
+    type t = unit
+(* BACKPORT END *)
+    (** the type of a profile *)
+
     type allocation_source = Normal | Marshal | Custom
     type allocation = private
       { n_samples : int;

--- a/stdlib/marshal.ml
+++ b/stdlib/marshal.ml
@@ -50,7 +50,11 @@ external from_channel: in_channel -> 'a = "caml_input_value"
 external from_bytes_unsafe: bytes -> int -> 'a = "caml_input_value_from_bytes"
 external data_size_unsafe: bytes -> int -> int = "caml_marshal_data_size"
 
+(* BACKPORT BEGIN
 let header_size = 16
+*)
+let header_size = 20
+(* BACKPORT END *)
 let data_size buff ofs =
   if ofs < 0 || ofs > Bytes.length buff - header_size
   then invalid_arg "Marshal.data_size"

--- a/stdlib/random.ml
+++ b/stdlib/random.ml
@@ -243,7 +243,11 @@ let self_init () = full_init (random_seed())
 
 (* Splitting *)
 
+(* BACKPORT BEGIN
 let split () = State.split (Domain.DLS.get random_key)
+*)
+let split () = State.split default
+(* BACKPORT END *)
 
 (* Manipulating the current state. *)
 

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -554,11 +554,27 @@ let ( ^^ ) (Format (fmt1, str1)) (Format (fmt2, str2)) =
 external sys_exit : int -> 'a = "caml_sys_exit"
 
 (* for at_exit *)
+(* BACKPORT BEGIN
 type 'a atomic_t
 external atomic_make : 'a -> 'a atomic_t = "%makemutable"
 external atomic_get : 'a atomic_t -> 'a = "%atomic_load"
 external atomic_compare_and_set : 'a atomic_t -> 'a -> 'a -> bool
   = "%atomic_cas"
+*)
+type 'a t = {mutable v: 'a}
+
+let atomic_make v = {v}
+let atomic_get r = r.v
+let[@inline never] atomic_compare_and_set r seen v =
+  (* BEGIN ATOMIC *)
+  let cur = r.v in
+  if cur == seen then (
+    r.v <- v;
+    (* END ATOMIC *)
+    true
+  ) else
+    false
+(* BACKPORT END *)
 
 let exit_function = atomic_make flush_all
 

--- a/testsuite/tests/instrumented-runtime/main.ml
+++ b/testsuite/tests/instrumented-runtime/main.ml
@@ -1,0 +1,13 @@
+(* TEST
+  * instrumented-runtime
+  ** native
+    flags = "-runtime-variant=i"
+*)
+
+(* Test if the instrumented runtime is in working condition *)
+
+[@@@ocaml.alert "-deprecated"]
+
+let _ =
+  Gc.eventlog_pause ();
+  Gc.eventlog_resume()

--- a/testsuite/tests/instrumented-runtime/main.run
+++ b/testsuite/tests/instrumented-runtime/main.run
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+export OCAML_EVENTLOG_ENABLED=1
+export OCAML_EVENTLOG_PREFIX=${program}
+
+if [ "${os_type}" = "Win32" ] ; then
+  program=$(cygpath "$program")
+fi
+
+rm -f "${program}"*.eventlog*
+${program} > ${output} &
+
+pid=$!
+wait $pid
+
+ls "${program}".*.eventlog | grep '\.[0-9][0-9]*\.eventlog$' | \
+while IFS= read -r file; do
+  touch ${program}.eventlogs
+  if [ ! -e "${program}.eventlog" ] ; then
+    touch ${program}.eventlog
+  else
+    rm -f ${program}.eventlog
+    break
+  fi
+done
+
+if [ -f "${program}.eventlog" ]; then
+  exit ${TEST_PASS}
+elif [ -f "${program}.eventlogs" ]; then
+  echo 'too many runtime traces found!' > ${ocamltest_response}
+  exit ${TEST_FAIL}
+else
+  echo 'instrumented runtime trace not found!' > ${ocamltest_response}
+  exit ${TEST_FAIL}
+fi

--- a/testsuite/tests/lib-bigarray/bigarrays.ml
+++ b/testsuite/tests/lib-bigarray/bigarrays.ml
@@ -244,6 +244,23 @@ let tests () =
     done;
     test 16 true !return
   end;
+(*
+  test 17 true
+    (test_setget float16
+                 [0.0, 0.0;
+                  -0.5, -0.5;
+                  1.0, 1.0;
+                  infinity, infinity;
+                  neg_infinity, neg_infinity;
+                  Float.min_float, 0.0;
+                  Float.max_float, infinity;
+                  65504.0, 65504.0;
+                  -65504.0, -65504.0;
+                  65519.0, 65504.0;
+                  -65519.0, -65504.0;
+                  65520.0, infinity;
+                  -65520.0, neg_infinity]);
+*)
 
   testing_function "set/get (specialized)";
   let a = Array1.create int c_layout 3 in

--- a/testsuite/tests/lib-bigarray/specialized.ml
+++ b/testsuite/tests/lib-bigarray/specialized.ml
@@ -1,0 +1,95 @@
+(* TEST *)
+
+open Bigarray
+
+(* Check that type-specialized accesses produce the same results
+   as generic accesses *)
+
+let generic (a: ('a, 'b, 'c) Array1.t) v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+(*
+let special_float16 (a: (float, float16_elt, c_layout) Array1.t) v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+*)
+
+let special_float32 (a: (float, float32_elt, c_layout) Array1.t) v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_float64 (a: (float, float64_elt, c_layout) Array1.t) v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_int8s (a: (int, int8_signed_elt, c_layout) Array1.t) v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_int8u (a: (int, int8_unsigned_elt, c_layout) Array1.t) v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_int16s (a: (int, int16_signed_elt, c_layout) Array1.t) v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_int16u (a: (int, int16_unsigned_elt, c_layout) Array1.t) v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_int32 (a: (int32, int32_elt, c_layout) Array1.t) v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_int64 (a: (int64, int64_elt, c_layout) Array1.t) v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_int (a: (int, int_elt, c_layout) Array1.t) v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_nativeint (a: (nativeint, nativeint_elt, c_layout) Array1.t)
+                      v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_complex32 (a: (Complex.t, complex32_elt, c_layout) Array1.t)
+                      v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_complex64 (a: (Complex.t, complex64_elt, c_layout) Array1.t)
+                      v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_char (a: (char, int8_unsigned_elt, c_layout) Array1.t) v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let test kind special v0 v1 v2 =
+  let a = Array1.create kind c_layout 3 in
+  let s = special a v0 v1 v2 in
+  let g = generic a v0 v1 v2 in
+  assert (s = g)
+
+let _ =
+(*
+  test float16 special_float16 1.0 (-2.0) Float.pi;
+*)
+  test float32 special_float32 1.0 (-2.0) Float.pi;
+  test float64 special_float64 1.0 (-2.0) Float.pi;
+  test int8_signed special_int8s 123 (-456) 0xFF00FF;
+  test int8_unsigned special_int8u 123 (-456) 0xFF00FF;
+  test int16_signed special_int16s 123 (-456) 0xFF00FF;
+  test int16_unsigned special_int16u 123 (-456) 0xFF00FF;
+  test int32 special_int32 123l (-456l) (0x22334455l);
+  test int64 special_int64 123L (-456L) (0x2233445566778899L);
+  test int special_int 123 (-456) 0xFF00FF;
+  test nativeint special_nativeint 123n (-456n) (0x22334455n);
+  test complex32 special_complex32 Complex.zero Complex.one Complex.i;
+  test complex64 special_complex64 Complex.zero Complex.one Complex.i;
+  test char special_char 'A' '-' 'Z'

--- a/testsuite/tests/lib-runtime-events/test.ml
+++ b/testsuite/tests/lib-runtime-events/test.ml
@@ -1,6 +1,8 @@
 (* TEST
 modules = "stubs.c"
 include runtime_events
+* skip
+reason = "OCaml 5 only"
 *)
 
 external start_runtime_events : unit -> unit = "start_runtime_events"

--- a/testsuite/tests/lib-runtime-events/test_caml.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml.ml
@@ -1,5 +1,7 @@
 (* TEST
 include runtime_events
+* skip
+reason = "OCaml 5 only"
 *)
 open Runtime_events
 

--- a/testsuite/tests/lib-runtime-events/test_caml_exception.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml_exception.ml
@@ -1,5 +1,7 @@
 (* TEST
 include runtime_events
+* skip
+reason = "OCaml 5 only"
 *)
 open Runtime_events
 

--- a/testsuite/tests/lib-runtime-events/test_caml_parallel.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml_parallel.ml
@@ -1,5 +1,7 @@
 (* TEST
 include runtime_events
+* skip
+reason = "OCaml 5 only"
 *)
 open Runtime_events
 

--- a/testsuite/tests/lib-runtime-events/test_caml_reentry.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml_reentry.ml
@@ -1,5 +1,7 @@
 (* TEST
 include runtime_events
+* skip
+reason = "OCaml 5 only"
 *)
 open Runtime_events
 

--- a/testsuite/tests/lib-runtime-events/test_caml_slot_reuse.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml_slot_reuse.ml
@@ -1,5 +1,7 @@
 (* TEST
 include runtime_events
+* skip
+reason = "OCaml 5 only"
 *)
 open Runtime_events
 

--- a/testsuite/tests/lib-runtime-events/test_caml_stubs_gc.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml_stubs_gc.ml
@@ -1,5 +1,7 @@
 (* TEST
 include runtime_events
+* skip
+reason = "OCaml 5 only"
 *)
 open Runtime_events
 

--- a/testsuite/tests/lib-runtime-events/test_env_start.ml
+++ b/testsuite/tests/lib-runtime-events/test_env_start.ml
@@ -1,6 +1,8 @@
 (* TEST
 include runtime_events
 set OCAML_RUNTIME_EVENTS_START = "1"
+* skip
+reason = "OCaml 5 only"
 *)
 
 (* In this test the runtime_events should already be started by the environment

--- a/testsuite/tests/lib-runtime-events/test_external.ml
+++ b/testsuite/tests/lib-runtime-events/test_external.ml
@@ -1,4 +1,6 @@
 (* TEST
+   * skip
+   reason = "OCaml 5 only"
    include runtime_events
    include unix
    * libunix

--- a/testsuite/tests/lib-runtime-events/test_fork.ml
+++ b/testsuite/tests/lib-runtime-events/test_fork.ml
@@ -1,4 +1,7 @@
 (* TEST
+   * skip
+   reason = "OCaml 5 only"
+
    include runtime_events
    include unix
    * libunix

--- a/testsuite/tests/lib-runtime-events/test_instrumented.ml
+++ b/testsuite/tests/lib-runtime-events/test_instrumented.ml
@@ -1,4 +1,7 @@
 (* TEST
+   * skip
+   reason = "OCaml 5 only"
+
    include runtime_events
    flags = "-runtime-variant=i"
 

--- a/testsuite/tests/statmemprof/callstacks.flat-float-array.reference
+++ b/testsuite/tests/statmemprof/callstacks.flat-float-array.reference
@@ -56,7 +56,7 @@ Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
 Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
 -----------
-Raised by primitive operation at Stdlib__Marshal.from_bytes in file "marshal.ml", line 65, characters 9-35
+Raised by primitive operation at Stdlib__Marshal.from_bytes in file "marshal.ml", line 66, characters 9-35
 Called from Callstacks.alloc_unmarshal in file "callstacks.ml", line 62, characters 12-87
 Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15

--- a/tools/eventlog_metadata.in
+++ b/tools/eventlog_metadata.in
@@ -1,0 +1,256 @@
+/* CTF 1.8 */
+
+typealias integer {size = 8;}  := uint8_t;
+typealias integer {size = 16;} := uint16_t;
+typealias integer {size = 32;} := uint32_t;
+typealias integer {size = 64;} := uint64_t;
+
+clock {
+    name = tracing_clock;
+    freq = 1000000000; /* tick = 1 ns */
+};
+
+typealias integer {
+    size = 64;
+    map = clock.tracing_clock.value;
+} := tracing_clock_int_t;
+
+
+/*
+
+Main trace description,
+major and minor refers to the CTF version being used.
+
+The packet header must contain at the very least
+a stream id and the CTF magic number.
+We only use one stream for now, and CTF magic number is 0xc1fc1fc1.
+
+We add an extra field ocaml_trace_version to enable simpler transition if we add
+or remove metrics in the future.
+
+*/
+trace {
+    major = 1;
+    minor = 8;
+    byte_order = @endianness@;
+    packet.header := struct {
+        uint32_t magic; /* required: must contain CTF magic number */
+        uint16_t ocaml_trace_version; /* our own trace format versioning */
+        uint16_t stream_id; /* required, although we have only one. */
+    };
+};
+
+/*
+
+We use only one stream at the moment.
+Each event payload must contain a header with a timestamp and a pid.
+The id field refers to the various event kinds defined further down this file.
+
+*/
+stream {
+    id = 0;
+    event.header := struct { /* for each event */
+        tracing_clock_int_t timestamp;
+        uint32_t id;
+    };
+    event.context := struct {
+        uint32_t tid;
+        uint8_t is_backup_thread;
+    };
+};
+
+/*
+
+These enumerations are mostly following the instrumented runtime datapoints.
+gc_phase aims to track the entry and exit time of each of the following events
+during collection.
+
+*/
+enum gc_phase : uint16_t {
+    "compact/main" = 0,
+    "compact/recompact",
+    "explicit/gc_set",
+    "explicit/gc_stat",
+    "explicit/gc_minor",
+    "explicit/gc_major",
+    "explicit/gc_full_major",
+    "explicit/gc_compact",
+    "major",
+    "major/roots",
+    "major/sweep",
+    "major/mark/roots",
+    "major/mark/main",
+    "major/mark/final",
+    "major/mark",
+    "major/mark/global_roots_slice",
+    "major_roots/global",
+    "major_roots/dynamic_global",
+    "major_roots/local",
+    "major_roots/C",
+    "major_roots/finalised",
+    "major_roots/memprof",
+    "major_roots/hook",
+    "major/check_and_compact",
+    "minor",
+    "minor/local_roots",
+    "minor/ref_tables",
+    "minor/copy",
+    "minor/update_weak",
+    "minor/finalized",
+    "explicit/gc_major_slice",
+    "domain/spawn",
+    "domain/send_interrupt",
+    "domain/idle_wait",
+    "finalise/update_first",
+    "finalise/update_last",
+    "interrupt/gc",
+    "interrupt/remote",
+    "major/ephe_mark",
+    "major/ephe_sweep",
+    "major/finish_marking",
+    "major_gc/cycle_domains",
+    "major_gc/phase_change",
+    "major_gc/stw",
+    "major/mark_opportunistic",
+    "major/slice",
+    "minor/clear",
+    "minor/finalizers/oldify",
+    "minor/global_roots",
+    "minor/leave_barrier",
+    "stw/api_barrier",
+    "stw/handler",
+    "stw/leader",
+    "minor/clear",
+    "minor_finalized",
+    "minor_finalizers_oldify",
+    "minor_global_roots",
+    "minor_leave_barrier",
+    "minor_local_roots",
+    "minor_ref_tables",
+    "minor_update_weak",
+    "stw_api_barrier",
+    "stw_handler",
+    "stw_leader",
+    "major_finish_sweeping",
+    "minor_finalizers_admin",
+    "domain/condition_wait",
+    "domain/resize_minor_heap_reservation"
+};
+
+/*
+
+Miscellaneous GC counters
+
+*/
+enum gc_counter : uint16_t {
+    "alloc_jump",
+    "force_minor/alloc_small",
+    "force_minor/make_vect",
+    "force_minor/set_minor_heap_size",
+    "force_minor/weak",
+    "force_minor/memprof",
+    "major/mark/slice/remain",
+    "major/mark/slice/fields",
+    "major/mark/slice/pointers",
+    "major/work/extra",
+    "major/work/mark",
+    "major/work/sweep",
+    "minor/promoted",
+    "request_major/alloc_shr",
+    "request_major/adjust_gc_speed",
+    "request_minor/realloc_ref_table",
+    "request_minor/realloc_ephe_ref_table",
+    "request_minor/realloc_custom_table"
+};
+
+/*
+
+Block allocation counters, per size buckets.
+
+*/
+enum alloc_bucket : uint8_t {
+  "alloc 01" = 1,
+  "alloc 02",
+  "alloc 03",
+  "alloc 04",
+  "alloc 05",
+  "alloc 06",
+  "alloc 07",
+  "alloc 08",
+  "alloc 09",
+  "alloc 10-19",
+  "alloc 20-29",
+  "alloc 30-39",
+  "alloc 40-49",
+  "alloc 50-59",
+  "alloc 60-69",
+  "alloc 70-79",
+  "alloc 80-89",
+  "alloc 90-99",
+  "alloc large"
+};
+
+/*
+
+Each event is comprised of the previously defined event.header
+and the fields defined here.
+
+An entry event marks the start of a gc phase.
+
+*/
+event {
+    id = 0;
+    name = "entry";
+    stream_id = 0;
+    fields := struct {
+        enum gc_phase phase;
+    };
+};
+
+/*
+
+exit counterparts to entry events
+
+*/
+event {
+    id = 1;
+    name = "exit";
+    stream_id = 0;
+    fields := struct {
+        enum gc_phase phase;
+    };
+};
+
+event {
+    id = 2;
+    name = "counter";
+    stream_id = 0;
+    fields := struct {
+        uint64_t count;
+        enum gc_counter kind;
+    };
+};
+
+event {
+    id = 3;
+    name = "alloc";
+    stream_id = 0;
+    fields := struct {
+        uint64_t count;
+        enum alloc_bucket bucket;
+    };
+};
+
+/*
+ Flush events are used to track the time spent by the tracing runtime flushing
+ data to disk, useful to remove flushing overhead for other runtime measurements
+ in the trace.
+*/
+event {
+     id = 4;
+     name = "flush";
+     stream_id = 0;
+     fields := struct {
+        tracing_clock_int_t duration;
+     };
+};


### PR DESCRIPTION
This should be everything from the stdlib backports, except the stdlib part of `46aea8c924`, which conflicts badly and I will look at separately.