### PR TITLE
OCaml5 merge: fix name issue in printtyp

### DIFF
--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1537,11 +1537,10 @@ let tree_of_constructor_args_and_ret_type args ret_type =
   match ret_type with
   | None -> (tree_of_constructor_arguments args, None)
   | Some res ->
-      Names.with_local_names (fun () ->
-        let out_ret = tree_of_typexp Type res in
-        let out_args = tree_of_constructor_arguments args in
-        let qtvs = extract_qtvs (res :: tys_of_constr_args args) in
-        (out_args, Some (qtvs, out_ret)))
+      let out_ret = tree_of_typexp Type res in
+      let out_args = tree_of_constructor_arguments args in
+      let qtvs = extract_qtvs (res :: tys_of_constr_args args) in
+      (out_args, Some (qtvs, out_ret))
 
 let tree_of_single_constructor cd =
   let name = Ident.name cd.cd_id in


### PR DESCRIPTION
In upstream [#11888](https://github.com/ocaml/ocaml/pull/11888), a call to `Names.with_local_names` in `Printtyp` moved from `tree_of_constructor` to `tree_of_constructor_in_decl`.  We had already moved this call to `tree_of_constructor_args_and_ret_type`, and in the merge we ended up with both calls.  This keeps the upstream one and delete the other.

This was causing test failures like [this one](https://github.com/ocaml-flambda/ocaml-jst/pull/228/files#diff-89a24f971ec4b19a438c28c349f2f982d6264b416798b5390bad230a35f3939aL200)

Review: @goldfirere 