### PR TITLE
Fixes for Stdlib.Random

### DIFF
--- a/runtime4/dune
+++ b/runtime4/dune
@@ -23,7 +23,7 @@
      callback.c weak.c
    finalise.c stacks.c dynlink.c backtrace_byt.c backtrace.c
      afl.c
-   bigarray.c eventlog.c)
+   bigarray.c eventlog.c misc.c)
  (action  (with-stdout-to %{targets} (run %{dep:gen_primitives.sh}))))
 
 (rule

--- a/runtime4/gen_primitives.sh
+++ b/runtime4/gen_primitives.sh
@@ -25,7 +25,7 @@ export LC_ALL=C
       alloc array compare extern floats gc_ctrl hash intern interp ints io \
       lexing md5 meta memprof obj parsing signals str sys callback weak \
       finalise stacks dynlink backtrace_byt backtrace afl \
-      bigarray eventlog
+      bigarray eventlog misc
   do
       sed -n -e 's/^CAMLprim value \([a-z0-9_][a-z0-9_]*\).*/\1/p' "$prim.c"
   done

--- a/runtime4/misc.c
+++ b/runtime4/misc.c
@@ -226,3 +226,58 @@ void caml_flambda2_invalid (value message)
   abort ();
 }
 
+/* The following is from runtime/prng.c (5.x) */
+
+#include "caml/alloc.h"
+#include "caml/bigarray.h"
+#include "caml/mlvalues.h"
+
+/* The L64X128 member of the LXM family.  Taken from figure 1 in
+   "LXM: Better Splittable Pseudorandom Number Generators
+    (and Almost as Fast)" by Guy L. Steele Jr. and Sebastiano Vigna,
+    OOPSLA 2021.  */
+
+static const uint64_t M = 0xd1342543de82ef95;
+
+struct LXM_state {
+  uint64_t a;            /* per-instance additive parameter (odd) */
+  uint64_t s;            /* state of the LCG subgenerator */
+  uint64_t x[2];         /* state of the XBG subgenerator (not 0) */
+};
+
+/* In OCaml, states are represented as a 1D big array of 64-bit integers */
+
+#define LXM_val(v) ((struct LXM_state *) Caml_ba_data_val(v))
+
+Caml_inline uint64_t rotl(const uint64_t x, int k) {
+  return (x << k) | (x >> (64 - k));
+}
+
+CAMLprim uint64_t caml_lxm_next_unboxed(value v)
+{
+  uint64_t z, q0, q1;
+  struct LXM_state * st = LXM_val(v);
+
+  /* Combining operation */
+  z = st->s + st->x[0];
+  /* Mixing function */
+  z = (z ^ (z >> 32)) * 0xdaba0b6eb09322e3;
+  z = (z ^ (z >> 32)) * 0xdaba0b6eb09322e3;
+  z = (z ^ (z >> 32));
+  /* LCG update */
+  st->s = st->s * M + st->a;
+  /* XBG update */
+  q0 = st->x[0]; q1 = st->x[1];
+  q1 ^= q0;
+  q0 = rotl(q0, 24);
+  q0 = q0 ^ q1 ^ (q1 << 16);
+  q1 = rotl(q1, 37);
+  st->x[0] = q0; st->x[1] = q1;
+  /* Return result */
+  return z;
+}
+
+CAMLprim value caml_lxm_next(value v)
+{
+  return caml_copy_int64(caml_lxm_next_unboxed(v));
+}

--- a/stdlib/random.ml
+++ b/stdlib/random.ml
@@ -113,6 +113,8 @@ module State = struct
           (String.get_int64_le d2 0)
           (String.get_int64_le d2 8)
 
+  let full_init = reinit
+
   let make seed =
     let s = create() in reinit s seed; s
 


### PR DESCRIPTION
The 5.x `Random` module uses a new PRNG.  I've copied this into `runtime4/misc.c`.  I think this is reasonable even though we are using the 4.x runtime for 5-minus.