### PR TITLE
OCaml 5: match upstream behavior in `check_univars`

### DIFF
--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4157,7 +4157,11 @@ let check_univars env kind exp ty_expected vars =
                   error exp_ty ty_expected
                     [Errortrace.Bad_jkind (uvar,err)]
               end
-            | _ -> error exp_ty ty_expected [])
+            | _ ->
+              (* It would be semantically correct for this case to error. But
+                 these errors are caught below anyway, and erroring earlier
+                 results in small differences in error messages vs upstream. *)
+              ())
             univars vars;
           unify_exp_types exp.exp_loc env exp_ty ty';
           ((exp_ty, vars), exp_ty::vars)


### PR DESCRIPTION
This fixes the test failure in `typing-poly/poly.ml`.

`Typecore.check_univars` checks that variables meant to be polymorphic haven't been instantiated by unification.  Way back in the first unboxed type PR, `check_univars` was reworked to also make sure sort variables also don't get inappropriately instantiated.  At the same time I added that check, I made it so we fail earlier in some cases where the old error could be issued, just because it was easy to do so.  But upstream has added a test that reveals this difference, and there's no particularly good reason to worry about issuing this type error as fast as possible, so let's not.

review: @lpw25 (or anyone else so inclined)