### PR TITLE
OCaml 5 on runtime4: asmcomp/ changes + a few others

### DIFF
--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -85,7 +85,14 @@ let frame_size env =                     (* includes return address *)
        + 8 * (env.f.fun_num_stack_slots.(0) + env.f.fun_num_stack_slots.(1))
        + 8
        + (if fp then 8 else 0))
-    in Misc.align sz 16
+    in
+(* BACKPORT BEGIN *)
+    Misc.align
+(* BACKPORT END *)
+      sz
+(* BACKPORT BEGIN *)
+      16
+(* BACKPORT END *)
   end else
     env.stack_offset + 8
 

--- a/asmcomp/amd64/proc.ml
+++ b/asmcomp/amd64/proc.ml
@@ -238,7 +238,11 @@ let win64_float_external_arguments =
 let win64_loc_external_arguments arg =
   let loc = Array.make (Array.length arg) Reg.dummy in
   let reg = ref 0
+(* BACKPORT BEGIN
   and ofs = ref 0 in
+*)
+  and ofs = ref 32 in
+(* BACKPORT END *)
   for i = 0 to Array.length arg - 1 do
     match arg.(i) with
     | Val | Int | Addr as ty ->

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -34,8 +34,10 @@ let reg_trap_ptr = phys_reg 23 (* x26 *)
 let reg_alloc_ptr = phys_reg 24 (* x27 *)
 let reg_tmp1 = phys_reg 26 (* x16 *)
 let reg_x8 = phys_reg 8 (* x8 *)
+(* BACKPORT
 let reg_stack_arg_begin = phys_reg 17  (* x20 *)
 let reg_stack_arg_end  = phys_reg 18 (* x21 *)
+*)
 
 (* Output a label *)
 
