### PR TITLE
Fix Proc.destroyed_at_c_call for amd64

### DIFF
--- a/asmcomp/amd64/proc.ml
+++ b/asmcomp/amd64/proc.ml
@@ -293,6 +293,7 @@ let stack_ptr_dwarf_register_number = 7
 
 (* Registers destroyed by operations *)
 
+(* BACKPORT BEGIN
 let destroyed_at_c_call =
   (* C calling conventions preserve rbx, but it is clobbered
      by the code sequence used for C calls in emit.mlp, so it
@@ -308,6 +309,20 @@ let destroyed_at_c_call =
       [0;1;2;3;4;5;6;7;10;11;
        100;101;102;103;104;105;106;107;
        108;109;110;111;112;113;114;115])
+*)
+let destroyed_at_c_call =
+  if win64 then
+    (* Win64: rbx, rbp, rsi, rdi, r12-r15, xmm6-xmm15 preserved *)
+    Array.of_list(List.map phys_reg
+      [0;4;5;6;7;10;11;
+       100;101;102;103;104;105])
+  else
+    (* Unix: rbp, rbx, r12-r15 preserved *)
+    Array.of_list(List.map phys_reg
+      [0;2;3;4;5;6;7;10;11;
+       100;101;102;103;104;105;106;107;
+       108;109;110;111;112;113;114;115])
+(* BACKPORT END *)
 
 let destroyed_at_alloc_or_poll =
   if X86_proc.use_plt then


### PR DESCRIPTION
This was also missed from `46aea8c92445a0d7e77db8223b53b83d48fa94c3`.  This version is slightly different from that backport commit, but clearer I think.