### PR TITLE
OCaml 5: rework some OCaml-5-only tests

### DIFF
--- a/testsuite/tests/gc-roots/globroots.ml
+++ b/testsuite/tests/gc-roots/globroots.ml
@@ -26,14 +26,27 @@ module Generational : GLOBREF = struct
   external remove: t -> unit = "gb_generational_remove"
 end
 
+(* BACKPORT BEGIN *)
+module Domain = struct
+  module DLS = struct
+    let get t = Lazy.force t
+  end
+end
+(* BACKPORT END *)
+
 module Test(G: GLOBREF) () = struct
 
   let size = 1024
 
   let random_state =
+    (* BACKPORT BEGIN
     Domain.DLS.new_key
       ~split_from_parent:Random.State.split
       Random.State.make_self_init
+    *)
+    lazy (Random.State.make_self_init ())
+    (* BACKPORT END *)
+
 
   let vals = Array.init size Int.to_string
 

--- a/testsuite/tests/gc-roots/globroots_parallel.ml
+++ b/testsuite/tests/gc-roots/globroots_parallel.ml
@@ -1,6 +1,9 @@
 (* TEST
    flags += " -w a "
    modules = "globrootsprim.c globroots.ml"
+
+   * skip
+     reason = "OCaml 5 only"
 *)
 
 open Globroots

--- a/testsuite/tests/gc-roots/globroots_parallel_spawn_burn.ml
+++ b/testsuite/tests/gc-roots/globroots_parallel_spawn_burn.ml
@@ -1,6 +1,9 @@
 (* TEST
    flags += " -w a "
    modules = "globrootsprim.c globroots.ml"
+
+   * skip
+     reason = "OCaml 5 only"
 *)
 
 open Globroots

--- a/testsuite/tests/gc-roots/globrootsprim.c
+++ b/testsuite/tests/gc-roots/globrootsprim.c
@@ -13,13 +13,17 @@
 
 /* For testing global root registration */
 
+/* BACKPORT
 #define CAML_INTERNALS
+*/
 
 #include "caml/mlvalues.h"
 #include "caml/memory.h"
 #include "caml/alloc.h"
 #include "caml/gc.h"
+/* BACKPORT
 #include "caml/shared_heap.h"
+*/
 #include "caml/callback.h"
 
 struct block { value header; value v; };
@@ -35,7 +39,11 @@ value gb_get(value vblock)
 value gb_classic_register(value v)
 {
   struct block * b = caml_stat_alloc(sizeof(struct block));
+  /* BACKPORT BEGIN
   b->header = Make_header(1, 0, NOT_MARKABLE);
+  */
+  b->header = Make_header(1, 0, Caml_black);
+  /* BACKPORT END */
   b->v = v;
   caml_register_global_root(&(b->v));
   return Val_block(b);
@@ -56,7 +64,11 @@ value gb_classic_remove(value vblock)
 value gb_generational_register(value v)
 {
   struct block * b = caml_stat_alloc(sizeof(struct block));
+  /* BACKPORT BEGIN
   b->header = Make_header(1, 0, NOT_MARKABLE);
+  */
+  b->header = Make_header(1, 0, Caml_black);
+  /* BACKPORT END */
   b->v = v;
   caml_register_generational_global_root(&(b->v));
   return Val_block(b);

--- a/testsuite/tests/lazy/minor_major_force.ml
+++ b/testsuite/tests/lazy/minor_major_force.ml
@@ -1,5 +1,8 @@
 (* TEST
    ocamlopt_flags += " -O3 "
+
+   * skip
+     reason = "OCaml 5 only"
 *)
 
 (*

--- a/testsuite/tests/lf_skiplist/test.ml
+++ b/testsuite/tests/lf_skiplist/test.ml
@@ -1,5 +1,8 @@
 (* TEST
    modules = "stubs.c"
+
+   * skip
+     reason = "OCaml 5 only"
 *)
 
 external test_skiplist_serial : unit -> unit = "test_skiplist_serial"

--- a/testsuite/tests/lf_skiplist/test_parallel.ml
+++ b/testsuite/tests/lf_skiplist/test_parallel.ml
@@ -1,5 +1,8 @@
 (* TEST
    modules = "stubs.c"
+
+   * skip
+     reason = "OCaml 5 only"
 *)
 
 external init_skiplist : unit -> unit = "init_skiplist"

--- a/testsuite/tests/regression/pr9326/gc_set.ml
+++ b/testsuite/tests/regression/pr9326/gc_set.ml
@@ -1,6 +1,7 @@
 (* TEST
 *)
 
+(* BACKPORT BEGIN
 open Gc
 
 let min_heap_sz = 524288 (* 512k *)
@@ -36,3 +37,44 @@ let _ =
   assert (g2.custom_major_ratio = custom_major_ratio);
   assert (g2.custom_minor_ratio = custom_minor_ratio);
   assert (g2.custom_minor_max_size = custom_minor_max_size)
+*)
+
+(* OCaml 4 and 5's runtime differ in what fields are controllable via [Gc.set],
+   e.g. [stack_limit] can be changed in OCaml 5 native code but not in OCaml 4
+   native code.
+ *)
+
+open Gc
+
+let min_heap_sz = 524288 (* 512k *)
+let maj_heap_inc = 4194304 (* 4M *)
+
+let _ =
+  let g1 = Gc.get() in
+  (* Do not use { g1 with ... }, so that the code will break if more fields
+     are added to the Gc.control record type *)
+  Gc.set { minor_heap_size = min_heap_sz;
+           major_heap_increment = maj_heap_inc;
+           space_overhead = g1.space_overhead;
+           verbose = g1.verbose;
+           max_overhead = g1.max_overhead;
+           stack_limit = g1.stack_limit;
+           allocation_policy = g1.allocation_policy;
+           window_size = g1.window_size;
+           custom_major_ratio = g1.custom_major_ratio;
+           custom_minor_ratio = g1.custom_minor_ratio;
+           custom_minor_max_size = g1.custom_minor_max_size };
+  let g2 = Gc.get() in
+  assert (g2.minor_heap_size = min_heap_sz);
+  assert (g2.major_heap_increment = maj_heap_inc);
+  assert (g2.space_overhead = g1.space_overhead);
+  assert (g2.verbose = g1.verbose);
+  assert (g2.max_overhead = g1.max_overhead);
+  assert (g2.stack_limit = g1.stack_limit);
+  assert (g2.allocation_policy = g1.allocation_policy);
+  assert (g2.window_size = g1.window_size);
+  assert (g2.custom_major_ratio = g1.custom_major_ratio);
+  assert (g2.custom_minor_ratio = g1.custom_minor_ratio);
+  assert (g2.custom_minor_max_size = g1.custom_minor_max_size)
+
+(* BACKPORT END *)


### PR DESCRIPTION
Rework/disable pieces of tests that only work in OCaml 5.
* `lf_skiplist`: disable, this uses some a new C module added in the 5 runtime.
* `globroots.ml`: disable the parallel ones, keep the sequential one (and comment out the use of `Domain` in the sequential one)
* `lazy/major_minor_force.ml`: skip, this was added in OCaml 5 and relies on the new implementation of lazy
* `regression/pr9326/gc_set.ml`: revert to the `tip-jst` version for now, as different GC control fields are settable in the 5 runtime vs. the 4 runtime (and this test just checks which fields are settable)

suggested reviewer: @xclerc 