### PR TITLE
Adjust location to match upstream for consistent errors

### DIFF
--- a/testsuite/tests/parsetree/locations_test.compilers.reference
+++ b/testsuite/tests/parsetree/locations_test.compilers.reference
@@ -243,7 +243,7 @@ Ptop_def
             Ppat_constraint
             pattern (//toplevel//[2,1+4]..[2,1+5])
               Ppat_var "x" (//toplevel//[2,1+4]..[2,1+5])
-            core_type (//toplevel//[2,1+4]..[2,1+35]) ghost
+            core_type (//toplevel//[2,1+16]..[2,1+22]) ghost
               Ptyp_poly 'a
               core_type (//toplevel//[2,1+16]..[2,1+22])
                 Ptyp_arrow

--- a/testsuite/tests/typing-layouts/annots_beta.ml
+++ b/testsuite/tests/typing-layouts/annots_beta.ml
@@ -356,9 +356,9 @@ val f : ('a : float64). 'a -> 'a = <fun>
 let f : type (a : any). a -> a = fun x -> x
 ;;
 [%%expect {|
-Line 1, characters 4-43:
+Line 1, characters 24-30:
 1 | let f : type (a : any). a -> a = fun x -> x
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                            ^^^^^^
 Error: The universal type variable 'a was declared to have
        layout any, but was inferred to have a representable layout.
 |}]


### PR DESCRIPTION
This fixes [typing-gadts/test.ml](https://github.com/ocaml-flambda/ocaml-jst/pull/228/files#diff-9806dee4a84e77cbd79cba5141ffb88fb80eb8be71f8faa9a38a7b241d33ca0e)

We're parsing type constraints on let bindings a little differently than upstream when they contain locally abstract types (e.g., `let x : type a . a = ...`).  Upstream 5.1 gives the `core_type` node for the annotation a different (probably better) location than it used to, and this simply matches that.

Two other tests are promoted because they contain similar locations:
```
parsetree/locations_test.compilers.reference
typing-layouts/annots_beta.ml
```
In the former case the test also exists upstream, and after this PR we now match the upstream behavior.

Reviewer: @ncik-roberts 