### PR TITLE
Minor String and Sys fixes for runtime functionality not available in 4.x

### DIFF
--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -223,8 +223,10 @@ let ends_with ~suffix s =
     else aux (i + 1)
   in diff >= 0 && aux 0
 
+(* BACKPORT
 external seeded_hash : int -> string -> int = "caml_string_hash" [@@noalloc]
 let hash x = seeded_hash 0 x
+*)
 
 (* duplicated in bytes.ml *)
 let split_on_char sep s =

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -483,6 +483,8 @@ val get_int32_ne : string -> int -> int32
     @since 4.13
 *)
 
+(* BACKPORT
+   not in 4.x runtime (caml_string_hash)
 val hash : t -> int
 (** An unseeded hash function for strings, with the same output value as
     {!Hashtbl.hash}. This function allows this module to be passed as argument
@@ -496,6 +498,7 @@ val seeded_hash : int -> t -> int
     argument to the functor {!Hashtbl.MakeSeeded}.
 
     @since 5.0 *)
+*)
 
 val get_int32_be : string -> int -> int32
 (** [get_int32_be b i] is [b]'s big-endian 32-bit integer

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -485,6 +485,9 @@ val get_int32_ne : string -> int -> int32
     @since 4.13
 *)
 
+(* BACKPORT
+   not in 4.x runtime (caml_string_hash)
+
 val hash : t -> int
 (** An unseeded hash function for strings, with the same output value as
     {!Hashtbl.hash}. This function allows this module to be passed as argument
@@ -498,6 +501,7 @@ val seeded_hash : int -> t -> int
     argument to the functor {!Hashtbl.MakeSeeded}.
 
     @since 5.0 *)
+*)
 
 val get_int32_be : string -> int -> int32
 (** [get_int32_be b i] is [b]'s big-endian 32-bit integer

--- a/stdlib/sys.ml.in
+++ b/stdlib/sys.ml.in
@@ -52,7 +52,10 @@ external runtime_parameters : unit -> string = "caml_runtime_parameters"
 
 external file_exists: string -> bool = "caml_sys_file_exists"
 external is_directory : string -> bool = "caml_sys_is_directory"
+(* BACKPORT
+   not in 4.x runtime (caml_sys_is_regular_file)
 external is_regular_file : string -> bool = "caml_sys_is_regular_file"
+*)
 external remove: string -> unit = "caml_sys_remove"
 external rename : string -> string -> unit = "caml_sys_rename"
 external getenv: string -> string = "caml_sys_getenv"

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -45,11 +45,14 @@ external is_directory : string -> bool = "caml_sys_is_directory"
     @since 3.10
 *)
 
+(* BACKPORT
+   not in 4.x runtime (caml_sys_is_regular_file)
 external is_regular_file : string -> bool = "caml_sys_is_regular_file"
 (** Returns [true] if the given name refers to a regular file,
     [false] if it refers to another kind of file.
     @raise Sys_error if no file exists with the given name.
     @since 5.1
+*)
 *)
 
 external remove : string -> unit = "caml_sys_remove"


### PR DESCRIPTION
The interface changes don't affect any functions that were present in the Stdlib in 4.x, so this should be ok.