@@ -461,24 +463,38 @@ module BR = Branch_relaxation.Make (struct
     | Lop (Itailcall_ind) -> epilogue_size f
     | Lop (Itailcall_imm { func; _ }) ->
       if func = f.fun_name then 1 else epilogue_size f
-    | Lop (Iextcall {alloc; stack_ofs} ) ->
+    | Lop (Iextcall {alloc; stack_ofs = _} ) ->
+(* BACKPORT
       if stack_ofs > 0 then 5
-      else if alloc then 3
+      else*) if alloc then 3
+(* BACKPORT BEGIN
       else 5
+*)
+      else 1
+(* BACKPORT END *)
     | Lop (Istackoffset _) -> 2
+(* BACKPORT BEGIN
     | Lop (Iload  { memory_chunk; addressing_mode; is_atomic }) ->
       let based = match addressing_mode with Iindexed _ -> 0 | Ibased _ -> 1
       and barrier = if is_atomic then 1 else 0
       and single = match memory_chunk with Single -> 2 | _ -> 1 in
       based + barrier + single
     | Lop (Istore (memory_chunk, addressing_mode, assignment)) ->
+*)
+    | Lop (Iload  { memory_chunk; addressing_mode })
+    | Lop (Istore (memory_chunk, addressing_mode, _)) ->
+(* BACKPORT END *)
       let based = match addressing_mode with Iindexed _ -> 0 | Ibased _ -> 1
+      in
+      based + begin match memory_chunk with Single -> 2 | _ -> 1 end
+(* BACKPORT
       and barrier =
         match memory_chunk, assignment with
         | (Word_int | Word_val), true -> 1
         | _ -> 0
       and single = match memory_chunk with Single -> 2 | _ -> 1 in
       based + barrier + single
+*)
     | Lop (Ialloc _) when f.fun_fast -> 5
     | Lop (Ispecific (Ifar_alloc _)) when f.fun_fast -> 6
     | Lop (Ipoll _) -> 3
@@ -542,7 +558,11 @@ module BR = Branch_relaxation.Make (struct
     | Lpoptrap -> 1
     | Lraise k ->
       begin match k with
+(* BACKPORT BEGIN
       | Lambda.Raise_regular -> 1
+*)
+      | Lambda.Raise_regular -> 2
+(* BACKPORT END *)
       | Lambda.Raise_reraise -> 1
       | Lambda.Raise_notrace -> 4
       end
@@ -743,7 +763,8 @@ let emit_instr env i =
           `	b	{emit_label env.f.fun_tailrec_entry_point_label}\n`
         else
           output_epilogue env (fun () -> `	b	{emit_symbol func}\n`)
-    | Lop(Iextcall {func; alloc; stack_ofs}) ->
+    | Lop(Iextcall {func; alloc; stack_ofs = _}) ->
+(* BACKPORT BEGIN
         if stack_ofs > 0 then begin
           `	mov	{emit_reg reg_stack_arg_begin}, sp\n`;
           `	add	{emit_reg reg_stack_arg_end}, sp, #{emit_int (Misc.align stack_ofs 16)}\n`;
@@ -751,9 +772,18 @@ let emit_instr env i =
           `	bl	{emit_symbol "caml_c_call_stack_args"}\n`;
           `{record_frame env i.live (Dbg_other i.dbg)}\n`
         end else if alloc then begin
+*)
+        if not alloc then
+        `	bl	{emit_symbol func}\n`
+        else begin
+(* BACKPORT END *)
           emit_load_symbol_addr reg_x8 func;
           `	bl	{emit_symbol "caml_c_call"}\n`;
           `{record_frame env i.live (Dbg_other i.dbg)}\n`
+(* BACKPORT BEGIN *)
+        end
+(* BACKPORT END *)
+(* BACKPORT
         end else begin
           (* store ocaml stack in the frame pointer register
              NB: no need to store previous x29 because OCaml frames don't
@@ -768,6 +798,7 @@ let emit_instr env i =
           `	mov	sp, x29\n`;
           cfi_restore_state ()
         end
+*)
     | Lop(Istackoffset n) ->
         assert (n mod 16 = 0);
         emit_stack_adjustment (-n);
@@ -808,7 +839,11 @@ let emit_instr env i =
         | Double ->
             `	ldr	{emit_reg dst}, {emit_addressing addressing_mode base}\n`
         end
+(* BACKPORT BEGIN
     | Lop(Istore(size, addr, assignment)) ->
+*)
+    | Lop(Istore(size, addr, _)) ->
+(* BACKPORT END *)
         (* NB: assignments other than Word_int and Word_val do not follow the
         Multicore OCaml memory model and so do not emit a barrier *)
         let src = i.arg.(0) in
@@ -831,7 +866,9 @@ let emit_instr env i =
             `	str	s7, {emit_addressing addr base}\n`;
         | Word_int | Word_val ->
             (* memory model barrier for non-initializing store *)
-            if assignment then `	dmb	ishld\n`;
+(* BACKPORT
+            if assignment then ` dmb ishld\n`;
+*)
             `	str	{emit_reg src}, {emit_addressing addr base}\n`
         | Double ->
             `	str	{emit_reg src}, {emit_addressing addr base}\n`
@@ -964,8 +1001,13 @@ let emit_instr env i =
     | Lop (Iprobe _ |Iprobe_is_enabled _) ->
       Misc.fatal_error ("Probes not supported.")
     | Lop(Idls_get) ->
+(* BACKPORT BEGIN *)
+        assert false
+(* BACKPORT END *)
+(* BACKPORT
         let offset = Domainstate.(idx_of_field Domain_dls_root) * 8 in
-        `	ldr	{emit_reg i.res.(0)}, [{emit_reg reg_domain_state_ptr}, {emit_int offset}]\n`
+        ` ldr {emit_reg i.res.(0)}, [{emit_reg reg_domain_state_ptr}, {emit_int offset}]\n`
+*)
     | Lreloadretaddr ->
         ()
     | Lreturn ->
@@ -1052,10 +1094,18 @@ let emit_instr env i =
     | Lraise k ->
         begin match k with
         | Lambda.Raise_regular ->
+(* BACKPORT BEGIN *)
+          let offset = Domainstate.(idx_of_field Domain_backtrace_pos) * 8 in
+          `	str	xzr, [{emit_reg reg_domain_state_ptr}, {emit_int offset}]\n`;
+(* BACKPORT END *)
           `	bl	{emit_symbol "caml_raise_exn"}\n`;
           `{record_frame env Reg.Set.empty (Dbg_raise i.dbg)}\n`
         | Lambda.Raise_reraise ->
+(* BACKPORT BEGIN
           `	bl	{emit_symbol "caml_reraise_exn"}\n`;
+*)
+          `	bl	{emit_symbol "caml_raise_exn"}\n`;
+(* BACKPORT END *)
           `{record_frame env Reg.Set.empty (Dbg_raise i.dbg)}\n`
         | Lambda.Raise_notrace ->
           `	mov	sp, {emit_reg reg_trap_ptr}\n`;
@@ -1077,47 +1127,43 @@ let fundecl fundecl =
   `	.align	3\n`;
   `	.globl	{emit_symbol fundecl.fun_name}\n`;
   emit_symbol_type emit_symbol fundecl.fun_name "function";
+  `{emit_symbol fundecl.fun_name}:\n`;
+  emit_debug_info fundecl.fun_dbg;
+  cfi_startproc();
+  let num_call_gc, num_check_bound =
+    num_call_gc_and_check_bound_points env
+  in
+
+(* BACKPORT
   (* Dynamic stack checking *)
   let stack_threshold_size = Config.stack_threshold * 8 in (* bytes *)
   let { max_frame_size; contains_nontail_calls} =
     preproc_stack_check
       ~fun_body:fundecl.fun_body ~frame_size:(frame_size env) ~trap_size:16
   in
-  let handle_overflow, stack_check_size =
-    if contains_nontail_calls || max_frame_size >= stack_threshold_size then begin
-      let overflow = new_label () in
-      `{emit_label overflow}:\n`;
-      (* Pass the desired frame size on the stack, since all of the
-        argument-passing registers may be in use. *)
-      let s = (Config.stack_threshold + max_frame_size / 8) in
-      `	mov	{emit_reg reg_tmp1}, #{emit_int s}\n`;
-      `	stp	{emit_reg reg_tmp1}, x30, [sp, #-16]!\n`;
-      `	bl	{emit_symbol "caml_call_realloc_stack"}\n`;
-      `	ldp	{emit_reg reg_tmp1}, x30, [sp], #16\n`;
-      (* fall through function entry point *)
-      Some overflow, 5
-    end else
-      None, 0 in
-  `{emit_symbol fundecl.fun_name}:\n`;
-  emit_debug_info fundecl.fun_dbg;
-  cfi_startproc();
-  begin match handle_overflow with
-  | None -> ()
-  | Some overflow ->
-      let threshold_offset = Domainstate.stack_ctx_words * 8 + stack_threshold_size in
-      let f = max_frame_size + threshold_offset in
-      let offset = Domainstate.(idx_of_field Domain_current_stack) * 8 in
-      `	ldr	{emit_reg reg_tmp1}, [{emit_reg reg_domain_state_ptr}, #{emit_int offset}]\n`;
-      emit_addimm reg_tmp1 reg_tmp1 f;
-      `	cmp	sp, {emit_reg reg_tmp1}\n`;
-      `	bcc	{emit_label overflow}\n`
+  let stack_check_size = ref 0 in
+  let handle_overflow = ref None in
+  if contains_nontail_calls || max_frame_size >= stack_threshold_size then begin
+    let overflow = new_label () and ret = new_label () in
+    let threshold_offset = Domainstate.stack_ctx_words * 8 + stack_threshold_size in
+    let f = max_frame_size + threshold_offset in
+    let offset = Domainstate.(idx_of_field Domain_current_stack) * 8 in
+    `  ldr {emit_reg reg_tmp1}, [{emit_reg reg_domain_state_ptr}, #{emit_int offset}]\n`;
+    `  add {emit_reg reg_tmp1}, {emit_reg reg_tmp1}, #{emit_int f}\n`;
+    `  cmp sp, {emit_reg reg_tmp1}\n`;
+    `  bcc {emit_label overflow}\n`;
+    `{emit_label ret}:\n`;
+    handle_overflow := Some (overflow, ret);
+    stack_check_size := 5
   end;
-  let num_call_gc, num_check_bound =
-    num_call_gc_and_check_bound_points env
-  in
+*)
+
   let max_out_of_line_code_offset =
-    stack_check_size +
-    max_out_of_line_code_offset ~num_call_gc ~num_check_bound
+(* BACKPORT
+    !stack_check_size +
+*)
+    max_out_of_line_code_offset ~num_call_gc
+      ~num_check_bound
   in
 
   BR.relax fundecl ~max_out_of_line_code_offset;
@@ -1127,6 +1173,23 @@ let fundecl fundecl =
   List.iter emit_call_bound_error env.bound_error_sites;
   assert (List.length env.call_gc_sites = num_call_gc);
   assert (List.length env.bound_error_sites = num_check_bound);
+
+(* BACKPORT
+  begin match !handle_overflow with
+  | None -> ()
+  | Some (overflow,ret) -> begin
+      `{emit_label overflow}:\n`;
+      (* Pass the desired frame size on the stack, since all of the
+        argument-passing registers may be in use. *)
+      let s = (Config.stack_threshold + max_frame_size / 8) in
+      `  mov {emit_reg reg_tmp1}, #{emit_int s}\n`;
+      `  stp {emit_reg reg_tmp1}, x30, [sp, #-16]!\n`;
+      `  bl {emit_symbol "caml_call_realloc_stack"}\n`;
+      `  ldp {emit_reg reg_tmp1}, x30, [sp], #16\n`;
+      `  b {emit_label ret}\n`
+    end
+  end;
+*)
 
   cfi_endproc();
   emit_symbol_type emit_symbol fundecl.fun_name "function";

--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -271,7 +271,11 @@ let make_startup_file ~ppf_dump units_list ~crc_interfaces =
   compile_phrase (Cmm_helpers.entry_point name_list);
   let units = List.map (fun (info,_,_) -> info) units_list in
   List.iter compile_phrase
+(* BACKPORT BEGIN
     (Cmm_helpers.emit_preallocated_blocks [] (* add gc_roots (for dynlink) *)
+*)
+    (
+(* BACKPORT END *)
       (Cmm_helpers.generic_functions false units));
   Array.iteri
     (fun i name -> compile_phrase (Cmm_helpers.predef_exception i name))
@@ -308,7 +312,11 @@ let make_shared_startup_file ~ppf_dump units =
   Compilenv.reset shared_startup_comp_unit;
   Emit.begin_assembly ();
   List.iter compile_phrase
+(* BACKPORT BEGIN
     (Cmm_helpers.emit_preallocated_blocks [] (* add gc_roots (for dynlink) *)
+*)
+    (
+(* BACKPORT END *)
       (Cmm_helpers.generic_functions true (List.map fst units)));
   compile_phrase (Cmm_helpers.plugin_header units);
   compile_phrase

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -702,8 +702,17 @@ let set_field ptr n newval init dbg =
   Cop(Cstore (Word_val, init), [field_address ptr n dbg; newval], dbg)
 
 let get_header ptr dbg =
-  (* header loads are mutable because laziness changes tags. *)
-  Cop(mk_load_mut Word_int,
+  (* Headers can be mutated when forcing a lazy value. However, for all
+     purposes that the mutability tag currently serves in the compiler, header
+     loads can be marked as [Immutable], since the runtime should ensure that
+     there is no data race on headers. This saves performance with
+     ThreadSanitizer instrumentation by avoiding to instrument header loads. *)
+  Cop(
+(* BACKPORT BEGIN
+    mk_load_immut Word_int,
+*)
+    mk_load_mut Word_int,
+(* BACKPORT END *)
     [Cop(Cadda, [ptr; Cconst_int(-size_int, dbg)], dbg)], dbg)
 
 let get_header_masked ptr dbg =
@@ -720,9 +729,14 @@ let get_tag ptr dbg =
   if Proc.word_addressed then           (* If byte loads are slow *)
     Cop(Cand, [get_header ptr dbg; Cconst_int (255, dbg)], dbg)
   else                                  (* If byte loads are efficient *)
-    (* header loads are mutable because laziness changes tags. *)
-    Cop(mk_load_mut Byte_unsigned,
-        [Cop(Cadda, [ptr; Cconst_int(tag_offset, dbg)], dbg)], dbg)
+    (* Same comment as [get_header] above *)
+    Cop(
+(* BACKPORT BEGIN
+      mk_load_immut Byte_unsigned,
+*)
+      mk_load_mut Byte_unsigned,
+(* BACKPORT END *)
+      [Cop(Cadda, [ptr; Cconst_int(tag_offset, dbg)], dbg)], dbg)
 
 let get_size ptr dbg =
   Cop(Clsr, [get_header_masked ptr dbg; Cconst_int (10, dbg)], dbg)

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -1012,7 +1012,11 @@ let make_alloc_generic ~mode set_fn dbg tag wordsize args =
     | e1::el -> Csequence(set_fn (Cvar id) (Cconst_int (idx, dbg)) e1 dbg,
                           fill_fields (idx + 2) el) in
     Clet(VP.create id,
+(* BACKPORT BEGIN
          Cop(Cextcall("caml_alloc_shr_check_gc", typ_val, [], true),
+*)
+         Cop(Cextcall("caml_alloc", typ_val, [], true),
+(* BACKPORT END *)
                  [Cconst_int (wordsize, dbg); Cconst_int (tag, dbg)], dbg),
          fill_fields 1 args)
   end

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -128,7 +128,7 @@ let min_mut x y =
 let get_field env mut ptr n dbg =
   let mut = min_mut mut (mut_from_env env ptr) in
 *)
-let get_field env _mut ptr n dbg =
+let get_field env layout ptr n dbg =
   let mut = mut_from_env env ptr in
 (* BACKPORT END *)
   let memory_chunk =

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -116,8 +116,21 @@ let mut_from_env env ptr =
       else Asttypes.Mutable
     | _ -> Asttypes.Mutable
 
-let get_field env layout ptr n dbg =
+(* BACKPORT
+(* Minimum of two [mutable_flag] values, assuming [Immutable < Mutable]. *)
+let min_mut x y =
+  match x,y with
+  | Immutable,_ | _,Immutable -> Immutable
+  | Mutable,Mutable -> Mutable
+*)
+
+(* BACKPORT BEGIN
+let get_field env mut ptr n dbg =
+  let mut = min_mut mut (mut_from_env env ptr) in
+*)
+let get_field env _mut ptr n dbg =
   let mut = mut_from_env env ptr in
+(* BACKPORT END *)
   let memory_chunk =
     match layout with
     | Pvalue Pintval | Punboxed_int _ -> Word_int

--- a/otherlibs/dynlink/native/dynlink.ml
+++ b/otherlibs/dynlink/native/dynlink.ml
@@ -37,8 +37,10 @@ module Native = struct
 
   external ndl_open : string -> bool -> handle * Cmxs_format.dynheader
     = "caml_natdynlink_open"
+(* BACKPORT
   external ndl_register : handle -> string array -> unit
     = "caml_natdynlink_register"
+*)
   external ndl_run : handle -> string -> unit = "caml_natdynlink_run"
   external ndl_getmap : unit -> global_map list = "caml_natdynlink_getmap"
   external ndl_globals_inited : unit -> int = "caml_natdynlink_globals_inited"
@@ -98,11 +100,13 @@ module Native = struct
     if header.dynu_magic <> Config.cmxs_magic_number then begin
       raise (DT.Error (Not_a_bytecode_file filename))
     end;
+(* BACKPORT
     let syms =
       "_shared_startup" ::
       List.concat_map Unit_header.defined_symbols header.dynu_units
     in
     ndl_register handle (Array.of_list syms);
+*)
     handle, header.dynu_units
 
   let unsafe_get_global_value ~bytecode_or_asm_symbol =

--- a/testsuite/tests/asmcomp/polling.c
+++ b/testsuite/tests/asmcomp/polling.c
@@ -3,8 +3,10 @@
 #include <caml/mlvalues.h>
 #include <caml/domain_state.h>
 #include <caml/signals.h>
+#if 0 /* BACKPORT */
 #include <caml/minor_gc.h>
 #include <caml/camlatomic.h>
+#endif
 
 CAMLprim value request_minor_gc(value v) {
   Caml_state->requested_minor_gc = 1;
@@ -20,5 +22,8 @@ CAMLprim value request_minor_gc(value v) {
 }
 
 CAMLprim value minor_gcs(value v) {
+#if 0 /* BACKPORT */
   return Val_long(atomic_load(&caml_minor_collections_count));
+#endif
+  return Val_long(Caml_state->stat_minor_collections);
 }

--- a/testsuite/tests/backtrace/backtrace_dynlink.flambda.reference
+++ b/testsuite/tests/backtrace/backtrace_dynlink.flambda.reference
@@ -1,18 +1,22 @@
 Raised by primitive operation at Backtrace_dynlink_plugin in file "backtrace_dynlink_plugin.ml", line 6, characters 13-38
-Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 87, characters 12-29
+Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 89, characters 12-29
 Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
-Called from Dynlink.Native.run in file "otherlibs/dynlink/native/dynlink.ml", line 86, characters 4-273
-Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 363, characters 13-56
+Called from Dynlink.Native.run in file "otherlibs/dynlink/native/dynlink.ml", line 88, characters 4-273
+Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 372, characters 13-56
 Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 359, characters 8-392
 Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 374, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52
 execution of module initializers in the shared library failed: Failure("SUCCESS")
-Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 87, characters 12-29
-Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 89, characters 10-149
+Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+Called from Backtrace_dynlink_plugin in file "backtrace_dynlink_plugin.ml", line 3, characters 4-22
+Re-raised at Backtrace_dynlink_plugin in file "backtrace_dynlink_plugin.ml", line 8, characters 5-12
+Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 89, characters 12-29
+Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 89, characters 12-29
+Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 91, characters 10-149
 Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
-Called from Dynlink.Native.run in file "otherlibs/dynlink/native/dynlink.ml", line 86, characters 4-273
-Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 363, characters 13-56
+Called from Dynlink.Native.run in file "otherlibs/dynlink/native/dynlink.ml", line 88, characters 4-273
+Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 372, characters 13-56
 Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 359, characters 8-392
 Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 372, characters 8-17

--- a/testsuite/tests/backtrace/backtrace_dynlink.reference
+++ b/testsuite/tests/backtrace/backtrace_dynlink.reference
@@ -1,5 +1,5 @@
 Raised by primitive operation at Backtrace_dynlink_plugin in file "backtrace_dynlink_plugin.ml", line 6, characters 13-38
-Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 87, characters 12-29
+Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 89, characters 12-29
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 363, characters 13-56
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
@@ -7,8 +7,12 @@ Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.m
 Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 374, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52
 execution of module initializers in the shared library failed: Failure("SUCCESS")
-Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 87, characters 12-29
-Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 89, characters 10-149
+Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+Called from Backtrace_dynlink_plugin in file "backtrace_dynlink_plugin.ml", line 3, characters 4-22
+Re-raised at Backtrace_dynlink_plugin in file "backtrace_dynlink_plugin.ml", line 8, characters 5-12
+Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 89, characters 12-29
+Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 89, characters 12-29
+Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 91, characters 10-149
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 363, characters 13-56
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15

--- a/testsuite/tests/effects/unhandled_unlinked.ml
+++ b/testsuite/tests/effects/unhandled_unlinked.ml
@@ -2,6 +2,8 @@
    * skip
 
      exit_status= "2"
+     * skip
+     reason = "OCaml 5 only"
 *)
 
 open Effect

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
@@ -3,12 +3,13 @@ Raised at Stdlib.failwith in file "stdlib.ml", line 32, characters 17-33
 Called from Test10_plugin.g in file "test10_plugin.ml" (inlined), line 2, characters 15-38
 Called from Test10_plugin.f in file "test10_plugin.ml", line 6, characters 2-6
 Called from Test10_plugin in file "test10_plugin.ml", line 10, characters 2-6
-Called from Dynlink.Native.ndl_run in file "otherlibs/dynlink/dynlink.ml", line 292, characters 8-25
-Called from Dynlink.Native.ndl_run in file "otherlibs/dynlink/dynlink.ml", line 292, characters 8-25
-Re-raised at Dynlink.Native.ndl_run in file "otherlibs/dynlink/dynlink.ml", line 304, characters 6-137
-Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
-Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 337, characters 13-54
-Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
-Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 335, characters 8-250
-Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 345, characters 8-17
+Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 89, characters 12-29
+Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 89, characters 12-29
+Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 91, characters 10-149
+Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
+Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 372, characters 13-56
+Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
+Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 368, characters 8-392
+Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 381, characters 8-17
+Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 383, characters 26-45
 Called from Test10_main in file "test10_main.ml", line 49, characters 30-87

--- a/testsuite/tests/tsan/array_elt.ml
+++ b/testsuite/tests/tsan/array_elt.ml
@@ -1,0 +1,17 @@
+(* TEST
+
+ include unix;
+ set TSAN_OPTIONS="detect_deadlocks=0";
+
+ reason = "OCaml 5 only";
+ skip;
+ tsan;
+ native;
+
+*)
+let () =
+  let v = Array.make 4 0 in
+  let t1 = Domain.spawn (fun () -> Array.set v 3 0; Unix.sleepf 0.1) in
+  let t2 = Domain.spawn (fun () -> ignore (Sys.opaque_identity (Array.get v 3)); Unix.sleepf 0.1) in
+  Domain.join t1;
+  Domain.join t2;

--- a/testsuite/tests/tsan/exn_from_c.ml
+++ b/testsuite/tests/tsan/exn_from_c.ml
@@ -1,0 +1,53 @@
+(* TEST
+
+ modules = "callbacks.c";
+
+ ocamlopt_flags = "-g -ccopt -fsanitize=thread -ccopt -O1 -ccopt -fno-omit-frame-pointer -ccopt -g";
+ include unix;
+ set TSAN_OPTIONS="detect_deadlocks=0";
+
+ reason = "OCaml 5 only";
+ skip;
+ tsan;
+ native;
+
+*)
+
+external print_and_raise : unit -> unit = "print_and_raise"
+
+open Printf
+
+let r = ref 0
+
+let [@inline never] race () = ignore @@ !r
+
+let [@inline never] i () =
+  printf "entering i\n%!";
+  printf "calling print_and_raise...\n%!";
+  print_and_raise ();
+  printf "leaving i\n%!"
+
+let [@inline never] h () =
+  printf "entering h\n%!";
+  i ();
+  printf "leaving h\n%!"
+
+let [@inline never] g () =
+  printf "entering g\n%!";
+  h ();
+  printf "leaving g\n%!"
+
+let [@inline never] f () =
+  printf "entering f\n%!";
+  (try g ()
+  with Failure msg ->
+    printf "caught Failure \"%s\"\n%!" msg;
+    Printexc.print_backtrace stdout;
+    race ());
+  printf "leaving f\n%!"
+
+let () =
+  Printexc.record_backtrace true;
+  let d = Domain.spawn (fun () -> Unix.sleep 1; r := 1) in
+  f (); Unix.sleep 1;
+  Domain.join d

--- a/testsuite/tests/tsan/exn_in_callback.ml
+++ b/testsuite/tests/tsan/exn_in_callback.ml
@@ -1,0 +1,63 @@
+(* TEST
+
+ modules = "callbacks.c";
+
+ ocamlopt_flags = "-g -ccopt -fsanitize=thread -ccopt -O1 -ccopt -fno-omit-frame-pointer -ccopt -g";
+ include unix;
+ set TSAN_OPTIONS="detect_deadlocks=0";
+
+ reason = "OCaml 5 only";
+ skip;
+ tsan;
+ native;
+
+*)
+exception ExnA
+exception ExnB
+
+external print_and_call_ocaml_h : unit -> unit = "print_and_call_ocaml_h"
+
+open Printf
+
+let r = ref 0
+
+let [@inline never] race () = ignore @@ !r
+
+let [@inline never] i () =
+  printf "entering i\n%!";
+  printf "throwing Exn...\n%!";
+  (*race ();*)
+  ignore (raise ExnB);
+  printf "leaving i\n%!"
+
+let [@inline never] h () =
+  printf "entering h\n%!";
+  i ();
+  (* try i () with
+  | ExnA -> printf "caught an ExnA\n%!";
+  *)
+  printf "leaving h\n%!"
+
+let _ = Callback.register "ocaml_h" h
+
+let [@inline never] g () =
+  printf "entering g\n%!";
+  printf "calling C code\n%!";
+  print_and_call_ocaml_h ();
+  printf "back from C code\n%!";
+  printf "leaving g\n%!"
+
+let [@inline never] f () =
+  printf "entering f\n%!";
+  (try g () with
+  | ExnB ->
+    printf "caught an ExnB\n%!";
+    Printexc.print_backtrace stdout;
+    race ());
+  printf "leaving f\n%!"
+
+let () =
+  Printexc.record_backtrace true;
+  let d = Domain.spawn (fun () -> Unix.sleep 1; r := 1) in
+  f (); Unix.sleep 1;
+  Domain.join d

--- a/testsuite/tests/tsan/exn_reraise.ml
+++ b/testsuite/tests/tsan/exn_reraise.ml
@@ -1,0 +1,52 @@
+(* TEST
+
+ ocamlopt_flags = "-g -ccopt -fsanitize=thread -ccopt -O1 -ccopt -fno-omit-frame-pointer -ccopt -g";
+ include unix;
+ set TSAN_OPTIONS="detect_deadlocks=0";
+
+ reason = "OCaml 5 only";
+ skip;
+ tsan;
+ native;
+
+*)
+exception ExnA
+exception ExnB
+
+open Printf
+
+let r = ref 0
+
+let [@inline never] race () = ignore @@ !r
+
+let [@inline never] i () =
+  printf "entering i\n%!";
+  printf "throwing Exn...\n%!";
+  ignore (raise ExnA);
+  printf "leaving i\n%!"
+
+let [@inline never] h () =
+  printf "entering h\n%!";
+  try i () with
+  | ExnB -> printf "caught an ExnB\n%!";
+  printf "leaving h\n%!"
+
+let [@inline never] g () =
+  printf "entering g\n%!";
+  h ();
+  printf "leaving g\n%!"
+
+let [@inline never] f () =
+  printf "entering f\n%!";
+  (try g () with
+  | ExnA ->
+    printf "caught an ExnA\n%!";
+    Printexc.print_backtrace stdout;
+    race ());
+  printf "leaving f\n%!"
+
+let () =
+  Printexc.record_backtrace true;
+  let d = Domain.spawn (fun () -> Unix.sleep 1; r := 1) in
+  f (); Unix.sleep 1;
+  Domain.join d

--- a/testsuite/tests/tsan/handlers_at_tail.ml
+++ b/testsuite/tests/tsan/handlers_at_tail.ml
@@ -1,0 +1,28 @@
+(* TEST
+
+ ocamlopt_flags = "-g";
+ set TSAN_OPTIONS="detect_deadlocks=0";
+
+ reason = "OCaml 5 only";
+ skip;
+ tsan;
+ native;
+
+*)
+
+(* This is a regression test for a bug that incorrectly instrumented two nested
+   try...with expressions, by treating the innermost exception handler as being
+   in tail position, and thus inserting a redundant call to [__tsan_func_exit]
+   before the call to [g], causing TSan's shadow stack to underflow after a few
+   iterations. *)
+
+let g () = raise Exit [@@inline never]
+
+let rec f n =
+  try
+    try
+      if n >= 1000 then () else g ()
+    with Exit -> g () (* Innermost handler *)
+  with Exit -> f (n+1)
+
+let () = f 1

--- a/testsuite/tests/tsan/norace_atomics.ml
+++ b/testsuite/tests/tsan/norace_atomics.ml
@@ -1,0 +1,20 @@
+(* TEST
+
+ include unix;
+ set TSAN_OPTIONS="detect_deadlocks=0";
+
+ reason = "OCaml 5 only";
+ skip;
+ tsan;
+ native;
+
+*)
+
+let v = Atomic.make 0
+
+let () =
+  let t1 = Domain.spawn (fun () -> Atomic.set v 10; Unix.sleep 1) in
+  let t2 = Domain.spawn (fun () ->
+      ignore (Sys.opaque_identity (Atomic.get v)); Unix.sleep 1) in
+  Domain.join t1;
+  Domain.join t2

--- a/testsuite/tests/tsan/perform.ml
+++ b/testsuite/tests/tsan/perform.ml
@@ -1,0 +1,88 @@
+(* TEST
+
+ ocamlopt_flags = "-g";
+ include unix;
+ set TSAN_OPTIONS="detect_deadlocks=0";
+
+ reason = "OCaml 5 only";
+ skip;
+ tsan;
+ native;
+
+*)
+
+(* This performs two effects. We trigger race reports in order to check
+   correctness of the backtrace in three places:
+    - In the effect handler after performing once;
+    - After resuming;
+    - In the value handler when the computation returned. *)
+open Printf
+open Effect
+open Effect.Deep
+
+type _ Effect.t += E : int -> int t
+
+let g_ref1 = ref 0
+let g_ref2 = ref 0
+let g_ref3 = ref 0
+
+let [@inline never] race =
+  function
+  | 0 -> g_ref1 := 42
+  | 1 -> g_ref2 := 42
+  | _ -> g_ref3 := 42
+
+let [@inline never] h () =
+  print_endline "entering h and perform-ing";
+  let v = perform (E 0) in
+  print_endline "resuming h";
+  race 0;
+  print_endline "leaving h";
+  v
+
+let [@inline never] g () =
+  print_endline "entering g";
+  let v = h () in
+  print_endline "leaving g";
+  v
+
+let [@inline never] f () =
+  print_endline "computation, entering f";
+  let v = g () in
+  print_endline "computation, leaving f";
+  v + 1
+
+let effh : type a. a t -> ((a, 'b) continuation -> 'b) option = function
+  | E v -> Some (fun k ->
+      print_endline "in the effect handler";
+      race 1;
+      let v = continue k (v + 1) in
+      print_endline "handler after continue";
+      v + 1
+      )
+  | e -> None
+
+let[@inline never] main () =
+  print_endline "Let's work!";
+  ignore (
+    match_with f ()
+    { retc = (fun v ->
+        print_endline "value handler";
+        race 2;
+        v + 1
+      );
+      exnc = (fun e -> raise e);
+      effc = effh }
+  );
+  44
+
+let[@inline never] other_domain () =
+  ignore (Sys.opaque_identity (!g_ref1, !g_ref2, !g_ref3));
+  Unix.sleepf 0.66
+
+let () =
+  let d = Domain.spawn other_domain in
+  Unix.sleepf 0.33;
+  let v = main () in
+  printf "result = %d\n" v;
+  Domain.join d

--- a/testsuite/tests/tsan/raise_through_handler.ml
+++ b/testsuite/tests/tsan/raise_through_handler.ml
@@ -1,0 +1,61 @@
+(* TEST
+
+ ocamlopt_flags = "-g";
+ include unix;
+ set TSAN_OPTIONS="detect_deadlocks=0";
+
+ reason = "OCaml 5 only";
+ skip;
+ tsan;
+ native;
+
+*)
+
+open Printf
+open Effect
+open Effect.Deep
+
+let g_ref = ref 0
+
+let [@inline never] race () =
+  g_ref := 42
+
+let [@inline never] g () =
+  print_endline "entering g";
+  ignore @@ raise Exit;
+  print_endline "leaving g";
+  12
+
+let [@inline never] f () =
+  print_endline "computation, entering f";
+  let v = g () in
+  print_endline "computation, leaving f";
+  v + 1
+
+let effh : type a. a t -> ((a, 'b) continuation -> 'b) option = fun _ -> None
+
+let[@inline never] main () =
+  print_endline "Let's work!";
+  (try
+    ignore (
+      match_with f ()
+      { retc = (fun v -> v + 1);
+        exnc = (fun e -> raise e);
+        effc = effh }
+    )
+  with Exit ->
+    print_endline "In exception handler";
+    race ();
+  );
+  44
+
+let[@inline never] other_domain () =
+  ignore (Sys.opaque_identity !g_ref);
+  Unix.sleepf 0.66
+
+let () =
+  let d = Domain.spawn other_domain in
+  Unix.sleepf 0.33;
+  let v = main () in
+  printf "result = %d\n" v;
+  Domain.join d

--- a/testsuite/tests/tsan/record_field.ml
+++ b/testsuite/tests/tsan/record_field.ml
@@ -1,0 +1,20 @@
+(* TEST
+
+ include unix;
+ set TSAN_OPTIONS="detect_deadlocks=0";
+
+ reason = "OCaml 5 only";
+ skip;
+ tsan;
+ native;
+
+*)
+type t = { mutable x : int }
+
+let v = { x = 0 }
+
+let () =
+  let t1 = Domain.spawn (fun () -> v.x <- 10; Unix.sleepf 0.1) in
+  let t2 = Domain.spawn (fun () -> ignore (Sys.opaque_identity v.x); Unix.sleepf 0.1) in
+  Domain.join t1;
+  Domain.join t2

--- a/testsuite/tests/tsan/reperform.ml
+++ b/testsuite/tests/tsan/reperform.ml
@@ -1,0 +1,103 @@
+(* TEST
+
+ ocamlopt_flags = "-g";
+ include unix;
+ set TSAN_OPTIONS="detect_deadlocks=0";
+
+ reason = "OCaml 5 only";
+ skip;
+ tsan;
+ native;
+
+*)
+
+(* This performs two effects. We trigger race reports in order to check
+   correctness of the backtrace in three places:
+   - In the outer effect handler after a perform and a reperform;
+   - After resuming, back in the deepest computation;
+   - After the outermost Effect.match_with has completed. *)
+open Printf
+open Effect
+open Effect.Deep
+
+let print_endline s = Stdlib.print_endline s; flush stdout
+
+type _ t += E1 : int -> int t
+type _ t += E2 : int -> int t
+
+let g_ref1 = ref 0
+let g_ref2 = ref 0
+let g_ref3 = ref 0
+
+let [@inline never] race =
+  function
+  | 0 -> g_ref1 := 1
+  | 1 -> g_ref2 := 1
+  | _ -> g_ref3 := 1
+
+let [@inline never] h () =
+  print_endline "entering h";
+  let v = perform (E1 0) in
+  race 1;
+  print_endline "leaving h";
+  v
+
+let [@inline never] g () =
+  print_endline "entering g";
+  let v = h () in
+  print_endline "leaving g";
+  v
+
+let f () =
+  print_endline "entering f";
+  let v = g () in
+  print_endline "leaving f";
+  v + 1
+
+let [@inline never] fiber2 () =
+  ignore @@ match_with f ()
+  { retc = Fun.id;
+    exnc = raise;
+    effc = (fun (type a) (e : a t) ->
+        match e with
+        | E2 v -> Some (fun (k : (a, _) continuation) ->
+              print_endline "E2 handler before continue";
+              let v = continue k v in
+              print_endline "E2 handler after continue";
+              v)
+        | e -> None) };
+  42
+
+let effh : type a. a t -> ((a, 'b) continuation -> 'b) option = function
+  | E1 v -> Some (fun k ->
+      print_endline "E1 handler before continue";
+      race 0;
+      let v = continue k (v + 1) in
+      print_endline "E1 handler after continue";
+      v + 1
+      )
+  | e -> None
+
+let [@inline never] fiber1 () =
+  ignore @@ match_with fiber2 ()
+  { retc = (fun v ->
+    print_endline "value handler"; v + 1);
+    exnc = (fun e -> raise e);
+    effc = effh };
+  1338
+
+let[@inline never] main () =
+  let v = fiber1 () in
+  v + 1
+
+let[@inline never] other_domain () =
+  ignore @@ (!g_ref1, !g_ref2, !g_ref3);
+  Unix.sleepf 0.66
+
+let () =
+  let d = Domain.spawn other_domain in
+  Unix.sleepf 0.33;
+  let v = main () in
+  printf "result=%d\n%!" v;
+  race 2;
+  Domain.join d


### PR DESCRIPTION
(called "backend and lambda" in the internal list, but that is a bit misleading).

This does not include replacing the implementation of "lazy" in matching.ml with the OCaml 4 version.  A separate PR is coming for that.

The changeset that mentions a bootstrap no longer includes one.