### PR TITLE
OCaml5: fix typos in skip directives

### DIFF
--- a/testsuite/tests/effects/issue479.ml
+++ b/testsuite/tests/effects/issue479.ml
@@ -1,7 +1,6 @@
 (* TEST
    * skip
-
-   * toplevel
+   ** toplevel
 *)
 
 (* https://github.com/ocaml-multicore/ocaml-multicore/issues/479 *)

--- a/testsuite/tests/lib-str/parallel.ml
+++ b/testsuite/tests/lib-str/parallel.ml
@@ -1,10 +1,10 @@
 (* TEST
 * skip
 reason = "OCaml 5 only"
-* hasstr
+** hasstr
 include str
-** bytecode
-** native
+*** bytecode
+*** native
 *)
 
 let total = Atomic.make 0

--- a/testsuite/tests/lib-systhreads/multicore_lifecycle.ml
+++ b/testsuite/tests/lib-systhreads/multicore_lifecycle.ml
@@ -1,10 +1,10 @@
 (* TEST
 * skip
 reason = "OCaml 5 only"
-* hassysthreads
+** hassysthreads
 include systhreads
-** bytecode
-** native
+*** bytecode
+*** native
 *)
 
 let _ =

--- a/testsuite/tests/lib-unix/common/multicore_fork_domain_alone.ml
+++ b/testsuite/tests/lib-unix/common/multicore_fork_domain_alone.ml
@@ -2,10 +2,10 @@
 include unix
 * skip
 reason = "OCaml 5 only"
-* hasunix
-** not-windows
-*** bytecode
-*** native
+** hasunix
+*** not-windows
+**** bytecode
+**** native
 *)
 
 (* on Multicore, fork is not allowed is another domain is, and was running. *)

--- a/testsuite/tests/lib-unix/common/multicore_fork_domain_alone2.ml
+++ b/testsuite/tests/lib-unix/common/multicore_fork_domain_alone2.ml
@@ -2,10 +2,10 @@
 include unix
 * skip
 reason = "OCaml 5 only"
-* hasunix
-** not-windows
-*** bytecode
-*** native
+** hasunix
+*** not-windows
+**** bytecode
+**** native
 *)
 
 (* on Multicore, fork is not allowed is another domain is, and was running. *)

--- a/testsuite/tests/parallel/backup_thread.ml
+++ b/testsuite/tests/parallel/backup_thread.ml
@@ -1,10 +1,10 @@
 (* TEST
 * skip
 reason = "OCaml 5 only"
-* hasunix
+** hasunix
 include unix
-** bytecode
-** native
+*** bytecode
+*** native
 *)
 
 

--- a/testsuite/tests/parallel/backup_thread_pipe.ml
+++ b/testsuite/tests/parallel/backup_thread_pipe.ml
@@ -1,10 +1,10 @@
 (* TEST
 * skip
 reason = "OCaml 5 only"
-* hasunix
+** hasunix
 include unix
-** bytecode
-** native
+*** bytecode
+*** native
 *)
 
 

--- a/testsuite/tests/parallel/domain_serial_spawn_burn.ml
+++ b/testsuite/tests/parallel/domain_serial_spawn_burn.ml
@@ -1,10 +1,10 @@
 (* TEST
 * skip
 reason = "OCaml 5 only"
-* hasunix
+** hasunix
 include unix
-** bytecode
-** native
+*** bytecode
+*** native
 *)
 
 open Domain

--- a/testsuite/tests/parallel/fib_threads.ml
+++ b/testsuite/tests/parallel/fib_threads.ml
@@ -1,10 +1,10 @@
 (* TEST
 * skip
 reason = "OCaml 5 only"
-* hassysthreads
+** hassysthreads
 include systhreads
-** bytecode
-** native
+*** bytecode
+*** native
 *)
 
 

--- a/testsuite/tests/parallel/major_gc_wait_backup.ml
+++ b/testsuite/tests/parallel/major_gc_wait_backup.ml
@@ -1,10 +1,10 @@
 (* TEST
 * skip
 reason = "OCaml 5 only"
-* hasunix
+** hasunix
 include unix
-** native
-** bytecode
+*** native
+*** bytecode
 *)
 
 type 'a tree = Empty | Node of 'a tree * 'a tree

--- a/testsuite/tests/parallel/mctest.ml
+++ b/testsuite/tests/parallel/mctest.ml
@@ -1,10 +1,10 @@
 (* TEST
 * skip
 reason = "OCaml 5 only"
-* hasunix
+** hasunix
 include unix
-** bytecode
-** native
+*** bytecode
+*** native
 *)
 
 (*

--- a/testsuite/tests/parallel/multicore_systhreads.ml
+++ b/testsuite/tests/parallel/multicore_systhreads.ml
@@ -1,10 +1,10 @@
 (* TEST
 * skip
 reason = "OCaml 5 only"
-* hassysthreads
+** hassysthreads
 include systhreads
-** bytecode
-** native
+*** bytecode
+*** native
 *)
 
 

--- a/testsuite/tests/parallel/poll.ml
+++ b/testsuite/tests/parallel/poll.ml
@@ -1,10 +1,10 @@
 (* TEST
 * skip
 reason = "OCaml 5 only"
-* hasunix
+** hasunix
 include unix
-** bytecode
-** native
+*** bytecode
+*** native
 *)
 
 let continue = Atomic.make true

--- a/testsuite/tests/parallel/test_c_thread_register.ml
+++ b/testsuite/tests/parallel/test_c_thread_register.ml
@@ -1,11 +1,11 @@
 (* TEST
-* skip
 reason = "OCaml 5 only"
    modules = "test_c_thread_register_cstubs.c"
-   * hassysthreads
+   * skip
+   ** hassysthreads
    include systhreads
-   ** bytecode
-   ** native
+   *** bytecode
+   *** native
 *)
 
 (* spins a external thread from C and register it to the OCaml runtime *)


### PR DESCRIPTION
Some tests were failing because asterisks weren't well-nested. This PR fixes them.