### PR TITLE
OCaml 5 on runtime4: Minor Cmm_helpers fix

### DIFF
--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -2554,8 +2554,13 @@ let assignment_kind
   | Assignment Modify_maybe_stack, Pointer ->
     assert Config.stack_allocation;
     Caml_modify_local
+(* BACKPORT BEGIN
   | Heap_initialization, Pointer
   | Root_initialization, Pointer -> Caml_initialize
+*)
+  | Heap_initialization, Pointer -> Caml_initialize
+  | Root_initialization, Pointer -> Simple Initialization
+(* BACKPORT END *)
   | (Assignment _), Immediate -> Simple Assignment
   | Heap_initialization, Immediate
   | Root_initialization, Immediate -> Simple Initialization


### PR DESCRIPTION
This got missed, it was part of the backport commit `46aea8c92445a0d7e77db8223b53b83d48fa94c3` (from David's repo).