### PR TITLE
OCaml 5 on runtime4: use 4.x lazy implementation

### DIFF
--- a/jane/build-resolved-files-for-ci
+++ b/jane/build-resolved-files-for-ci
@@ -121,7 +121,6 @@ mls=$(
     grep -v "utils/config.common.ml" |
     grep -v "utils/config.fixed.ml" |
     grep -v "utils/config.generated.ml" |
-    grep -v "lambda/matching.ml" | # need Obj.forcing_tag in stdlib
     cat;
 )
 echo "$mls"

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1924,6 +1924,9 @@ let get_mod_field modname field =
          | path, _ -> transl_value_path Loc_unknown env path
        ))
 
+(* BACKPORT BEGIN
+   This is the OCaml 5 lazy implementation merged into ocaml-jst.
+
 let code_force_lazy_block = get_mod_field "CamlinternalLazy" "force_lazy_block"
 
 let code_force_lazy = get_mod_field "CamlinternalLazy" "force_gen"
@@ -2056,6 +2059,141 @@ let inline_lazy_force arg pos loc =
     (* generating bytecode: Lswitch would generate too many rather big
          tables (~ 250 elts); conditionals are better *)
     inline_lazy_force_cond arg pos loc
+*)
+(* BACKPORT END *)
+
+(* This is the OCaml 4 implementation of lazy with a tweak to the
+   Pfield occurrence in lazy_forward_field (to add "Pointer"). *)
+
+let code_force_lazy_block = get_mod_field "CamlinternalLazy" "force_lazy_block"
+
+let code_force_lazy = get_mod_field "CamlinternalLazy" "force"
+
+(* inline_lazy_force inlines the beginning of the code of Lazy.force. When
+   the value argument is tagged as:
+   - forward, take field 0
+   - lazy, call the primitive that forces (without testing again the tag)
+   - anything else, return it
+
+   Using Lswitch below relies on the fact that the GC does not shortcut
+   Forward(val_out_of_heap).
+*)
+
+let lazy_forward_field = Lambda.Pfield (0, Pointer, Reads_vary)
+
+let inline_lazy_force_cond arg pos loc =
+  let idarg = Ident.create_local "lzarg" in
+  let varg = Lvar idarg in
+  let tag = Ident.create_local "tag" in
+  let tag_var = Lvar tag in
+  let force_fun = Lazy.force code_force_lazy_block in
+  Llet
+    ( Strict,
+      Lambda.layout_lazy,
+      idarg,
+      arg,
+      Llet
+        ( Alias,
+          Lambda.layout_int,
+          tag,
+          Lprim (Pccall prim_obj_tag, [ varg ], loc),
+          Lifthenelse
+            (* if (tag == Obj.forward_tag) then varg.(0) else ... *)
+            ( Lprim
+                ( Pintcomp Ceq,
+                  [ tag_var; Lconst (Const_base (Const_int Obj.forward_tag)) ],
+                  loc ),
+              Lprim (lazy_forward_field, [ varg ], loc),
+              Lifthenelse
+                (* if (tag == Obj.lazy_tag) then Lazy.force varg else ... *)
+                ( Lprim
+                    ( Pintcomp Ceq,
+                      [ tag_var; Lconst (Const_base (Const_int Obj.lazy_tag)) ],
+                      loc ),
+                  Lapply
+                    { ap_tailcall = Default_tailcall;
+                      ap_loc = loc;
+                      ap_func = force_fun;
+                      ap_args = [ varg ];
+                      ap_result_layout = Lambda.layout_lazy_contents;
+                      ap_region_close = pos;
+                      ap_mode = alloc_heap;
+                      ap_inlined = Never_inlined;
+                      ap_specialised = Default_specialise;
+                      ap_probe=None
+                    },
+                  (* ... arg *)
+                  varg, Lambda.layout_lazy_contents), Lambda.layout_lazy_contents) ) )
+
+let inline_lazy_force_switch arg pos loc =
+  let idarg = Ident.create_local "lzarg" in
+  let varg = Lvar idarg in
+  let force_fun = Lazy.force code_force_lazy_block in
+  Llet
+    ( Strict,
+      Lambda.layout_lazy,
+      idarg,
+      arg,
+      Lifthenelse
+        ( Lprim (Pisint { variant_only = false }, [ varg ], loc),
+          varg,
+          Lswitch
+            ( varg,
+              { sw_numconsts = 0;
+                sw_consts = [];
+                sw_numblocks = 256;
+                (* PR#6033 - tag ranges from 0 to 255 *)
+                sw_blocks =
+                  [ ( Obj.forward_tag,
+                      Lprim (lazy_forward_field, [ varg ], loc) );
+                    ( Obj.lazy_tag,
+                      Lapply
+                        { ap_tailcall = Default_tailcall;
+                          ap_loc = loc;
+                          ap_func = force_fun;
+                          ap_args = [ varg ];
+                          ap_result_layout = Lambda.layout_lazy_contents;
+                          ap_region_close = pos;
+                          ap_mode = alloc_heap;
+                          ap_inlined = Default_inlined;
+                          ap_specialised = Default_specialise;
+                          ap_probe=None;
+                        } )
+                  ];
+                sw_failaction = Some varg
+              },
+              loc, Lambda.layout_lazy_contents), Lambda.layout_lazy_contents) )
+
+let inline_lazy_force arg pos loc =
+  if !Clflags.afl_instrument then
+    (* Disable inlining optimisation if AFL instrumentation active,
+       so that the GC forwarding optimisation is not visible in the
+       instrumentation output.
+       (see https://github.com/stedolan/crowbar/issues/14) *)
+    Lapply
+      { ap_tailcall = Default_tailcall;
+        ap_loc = loc;
+        ap_func = Lazy.force code_force_lazy;
+        ap_args = [ arg ];
+        ap_result_layout = Lambda.layout_lazy_contents;
+        ap_region_close = pos;
+        ap_mode = alloc_heap;
+        ap_inlined = Never_inlined;
+        ap_specialised = Default_specialise;
+        ap_probe=None;
+      }
+  else if !Clflags.native_code && not (Clflags.is_flambda2 ()) then
+    (* CR vlaviron: Find a way for Flambda 2 to avoid both the call to
+       caml_obj_tag and the switch on arbitrary tags *)
+    (* Lswitch generates compact and efficient native code *)
+    inline_lazy_force_switch arg pos loc
+  else
+    (* generating bytecode: Lswitch would generate too many rather big
+         tables (~ 250 elts); conditionals are better *)
+    inline_lazy_force_cond arg pos loc
+
+
+(* End of lazy implementations. *)
 
 let get_expr_args_lazy ~scopes head (arg, _mut, _sort, _layout) rem =
   let loc = head_loc ~scopes head in

--- a/stdlib/lazy.ml
+++ b/stdlib/lazy.ml
@@ -62,7 +62,7 @@ external force : 'a t -> 'a = "%lazy_force"
    BACKPORT BEGIN
 let force_val l = CamlinternalLazy.force_gen ~only_val:true l
 *)
-  let force_val = CamlinteralLazy.force_val
+let force_val = CamlinteralLazy.force_val
 (* BACKPORT END *)
 
 let from_fun (f : unit -> 'arg) =
@@ -72,8 +72,11 @@ let from_fun (f : unit -> 'arg) =
 
 let from_val (v : 'arg) =
   let t = Obj.tag (Obj.repr v) in
-  if t = Obj.forward_tag || t = Obj.lazy_tag ||
-     t = Obj.forcing_tag || t = Obj.double_tag then begin
+  if t = Obj.forward_tag || t = Obj.lazy_tag
+(* BACKPORT BEGIN
+    || t = Obj.forcing_tag *)
+(* BACKPORT END *)
+    || t = Obj.double_tag then begin
     make_forward v
   end else begin
     (Obj.magic v : 'arg t)


### PR DESCRIPTION
This just wholesale replaces the implementation rather than using the approach from the backports changesets of commenting out specific sections, which was complicated to look at.  I copy/pasted the 4.x implementation from flambda-backend.