### PR TITLE
Fix magic number

### DIFF
--- a/runtime4/caml/exec.h
+++ b/runtime4/caml/exec.h
@@ -60,7 +60,7 @@ struct exec_trailer {
 
 /* Magic number for this release */
 
-#define EXEC_MAGIC "Caml1999X511"
+#define EXEC_MAGIC "Caml1999X520"
 
 #endif /* CAML_INTERNALS */
 


### PR DESCRIPTION
The exec magic number in `runtime4/caml/exec.h` was out of sync with the (updated) one elsewhere.