### PR TITLE
OCaml 5: one-line change to fix debugger env for testsuite

### DIFF
--- a/debugger/loadprinter.ml
+++ b/debugger/loadprinter.ml
@@ -94,7 +94,7 @@ let eval_value_path env path =
 let match_printer_type desc make_printer_type =
   Ctype.with_local_level ~post:Ctype.generalize begin fun () ->
     let ty_arg = Ctype.newvar Jkind.(value ~why:Debug_printer_argument) in
-    Ctype.unify Env.empty
+    Ctype.unify (Lazy.force Env.initial)
       (make_printer_type ty_arg)
       (Ctype.instance desc.val_type);
     ty_arg


### PR DESCRIPTION
The debugger checks that an installed printer's type matches the expected scheme. Pierre rightly pointed out in review of #199 that we might want `Env.initial` on this line instead of `Env.empty`. I thought that ocaml/ocaml#11745 obviated this, but I was wrong.

Indeed, the change from `Env.empty` to `Env.initial` was done internally, in preparation for unboxed types: https://github.com/ocaml/ocaml/pull/11745/files#diff-ba1ff056eac914a52442c6f08f0562daabc8d8520748120f4cf0308391a59802

Review suggestion: @ccasin 

This fixes test `testsuite/tool-debugger/printer/debuggee.ml`. Without this change you get the output:

```
> +Printer.p has the wrong type for a printing function.
>  Loading program... done.
>  Breakpoint: 1
>  18   <|b|>for _i = 0 to x do
> -x: int = S S O
> +x: int = 3
```

Testing:
```
$ make -f Makefile.jst install_for_test
$ make -f Makefile.jst test-one-no-rebuild TEST=testsuite/tests/tool-debugger/printer/debuggee.ml
```