### PR TITLE
OCaml5 merge: Fix ctype var defaulting

### DIFF
--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -5927,12 +5927,12 @@ let add_nongen_vars_in_schema =
     end
   in
   fun env acc ty ->
+    remove_mode_and_jkind_variables ty;
     let _, result = loop env (TypeSet.empty, acc) ty in
     result
 
 (* Return all non-generic variables of [ty]. *)
 let nongen_vars_in_schema env ty =
-  remove_mode_and_jkind_variables ty;
   let result = add_nongen_vars_in_schema env TypeSet.empty ty in
   if TypeSet.is_empty result
   then None


### PR DESCRIPTION
(This is the same as #261, which was closed when I accidentally messed with the history).

OCaml 4 had a function `Ctype.nongen_schema`, which is one of the places we remove mode variables.  That function was replaced by `Ctype.nongen_vars_in_schema` in [upstream #12051](https://github.com/ocaml/ocaml/pull/12051) so I copied the defaulting there.  But there is another change in that PR, which is that some functions which used to call `Ctype.nongen_schema` don't call `nongen_vars_in_schema` - instead they call a lower-level function used in its implementation, `add_nongen_vars_in_schema`.  So the defaulting should go there, and this PR moves it.

This fixes `typing-local/regression_class_type.ml`.

Review: @lpw25 (or whoever feels like it)