### PR TITLE
OCaml 5: Fix simple compile errors in language extensions tests

### DIFF
--- a/testsuite/tests/language-extensions/language_extensions.ml
+++ b/testsuite/tests/language-extensions/language_extensions.ml
@@ -21,7 +21,7 @@ let report ~name ~text =
 
 let typecheck_with_extension ?(full_name = false) name =
   let success =
-    match Typecore.type_expression (Lazy.force Env.initial_safe_string)
+    match Typecore.type_expression (Lazy.force Env.initial)
             extension_parsed_expression
     with
     | _ -> true

--- a/testsuite/tests/language-extensions/pprintast_unconditional.ml
+++ b/testsuite/tests/language-extensions/pprintast_unconditional.ml
@@ -60,6 +60,7 @@ module Example = struct
                          ; pvb_expr = expression
                          ; pvb_attributes = []
                          ; pvb_loc = loc
+                         ; pvb_constraint = None
                          }
   let payload          = PStr structure
   let class_signature  = { pcsig_self = core_type


### PR DESCRIPTION
This one's straightforward.

```
make -f Makefile.jst install_for_test
make -f Makefile.jst test-one-no-rebuild DIR=language-extensions
```