### PR TITLE
OCaml 5 on 4 runtime: Backport stdlib pieces of 46aea8c924

### DIFF
--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -69,10 +69,6 @@ STDLIB_MODULE_BASENAMES = \
   stack \
   queue \
   buffer \
-  mutex \
-  condition \
-  semaphore \
-  domain \
   camlinternalFormat \
   printf \
   arg \
@@ -102,8 +98,7 @@ STDLIB_MODULE_BASENAMES = \
   stdLabels \
   in_channel \
   out_channel \
-  camlinternalComprehensions \
-  effect
+  camlinternalComprehensions
 
 STDLIB_PREFIXED_MODULES = \
   $(filter-out stdlib camlinternal%, $(STDLIB_MODULE_BASENAMES))

--- a/stdlib/camlinternalLazy.ml
+++ b/stdlib/camlinternalLazy.ml
@@ -26,6 +26,9 @@ type 'a t = 'a lazy_t
 
 exception Undefined
 
+(* CR ocaml 5 runtime:
+   BACKPORT BEGIN
+
 (* [update_to_forcing blk] tries to update a [blk] with [lazy_tag] to
    [forcing_tag] using compare-and-swap (CAS), taking care to handle concurrent
    marking of the header word by a concurrent GC thread. Returns [0] if the
@@ -110,3 +113,58 @@ let force_gen ~only_val (lzv : 'arg lazy_t) =
   else if t = Obj.forcing_tag then raise Undefined
   else if t <> Obj.lazy_tag then (Obj.obj x : 'arg)
   else force_gen_lazy_block ~only_val lzv
+*)
+let raise_undefined = Obj.repr (fun () -> raise Undefined)
+
+external make_forward : Obj.t -> Obj.t -> unit = "caml_obj_make_forward"
+
+(* Assume [blk] is a block with tag lazy *)
+let force_lazy_block (blk : 'arg lazy_t) =
+  let closure = (Obj.obj (Obj.field (Obj.repr blk) 0) : unit -> 'arg) in
+  Obj.set_field (Obj.repr blk) 0 raise_undefined;
+  try
+    let result = closure () in
+    make_forward (Obj.repr blk) (Obj.repr result);
+    result
+  with e ->
+    Obj.set_field (Obj.repr blk) 0 (Obj.repr (fun () -> raise e));
+    raise e
+
+
+(* Assume [blk] is a block with tag lazy *)
+let force_val_lazy_block (blk : 'arg lazy_t) =
+  let closure = (Obj.obj (Obj.field (Obj.repr blk) 0) : unit -> 'arg) in
+  Obj.set_field (Obj.repr blk) 0 raise_undefined;
+  let result = closure () in
+  make_forward (Obj.repr blk) (Obj.repr result);
+  result
+
+
+(* [force] is not used, since [Lazy.force] is declared as a primitive
+   whose code inlines the tag tests of its argument, except when afl
+   instrumentation is turned on. *)
+
+let force (lzv : 'arg lazy_t) =
+  (* Using [Sys.opaque_identity] prevents two potential problems:
+     - If the value is known to have Forward_tag, then its tag could have
+       changed during GC, so that information must be forgotten (see GPR#713
+       and issue #7301)
+     - If the value is known to be immutable, then if the compiler
+       cannot prove that the last branch is not taken it will issue a
+       warning 59 (modification of an immutable value) *)
+  let lzv = Sys.opaque_identity lzv in
+  let x = Obj.repr lzv in
+  let t = Obj.tag x in
+  if t = Obj.forward_tag then (Obj.obj (Obj.field x 0) : 'arg) else
+  if t <> Obj.lazy_tag then (Obj.obj x : 'arg)
+  else force_lazy_block lzv
+
+
+let force_val (lzv : 'arg lazy_t) =
+  let x = Obj.repr lzv in
+  let t = Obj.tag x in
+  if t = Obj.forward_tag then (Obj.obj (Obj.field x 0) : 'arg) else
+  if t <> Obj.lazy_tag then (Obj.obj x : 'arg)
+  else force_val_lazy_block lzv
+
+(* BACKPORT END *)

--- a/stdlib/camlinternalLazy.mli
+++ b/stdlib/camlinternalLazy.mli
@@ -26,4 +26,14 @@ exception Undefined
 
 val force_lazy_block : 'a lazy_t -> 'a
 
+(* CR ocaml 5 runtime:
+   BACKPORT BEGIN *)
+val force_val_lazy_block : 'a lazy_t -> 'a
+
+val force : 'a lazy_t -> 'a
+val force_val : 'a lazy_t -> 'a
+(* BACKPORT END *)
+
+(* CR ocaml 5 runtime: add this back in
 val force_gen : only_val:bool -> 'a lazy_t -> 'a
+*)

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -333,8 +333,13 @@ let remove_extension name =
 external open_desc: string -> open_flag list -> int -> int = "caml_sys_open"
 external close_desc: int -> unit = "caml_sys_close"
 
+(* CR ocaml 5 runtime:
+   BACKPORT BEGIN
 let prng_key =
   Domain.DLS.new_key Random.State.make_self_init
+*)
+let prng_key = lazy(Random.State.make_self_init ())
+(* BACKPORT END *)
 
 let temp_file_name temp_dir prefix suffix =
   let random_state = Domain.DLS.get prng_key in

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -1027,6 +1027,8 @@ and err_formatter = formatter_of_out_channel Stdlib.stderr
 and str_formatter = formatter_of_buffer stdbuf
 
 (* Initialise domain local state *)
+(* CR ocaml 5 runtime:
+   BACKPORT BEGIN
 module DLS = Domain.DLS
 
 let stdbuf_key = DLS.new_key pp_make_buffer
@@ -1073,6 +1075,16 @@ let err_formatter_key = DLS.new_key (fun () ->
   Domain.at_exit (pp_print_flush ppf);
   ppf)
 let _ = DLS.set err_formatter_key err_formatter
+*)
+let std_formatter_key = std_formatter
+let err_formatter_key = err_formatter
+let str_formatter_key = str_formatter
+let stdbuf_key = stdbuf
+
+module DLS = struct
+  let get = Fun.id
+end
+(* BACKPORT END *)
 
 let get_std_formatter () = DLS.get std_formatter_key
 let get_err_formatter () = DLS.get err_formatter_key
@@ -1095,6 +1107,8 @@ let flush_str_formatter () =
   let str_formatter = DLS.get str_formatter_key in
   flush_buffer_formatter stdbuf str_formatter
 
+(* CR ocaml 5 runtime:
+   BACKPORT
 let make_synchronized_formatter output flush =
   DLS.new_key (fun () ->
     let buf = Buffer.create pp_buffer_size in
@@ -1108,6 +1122,7 @@ let make_synchronized_formatter output flush =
 
 let synchronized_formatter_of_out_channel oc =
   make_synchronized_formatter (output_substring oc) (fun () -> flush oc)
+*)
 
 (*
   Symbolic pretty-printing
@@ -1478,6 +1493,8 @@ let flush_standard_formatters () =
 
 let () = at_exit flush_standard_formatters
 
+(* CR ocaml 5 runtime:
+   BACKPORT
 let () = Domain.before_first_spawn (fun () ->
   flush_standard_formatters ();
   let fs = pp_get_formatter_out_functions std_formatter () in
@@ -1490,3 +1507,4 @@ let () = Domain.before_first_spawn (fun () ->
     {fs with out_string = buffered_out_string err_buf_key;
              out_flush = buffered_out_flush Stdlib.stderr err_buf_key};
 )
+*)

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -969,6 +969,7 @@ val formatter_of_out_channel : out_channel -> formatter
     to the corresponding output channel [oc].
 *)
 
+(* BACKPORT
 val synchronized_formatter_of_out_channel :
   out_channel -> formatter Domain.DLS.key
 [@@alert unstable][@@alert "-unstable"]
@@ -979,6 +980,7 @@ val synchronized_formatter_of_out_channel :
     When the formatter is used with multiple domains, the output from the
     domains will be interleaved with each other at points where the formatter
     is flushed, such as with {!print_flush}.
+*)
 *)
 
 
@@ -1052,6 +1054,7 @@ val make_formatter :
   returns a formatter to the {!Stdlib.out_channel} [oc].
 *)
 
+(* BACKPORT
 val make_synchronized_formatter :
   (string -> int -> int -> unit) -> (unit -> unit) -> formatter Domain.DLS.key
 [@@alert unstable][@@alert "-unstable"]
@@ -1063,6 +1066,7 @@ val make_synchronized_formatter :
     domains will be interleaved with each other at points where the formatter
     is flushed, such as with {!print_flush}.
     @since 5.0
+*)
 *)
 
 val formatter_of_out_functions :

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -969,7 +969,8 @@ val formatter_of_out_channel : out_channel -> formatter
     to the corresponding output channel [oc].
 *)
 
-(* BACKPORT
+(* CR ocaml 5 runtime:
+   BACKPORT
 val synchronized_formatter_of_out_channel :
   out_channel -> formatter Domain.DLS.key
 [@@alert unstable][@@alert "-unstable"]
@@ -1054,7 +1055,8 @@ val make_formatter :
   returns a formatter to the {!Stdlib.out_channel} [oc].
 *)
 
-(* BACKPORT
+(* CR ocaml 5 runtime:
+  BACKPORT
 val make_synchronized_formatter :
   (string -> int -> int -> unit) -> (unit -> unit) -> formatter Domain.DLS.key
 [@@alert unstable][@@alert "-unstable"]

--- a/stdlib/hashtbl.ml
+++ b/stdlib/hashtbl.ml
@@ -87,7 +87,7 @@ let create ?(random = Atomic.get randomized) initial_size =
     BACKPORT BEGIN
     if random then Random.State.bits (Domain.DLS.get prng_key) else 0
 *)
-    if random then Random.State.bits (Lazy.force prng)
+    if random then Random.State.bits (Lazy.force prng) else 0
 (* BACKPORT END *)
   in
   { initial_size = s; size = 0; seed = seed; data = Array.make s Empty }

--- a/stdlib/hashtbl.ml
+++ b/stdlib/hashtbl.ml
@@ -62,7 +62,12 @@ let randomized = Atomic.make randomized_default
 let randomize () = Atomic.set randomized true
 let is_randomized () = Atomic.get randomized
 
+(* CR ocaml 5 runtime
+   BACKPORT BEGIN
 let prng_key = Domain.DLS.new_key Random.State.make_self_init
+*)
+let prng = lazy (Random.State.make_self_init())
+(* BACKPORT END *)
 
 (* Functions which appear before the functorial interface must either be
    independent of the hash function or take it as a parameter (see #2202 and
@@ -78,7 +83,12 @@ let rec power_2_above x n =
 let create ?(random = Atomic.get randomized) initial_size =
   let s = power_2_above 16 initial_size in
   let seed =
+(* CR ocaml 5 runtime
+    BACKPORT BEGIN
     if random then Random.State.bits (Domain.DLS.get prng_key) else 0
+*)
+    if random then Random.State.bits (Lazy.force prng)
+(* BACKPORT END *)
   in
   { initial_size = s; size = 0; seed = seed; data = Array.make s Empty }
 
@@ -626,7 +636,11 @@ let of_seq i =
 let rebuild ?(random = Atomic.get randomized) h =
   let s = power_2_above 16 (Array.length h.data) in
   let seed =
+(* BACKPORT BEGIN
     if random then Random.State.bits (Domain.DLS.get prng_key)
+*)
+    if random then Random.State.bits (Lazy.force prng)
+(* BACKPORT END *)
     else if Obj.size (Obj.repr h) >= 4 then h.seed
     else 0 in
   let h' = {

--- a/stdlib/hashtbl.ml
+++ b/stdlib/hashtbl.ml
@@ -62,7 +62,7 @@ let randomized = Atomic.make randomized_default
 let randomize () = Atomic.set randomized true
 let is_randomized () = Atomic.get randomized
 
-(* CR ocaml 5 runtime
+(* CR ocaml 5 runtime:
    BACKPORT BEGIN
 let prng_key = Domain.DLS.new_key Random.State.make_self_init
 *)
@@ -83,7 +83,7 @@ let rec power_2_above x n =
 let create ?(random = Atomic.get randomized) initial_size =
   let s = power_2_above 16 initial_size in
   let seed =
-(* CR ocaml 5 runtime
+(* CR ocaml 5 runtime:
     BACKPORT BEGIN
     if random then Random.State.bits (Domain.DLS.get prng_key) else 0
 *)
@@ -636,7 +636,8 @@ let of_seq i =
 let rebuild ?(random = Atomic.get randomized) h =
   let s = power_2_above 16 (Array.length h.data) in
   let seed =
-(* BACKPORT BEGIN
+(* CR ocaml 5 runtime:
+  BACKPORT BEGIN
     if random then Random.State.bits (Domain.DLS.get prng_key)
 *)
     if random then Random.State.bits (Lazy.force prng)

--- a/stdlib/lazy.ml
+++ b/stdlib/lazy.ml
@@ -58,7 +58,7 @@ exception Undefined = CamlinternalLazy.Undefined
 external make_forward : 'a -> 'a lazy_t = "caml_lazy_make_forward"
 external force : 'a t -> 'a = "%lazy_force"
 
-(* CR ocaml 5 runtime
+(* CR ocaml 5 runtime:
    BACKPORT BEGIN
 let force_val l = CamlinternalLazy.force_gen ~only_val:true l
 *)

--- a/stdlib/lazy.ml
+++ b/stdlib/lazy.ml
@@ -58,7 +58,12 @@ exception Undefined = CamlinternalLazy.Undefined
 external make_forward : 'a -> 'a lazy_t = "caml_lazy_make_forward"
 external force : 'a t -> 'a = "%lazy_force"
 
+(* CR ocaml 5 runtime
+   BACKPORT BEGIN
 let force_val l = CamlinternalLazy.force_gen ~only_val:true l
+*)
+  let force_val = CamlinteralLazy.force_val
+(* BACKPORT END *)
 
 let from_fun (f : unit -> 'arg) =
   let x = Obj.new_block Obj.lazy_tag 1 in

--- a/stdlib/random.ml
+++ b/stdlib/random.ml
@@ -266,7 +266,7 @@ let split () = State.split (Domain.DLS.get random_key)
 
 (* Manipulating the current state. *)
 
-(* CR ocaml 5 runtime
+(* CR ocaml 5 runtime:
    BACKPORT BEGIN
 let get_state () = State.copy (Domain.DLS.get random_key)
 let set_state s = State.assign (Domain.DLS.get random_key) s

--- a/stdlib/random.ml
+++ b/stdlib/random.ml
@@ -222,6 +222,8 @@ let mk_default () =
            (-8591268803865043407L)
            6388613595849772044L
 
+(* CR ocaml 5 runtime:
+   BACKPORT BEGIN
 let random_key =
   Domain.DLS.new_key ~split_from_parent:State.split mk_default
 
@@ -239,6 +241,23 @@ let nativebits () = State.nativebits (Domain.DLS.get random_key)
 
 let full_init seed = State.reinit (Domain.DLS.get random_key) seed
 let init seed = full_init [| seed |]
+*)
+let default = mk_default ()
+let bits () = State.bits default
+let int bound = State.int default bound
+let full_int bound = State.full_int default bound
+let int32 bound = State.int32 default bound
+let nativeint bound = State.nativeint default bound
+let int64 bound = State.int64 default bound
+let float scale = State.float default scale
+let bool () = State.bool default
+let bits32 () = State.bits32 default
+let bits64 () = State.bits64 default
+let nativebits () = State.nativebits default
+
+let full_init seed = State.full_init default seed
+let init seed = State.full_init default [| seed |]
+(* BACKPORT END *)
 let self_init () = full_init (random_seed())
 
 (* Splitting *)
@@ -247,5 +266,11 @@ let split () = State.split (Domain.DLS.get random_key)
 
 (* Manipulating the current state. *)
 
+(* CR ocaml 5 runtime
+   BACKPORT BEGIN
 let get_state () = State.copy (Domain.DLS.get random_key)
 let set_state s = State.assign (Domain.DLS.get random_key) s
+*)
+let get_state () = State.copy default
+let set_state s = State.assign default s
+(* BACKPORT END *)

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -585,7 +585,8 @@ let exit retcode =
 
 let _ = register_named_value "Pervasives.do_at_exit" do_at_exit
 
-(* BACKPORT BEGIN *)
+(* CR ocaml 5 runtime:
+ BACKPORT BEGIN *)
 external major : unit -> unit = "caml_gc_major"
 external naked_pointers_checked : unit -> bool
   = "caml_sys_const_naked_pointers_checked"
@@ -605,12 +606,12 @@ module BytesLabels    = BytesLabels
 module Callback       = Callback
 module Char           = Char
 module Complex        = Complex
-(* CR ocaml 5 runtime
+(* CR ocaml 5 runtime:
    BACKPORT
 module Condition      = Condition
 *)
 module Digest         = Digest
-(* CR ocaml 5 runtime
+(* CR ocaml 5 runtime:
    BACKPORT
 module Domain         = Domain
 module Effect         = Effect
@@ -634,7 +635,7 @@ module ListLabels     = ListLabels
 module Map            = Map
 module Marshal        = Marshal
 module MoreLabels     = MoreLabels
-(* CR ocaml 5 runtime
+(* CR ocaml 5 runtime:
    BACKPORT
 module Mutex          = Mutex
 *)
@@ -650,7 +651,7 @@ module Queue          = Queue
 module Random         = Random
 module Result         = Result
 module Scanf          = Scanf
-(* CR ocaml 5 runtime
+(* CR ocaml 5 runtime:
    BACKPORT
 module Semaphore      = Semaphore
 *)

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -585,6 +585,13 @@ let exit retcode =
 
 let _ = register_named_value "Pervasives.do_at_exit" do_at_exit
 
+(* BACKPORT BEGIN *)
+external major : unit -> unit = "caml_gc_major"
+external naked_pointers_checked : unit -> bool
+  = "caml_sys_const_naked_pointers_checked"
+let () = if naked_pointers_checked () then at_exit major
+(* BACKPORT END *)
+
 (*MODULE_ALIASES*)
 module Arg            = Arg
 module Array          = Array
@@ -598,10 +605,16 @@ module BytesLabels    = BytesLabels
 module Callback       = Callback
 module Char           = Char
 module Complex        = Complex
+(* CR ocaml 5 runtime
+   BACKPORT
 module Condition      = Condition
+*)
 module Digest         = Digest
+(* CR ocaml 5 runtime
+   BACKPORT
 module Domain         = Domain
 module Effect         = Effect
+*)
 module Either         = Either
 module Ephemeron      = Ephemeron
 module Filename       = Filename
@@ -621,7 +634,10 @@ module ListLabels     = ListLabels
 module Map            = Map
 module Marshal        = Marshal
 module MoreLabels     = MoreLabels
+(* CR ocaml 5 runtime
+   BACKPORT
 module Mutex          = Mutex
+*)
 module Nativeint      = Nativeint
 module Obj            = Obj
 module Oo             = Oo
@@ -634,7 +650,10 @@ module Queue          = Queue
 module Random         = Random
 module Result         = Result
 module Scanf          = Scanf
+(* CR ocaml 5 runtime
+   BACKPORT
 module Semaphore      = Semaphore
+*)
 module Seq            = Seq
 module Set            = Set
 module Stack          = Stack

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -1403,8 +1403,13 @@ module BytesLabels    = BytesLabels
 module Callback       = Callback
 module Char           = Char
 module Complex        = Complex
+(* CR ocaml 5 runtime
+   BACKPORT
 module Condition      = Condition
+*)
 module Digest         = Digest
+(* CR ocaml 5 runtime
+BACKPORT
 module Domain         = Domain
 [@@alert "-unstable"]
 [@@alert unstable
@@ -1415,6 +1420,7 @@ module Effect         = Effect
 [@@alert unstable
     "The Effect interface may change in incompatible ways in the future."
 ]
+*)
 module Either         = Either
 module Ephemeron      = Ephemeron
 module Filename       = Filename
@@ -1434,7 +1440,10 @@ module ListLabels     = ListLabels
 module Map            = Map
 module Marshal        = Marshal
 module MoreLabels     = MoreLabels
+(* CR ocaml 5 runtime
+   BACKPORT
 module Mutex          = Mutex
+*)
 module Nativeint      = Nativeint
 module Obj            = Obj
 module Oo             = Oo
@@ -1447,7 +1456,10 @@ module Queue          = Queue
 module Random         = Random
 module Result         = Result
 module Scanf          = Scanf
+(* CR ocaml 5 runtime
+BACKPORT
 module Semaphore      = Semaphore
+*)
 module Seq            = Seq
 module Set            = Set
 module Stack          = Stack

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -1403,12 +1403,12 @@ module BytesLabels    = BytesLabels
 module Callback       = Callback
 module Char           = Char
 module Complex        = Complex
-(* CR ocaml 5 runtime
+(* CR ocaml 5 runtime:
    BACKPORT
 module Condition      = Condition
 *)
 module Digest         = Digest
-(* CR ocaml 5 runtime
+(* CR ocaml 5 runtime:
 BACKPORT
 module Domain         = Domain
 [@@alert "-unstable"]
@@ -1440,7 +1440,7 @@ module ListLabels     = ListLabels
 module Map            = Map
 module Marshal        = Marshal
 module MoreLabels     = MoreLabels
-(* CR ocaml 5 runtime
+(* CR ocaml 5 runtime:
    BACKPORT
 module Mutex          = Mutex
 *)
@@ -1456,7 +1456,7 @@ module Queue          = Queue
 module Random         = Random
 module Result         = Result
 module Scanf          = Scanf
-(* CR ocaml 5 runtime
+(* CR ocaml 5 runtime:
 BACKPORT
 module Semaphore      = Semaphore
 *)


### PR DESCRIPTION
Backport the pieces of https://github.com/dra27/ocaml/commit/46aea8c92445a0d7e77db8223b53b83d48fa94c3 that touch files under `stdlib/`. This was done almost entirely by copying-and-pasting from the diff for that commit, as ~everything conflicted.

Backported code is delimited by `BACKPORT BEGIN`/`BACKPORT END` blocks, as in the patch, but I also add a "CR ocaml 5 runtime" needle as we've used elsewhere:

```
(* CR ocaml 5 runtime:
  BACKPORT BEGIN
  <tip-5 code>
*)
<backported code>
(* BACKPORT END *)
```

When code is just commented out and nothing is added in its lieu, that looks like:
```
(* CR ocaml 5 runtime:
  BACKPORT
  <tip-5 code>
*)
```