### PR TITLE
OCaml 5: fix backtraces in C exn test

### DIFF
--- a/testsuite/tests/backtrace/backtrace_c_exn.byte.reference
+++ b/testsuite/tests/backtrace/backtrace_c_exn.byte.reference
@@ -1,0 +1,2 @@
+Failure("exn")
+Raised by primitive operation at Backtrace_c_exn in file "backtrace_c_exn.ml", line 20, characters 4-20

--- a/testsuite/tests/backtrace/backtrace_c_exn.ml
+++ b/testsuite/tests/backtrace/backtrace_c_exn.ml
@@ -2,6 +2,10 @@
    modules = "backtrace_c_exn_.c"
    flags = "-g"
    ocamlrunparam += ",b=1"
+   * bytecode
+     reference = "${test_source_directory}/backtrace_c_exn.byte.reference"
+   * native
+     reference = "${test_source_directory}/backtrace_c_exn.opt.reference"
 *)
 
 (* https://github.com/ocaml-multicore/ocaml-multicore/issues/498 *)

--- a/testsuite/tests/backtrace/backtrace_c_exn.opt.reference
+++ b/testsuite/tests/backtrace/backtrace_c_exn.opt.reference
@@ -1,0 +1,4 @@
+Failure("exn")
+Raised at Stdlib.failwith in file "stdlib.ml", line 32, characters 17-33
+Called from Backtrace_c_exn in file "backtrace_c_exn.ml", line 20, characters 4-20
+Called from Backtrace_c_exn in file "backtrace_c_exn.ml", line 20, characters 4-20

--- a/testsuite/tests/backtrace/backtrace_c_exn.reference
+++ b/testsuite/tests/backtrace/backtrace_c_exn.reference
@@ -1,2 +1,0 @@
-Failure("exn")
-Raised by primitive operation at Backtrace_c_exn in file "backtrace_c_exn.ml", line 16, characters 4-20


### PR DESCRIPTION
Rework a test to allow for different backtraces in bytecode vs. native code when a C function calls an OCaml function that raises an exception.

I confirmed that this test behaves identically at the head of flambda-backed. (by copying the test and running it there.) So this difference doesn't seem like anything introduced by the merge.

Testing:

```
$ make -f Makefile.jst install_for_test; make -f Makefile.jst test-one-no-rebuild TEST=backtrace/backtrace_c_exn.ml
```