### PR TITLE
Skip tests added in `tip-5` involving new modules (`Effect`/`Domain`/`Atomic`/...)

### DIFF
--- a/testsuite/tests/backtrace/backtrace_effects_nested.ml
+++ b/testsuite/tests/backtrace/backtrace_effects_nested.ml
@@ -1,14 +1,15 @@
 (* TEST
-   * skip
 
 
 flags = "-g"
-* bytecode
-* no-flambda
-** native
-* flambda
+* skip
+  reason = "OCaml 5 only"
+** bytecode
+** no-flambda
+*** native
+** flambda
 reference = "${test_source_directory}/backtrace_effects_nested.flambda.reference"
-** native
+*** native
 
 *)
 

--- a/testsuite/tests/callback/nested_fiber.ml
+++ b/testsuite/tests/callback/nested_fiber.ml
@@ -1,9 +1,11 @@
 (* TEST
    include unix
    modules = "nested_fiber_.c"
-   * libunix
-   ** bytecode
-   ** native
+   * skip
+     reason = "OCaml 5 only"
+   ** libunix
+   *** bytecode
+   *** native
 *)
 
 external caml_to_c : (unit -> 'a) -> 'a = "caml_to_c"

--- a/testsuite/tests/callback/stack_overflow.ml
+++ b/testsuite/tests/callback/stack_overflow.ml
@@ -1,9 +1,11 @@
 (* TEST
    include unix
    modules = "stack_overflow_.c"
-   * libunix
-   ** bytecode
-   ** native
+   * skip
+     reason = "OCaml 5 only"
+   ** libunix
+   *** bytecode
+   *** native
 *)
 
 external caml_to_c : (unit -> 'a) -> 'a = "caml_to_c"

--- a/testsuite/tests/callback/test7.ml
+++ b/testsuite/tests/callback/test7.ml
@@ -1,11 +1,12 @@
 (* TEST
-   * skip
 
    include unix
    modules = "test7_.c"
-   * libunix
-   ** bytecode
-   ** native
+   * skip
+     reason = "OCaml 5 only"
+   ** libunix
+   *** bytecode
+   *** native
 *)
 
 (* Tests nested calls from C (main C) to OCaml (main OCaml) to C (caml_to_c) to

--- a/testsuite/tests/lazy/lazy2.ml
+++ b/testsuite/tests/lazy/lazy2.ml
@@ -1,5 +1,7 @@
 (* TEST
    ocamlopt_flags += " -O3 "
+   * skip
+     reason = "OCaml 5 only"
 *)
 
 open Domain

--- a/testsuite/tests/lazy/lazy3.ml
+++ b/testsuite/tests/lazy/lazy3.ml
@@ -1,5 +1,7 @@
 (* TEST
    ocamlopt_flags += " -O3 "
+   * skip
+     reason = "OCaml 5 only"
 *)
 
 let f count =

--- a/testsuite/tests/lazy/lazy5.ml
+++ b/testsuite/tests/lazy/lazy5.ml
@@ -1,5 +1,7 @@
 (* TEST
    ocamlopt_flags += " -O3 "
+   * skip
+     reason = "OCaml 5 only"
 *)
 let rec safe_force l =
   try Lazy.force l with

--- a/testsuite/tests/lazy/lazy6.ml
+++ b/testsuite/tests/lazy/lazy6.ml
@@ -1,5 +1,7 @@
 (* TEST
    ocamlopt_flags += " -O3 "
+   * skip
+     reason = "OCaml 5 only"
 *)
 
 let flag1 = Atomic.make false

--- a/testsuite/tests/lazy/lazy7.ml
+++ b/testsuite/tests/lazy/lazy7.ml
@@ -1,5 +1,7 @@
 (* TEST
    ocamlopt_flags += " -O3 "
+   * skip
+     reason = "OCaml 5 only"
 *)
 
 let num_domains = 4

--- a/testsuite/tests/lazy/lazy8.ml
+++ b/testsuite/tests/lazy/lazy8.ml
@@ -1,5 +1,7 @@
 (* TEST
    ocamlopt_flags += " -O3 "
+   * skip
+     reason = "OCaml 5 only"
 *)
 
 exception E

--- a/testsuite/tests/lib-runtime-events/test_external.ml
+++ b/testsuite/tests/lib-runtime-events/test_external.ml
@@ -1,11 +1,11 @@
 (* TEST
-   * skip
    reason = "OCaml 5 only"
    include runtime_events
    include unix
-   * libunix
-   ** bytecode
-   ** native *)
+   * skip
+   ** libunix
+   *** bytecode
+   *** native *)
 
 let got_major = ref false
 let got_minor = ref false

--- a/testsuite/tests/lib-runtime-events/test_fork.ml
+++ b/testsuite/tests/lib-runtime-events/test_fork.ml
@@ -1,12 +1,11 @@
 (* TEST
-   * skip
-   reason = "OCaml 5 only"
-
    include runtime_events
    include unix
-   * libunix
-   ** bytecode
-   ** native *)
+   * skip
+   reason = "OCaml 5 only"
+   ** libunix
+   *** bytecode
+   *** native *)
 
 let got_start = ref false
 let got_fork_child = ref false

--- a/testsuite/tests/lib-runtime-events/test_instrumented.ml
+++ b/testsuite/tests/lib-runtime-events/test_instrumented.ml
@@ -1,12 +1,11 @@
 (* TEST
-   * skip
-   reason = "OCaml 5 only"
-
    include runtime_events
    flags = "-runtime-variant=i"
 
-   * instrumented-runtime
-   ** native
+   * skip
+   reason = "OCaml 5 only"
+   ** instrumented-runtime
+   *** native
 *)
 
 open Runtime_events

--- a/testsuite/tests/lib-sync/trylock.ml
+++ b/testsuite/tests/lib-sync/trylock.ml
@@ -1,4 +1,6 @@
 (* TEST
+ * skip
+   reason = "OCaml 5 only"
 *)
 
 (* Test Mutex.try_lock *)

--- a/testsuite/tests/lib-sync/trylock2.ml
+++ b/testsuite/tests/lib-sync/trylock2.ml
@@ -1,4 +1,6 @@
 (* TEST
+ * skip
+   reason = "OCaml 5 only"
 *)
 
 (* Test Mutex.try_lock *)


### PR DESCRIPTION
Several of these had improper `* skip` ocamltest directives, so I fixed those. Others were just not disabled, even though they were added in OCaml 5 and use the new stdlib modules &mdash; I disabled those.