### PR TITLE
Fix parsing mli conflicts, except `parser.mly`

### DIFF
--- a/jane/build-resolved-files-for-ci
+++ b/jane/build-resolved-files-for-ci
@@ -10,10 +10,10 @@ echo "==========="
 
 # ocamlcommon mlis
 mlis=$(
-  { echo driver/{compenv,compmisc,main_args}.mli
-    echo file_formats/{cmi,cmo,cms,cmt}_format.mli
-    echo parsing/parser.mli
-    echo {utils,typing,parsing,lambda}/*.mli
+  { # echo driver/{compenv,compmisc,main_args}.mli
+    # echo file_formats/{cmi,cmo,cms,cmt}_format.mli
+    # echo {utils,typing,lambda}/*.mli
+    echo parsing/*.mli
   } |
     tr ' ' '\n'
 )
@@ -25,307 +25,307 @@ dune_targets=$(
   done
 )
 
-# ocamlbytecomp mlis
-mlis=$(
-  { echo driver/{errors,compile,maindriver}.mli
-    echo bytecomp/{bytegen,bytelibrarian,bytelink,bytepackager}.mli
-    echo bytecomp/{emitcode,printinstr,instruct}.mli
-  } |
-    tr ' ' '\n'
-)
-echo "$mlis"
-dune_targets=$(
-  echo $dune_targets
-  for mli in $mlis; do
-    cmi=$(basename ${mli%.mli})
-    echo _build/default/.ocamlbytecomp.objs/byte/$cmi.cmi
-  done
-)
-
-# ocamloptcomp mlis
-mlis=$(
-  { echo middle_end/{,closure,flambda}/*.mli
-    echo asmcomp/*.mli
-    echo file_formats/{cmx,cmxs,linear}_format.mli
-  } |
-    tr ' ' '\n' |
-    sed "s/CSE/cSE/"
-)
-echo "$mlis"
-dune_targets=$(
-  echo $dune_targets
-  for mli in $mlis; do
-    cmi=$(basename ${mli%.mli})
-    echo _build/default/.ocamloptcomp.objs/byte/$cmi.cmi
-  done
-)
-mlis=$(
-  { echo debugger/*.mli
-  } |
-    tr ' ' '\n'
-)
-echo "$mlis"
-dune_targets=$(
-  echo $dune_targets
-  for mli in $mlis; do
-    basename=$(basename ${mli%.mli})
-    cmi=ocamldebug__$(echo $basename | awk '{for (i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)} 1')
-    echo _build/default/debugger/.ocamldebug.objs/byte/$cmi.cmi
-  done
-)
-echo "Dune targets:"
-echo "$dune_targets"
-dune b --workspace=duneconf/boot.ws $dune_targets
-
-echo "==========="
-echo "Testing mls"
-echo "==========="
-
-typing_mls=(
-  ctype
-  datarepr
-  env
-  includecore
-  includemod
-  jkind
-  jkind_types
-  mtype
-  oprint
-  parmatch
-  path
-  persistent_env
-  predef
-  printtyp
-  printtyped
-  shape
-  subst
-  tast_iterator
-  tast_mapper
-  typecore
-  typeclass
-  typedecl
-  typedecl_variance
-  typedtree
-  typemod
-  types
-  typetexp
-  uniqueness_analysis)
-
-# ocamlcommon mls
-mls=$(
-  { echo driver/{compenv,compmisc,main_args}.ml
-    echo file_formats/{cmi,cms,cmt}_format.ml
-    echo parsing/parser.ml
-    echo {utils,parsing,lambda}/*.ml
-    echo bytecomp/{meta,opcodes,bytesections,dll,symtable}.ml
-    for f in "${typing_mls[@]}"; do
-        echo "typing/${f}.ml"
-    done
-  } |
-    tr ' ' '\n' |
-    grep -v "utils/config.common.ml" |
-    grep -v "utils/config.fixed.ml" |
-    grep -v "utils/config.generated.ml" |
-    cat;
-)
-echo "$mls"
-dune_targets=$(
-  for ml in $mls; do
-    cmx=$(basename ${ml%.ml})
-    echo _build/default/.ocamlcommon.objs/native/$cmx.cmx
-  done
-)
-
-# ocamlbytecomp mls
-mls=$(
-  { echo driver/{errors,compile,maindriver}.ml
-    echo bytecomp/{bytegen,bytelibrarian,bytelink,bytepackager}.ml
-    echo bytecomp/{emitcode,printinstr,instruct}.ml
-  } |
-    tr ' ' '\n'
-)
-echo "$mls"
-dune_targets=$(
-  echo $dune_targets
-  for ml in $mls; do
-    cmx=$(basename ${ml%.ml})
-    echo _build/default/.ocamlbytecomp.objs/native/$cmx.cmx
-  done
-)
-
-# toplevel
-dune_targets=$(
-  echo "$dune_targets"
-  for cmt in genprintval topcommon topdirs topeval toploop topmain topprinters trace; do
-    echo _build/default/toplevel/byte/.ocamltoplevel.objs/byte/$cmt.cmt{,i}
-    echo _build/default/toplevel/native/.ocamltoplevel_native.objs/byte/$cmt.cmt{,i}
-  done
-  echo _build/default/toplevel/native/.ocamltoplevel_native.objs/byte/tophooks.cmt{,i}
-  for cmt in topstart; do
-    echo _build/default/toplevel/native/.topstart.eobjs/byte/$cmt.cmt{,i}
-    echo _build/default/toplevel/.topstart.eobjs/byte/$cmt.cmt{,i}
-  done
-  echo _build/default/toplevel/.expunge.eobjs/byte/expunge.cmt{,i}
-)
-
-# ocamloptcomp mls
-mls=$(
-  { echo middle_end/{,closure,flambda}/*.ml
-    echo asmcomp/*.ml
-    echo asmcomp/amd64/*.ml
-    echo file_formats/linear_format.ml
-  } |
-    tr ' ' '\n' |
-    sed "s/CSE/cSE/"
-)
-echo "$mls"
-dune_targets=$(
-  echo $dune_targets
-  for ml in $mls; do
-    cmx=$(basename ${ml%.ml})
-    echo _build/default/.ocamloptcomp.objs/native/$cmx.cmx
-  done
-)
-
-#ocamldoc
-ocamldoc=_build/default/ocamldoc/.odoc_lib.objs/
-mls=$(
-  GLOBIGNORE="ocamldoc/odoc.ml"
-  echo ocamldoc/*.ml |
-    tr ' ' '\n'
-  unset GLOBIGNORE
-)
-echo "$mls"
-dune_targets=$(
-  echo $dune_targets
-  for ml in $mls; do
-    cmx=$(basename ${ml%.ml})
-    echo _build/default/ocamldoc/.odoc_lib.objs/native/$cmx.cmx
-    echo _build/default/ocamldoc/.odoc_lib.objs/byte/$cmx.cmi
-  done
-  echo _build/default/ocamldoc/.odoc_native.eobjs/byte/odoc_native.cmi
-  echo _build/default/ocamldoc/.odoc_byte.eobjs/byte/odoc_byte.cmi
-  echo _build/default/ocamldoc/.odoc_native.eobjs/native/odoc_native.cmx
-  echo _build/default/ocamldoc/.odoc_byte.eobjs/native/odoc_byte.cmx
-)
-
-mls=$(
-  { echo debugger/*.ml
-  } |
-    tr ' ' '\n' |
-    grep -v ocamldebug_entry
-)
-echo "$mls"
-dune_targets=$(
-  echo $dune_targets
-  for ml in $mls; do
-    basename=$(basename ${ml%.ml})
-    cmx=ocamldebug__$(echo $basename | awk '{for (i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)} 1')
-    echo _build/default/debugger/.ocamldebug.objs/native/$cmx.cmx
-  done
-)
-
-# tools
-dune_targets=$(
-  echo "$dune_targets"
-  cmxes_and_dirs="\
-    objinfo .objinfo.eobjs
-    make_opcodes .make_opcodes.eobjs
-    cvt_emit .make_opcodes.eobjs
-    ocamldep .ocamldep.eobjs
-    cmpbyt .cmpbyt.eobjs
-    ocamlmklib .ocamlmklib.eobjs
-    ocamlmktop .ocamlmktop.eobjs
-    debug_printers .debug_printers.objs
-    opnames .opnames.objs"
-  # omit dumpobj because it uses new opcodes, e.g. perform
-  echo "$cmxes_and_dirs" | while read cmx dir; do
-    echo _build/default/tools/$dir/native/$cmx.cmx
-  done
-)
-
-dune_targets=$(
-  echo "$dune_targets"
-  mls="dynlink dynlink_common dynlink_platform_intf dynlink_types"
-  for ml in $mls; do
-    echo _build/default/otherlibs/dynlink/.dynlink_internal.objs/native/$ml.cmx;
-    echo _build/default/otherlibs/dynlink/.dynlink_internal.objs/byte/$ml.cmi
-  done
-)
-
-dune_targets="$dune_targets \
-_build/default/otherlibs/str/.str.objs/native/str.cmx \
-_build/default/otherlibs/str/.str.objs/byte/str.cmi \
-_build/default/otherlibs/systhreads/byte/.threads.objs/native/thread.cmx \
-_build/default/otherlibs/systhreads/byte/.threads.objs/byte/thread.cmi \
-_build/default/otherlibs/systhreads/native/.threadsnat.objs/native/thread.cmx \
-_build/default/otherlibs/systhreads/native/.threadsnat.objs/byte/thread.cmi
-"
-
-# ocamltest
-ocamltest=_build/default/ocamltest/.ocamltest_core_and_plugin.objs/byte
-dune_targets="$dune_targets \
-  $ocamltest/actions.cmi \
-  $ocamltest/actions_helpers.cmi \
-  $ocamltest/builtin_actions.cmi \
-  $ocamltest/builtin_variables.cmi \
-  $ocamltest/empty.cmi \
-  $ocamltest/environments.cmi \
-  $ocamltest/filecompare.cmi \
-  $ocamltest/modifier_parser.cmi \
-  $ocamltest/ocaml_actions.cmi \
-  $ocamltest/ocaml_backends.cmi \
-  $ocamltest/ocaml_commands.cmi \
-  $ocamltest/ocaml_compilers.cmi \
-  $ocamltest/ocaml_directories.cmi \
-  $ocamltest/ocaml_files.cmi \
-  $ocamltest/ocaml_filetypes.cmi \
-  $ocamltest/ocaml_flags.cmi \
-  $ocamltest/ocaml_modifiers.cmi \
-  $ocamltest/ocaml_tests.cmi \
-  $ocamltest/ocaml_tools.cmi \
-  $ocamltest/ocaml_toplevels.cmi \
-  $ocamltest/ocaml_variables.cmi \
-  $ocamltest/ocamltest_config.cmi \
-  $ocamltest/ocamltest_stdlib.cmi \
-  $ocamltest/ocamltest_unix.cmi \
-  $ocamltest/result.cmi \
-  $ocamltest/run_command.cmi \
-  $ocamltest/strace.cmi \
-  $ocamltest/tests.cmi \
-  $ocamltest/tsl_ast.cmi \
-  $ocamltest/tsl_semantics.cmi \
-  $ocamltest/variables.cmi \
-  $ocamltest/actions.cmo \
-  $ocamltest/actions_helpers.cmo \
-  $ocamltest/builtin_variables.cmo \
-  $ocamltest/empty.cmo \
-  $ocamltest/environments.cmo \
-  $ocamltest/filecompare.cmo \
-  $ocamltest/ocaml_actions.cmo \
-  $ocamltest/ocaml_backends.cmo \
-  $ocamltest/ocaml_commands.cmo \
-  $ocamltest/ocaml_compilers.cmo \
-  $ocamltest/ocaml_directories.cmo \
-  $ocamltest/ocaml_files.cmo \
-  $ocamltest/ocaml_filetypes.cmo \
-  $ocamltest/ocaml_flags.cmo \
-  $ocamltest/ocaml_modifiers.cmo \
-  $ocamltest/ocaml_tests.cmo \
-  $ocamltest/ocaml_tools.cmo \
-  $ocamltest/ocaml_toplevels.cmo \
-  $ocamltest/ocaml_variables.cmo \
-  $ocamltest/ocamltest_config.cmo \
-  $ocamltest/ocamltest_stdlib.cmo \
-  $ocamltest/ocamltest_unix.cmo \
-  $ocamltest/result.cmo \
-  $ocamltest/run_command.cmo \
-  $ocamltest/strace.cmo \
-  $ocamltest/tests.cmo \
-  $ocamltest/tsl_ast.cmo \
-  $ocamltest/tsl_semantics.cmo \
-  $ocamltest/variables.cmo \
-"
+# # ocamlbytecomp mlis
+# mlis=$(
+#   { echo driver/{errors,compile,maindriver}.mli
+#     echo bytecomp/{bytegen,bytelibrarian,bytelink,bytepackager}.mli
+#     echo bytecomp/{emitcode,printinstr,instruct}.mli
+#   } |
+#     tr ' ' '\n'
+# )
+# echo "$mlis"
+# dune_targets=$(
+#   echo $dune_targets
+#   for mli in $mlis; do
+#     cmi=$(basename ${mli%.mli})
+#     echo _build/default/.ocamlbytecomp.objs/byte/$cmi.cmi
+#   done
+# )
+# 
+# # ocamloptcomp mlis
+# mlis=$(
+#   { echo middle_end/{,closure,flambda}/*.mli
+#     echo asmcomp/*.mli
+#     echo file_formats/{cmx,cmxs,linear}_format.mli
+#   } |
+#     tr ' ' '\n' |
+#     sed "s/CSE/cSE/"
+# )
+# echo "$mlis"
+# dune_targets=$(
+#   echo $dune_targets
+#   for mli in $mlis; do
+#     cmi=$(basename ${mli%.mli})
+#     echo _build/default/.ocamloptcomp.objs/byte/$cmi.cmi
+#   done
+# )
+# mlis=$(
+#   { echo debugger/*.mli
+#   } |
+#     tr ' ' '\n'
+# )
+# echo "$mlis"
+# dune_targets=$(
+#   echo $dune_targets
+#   for mli in $mlis; do
+#     basename=$(basename ${mli%.mli})
+#     cmi=ocamldebug__$(echo $basename | awk '{for (i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)} 1')
+#     echo _build/default/debugger/.ocamldebug.objs/byte/$cmi.cmi
+#   done
+# )
+# echo "Dune targets:"
+# echo "$dune_targets"
+# dune b --workspace=duneconf/boot.ws $dune_targets
+# 
+# echo "==========="
+# echo "Testing mls"
+# echo "==========="
+# 
+# typing_mls=(
+#   ctype
+#   datarepr
+#   env
+#   includecore
+#   includemod
+#   jkind
+#   jkind_types
+#   mtype
+#   oprint
+#   parmatch
+#   path
+#   persistent_env
+#   predef
+#   printtyp
+#   printtyped
+#   shape
+#   subst
+#   tast_iterator
+#   tast_mapper
+#   typecore
+#   typeclass
+#   typedecl
+#   typedecl_variance
+#   typedtree
+#   typemod
+#   types
+#   typetexp
+#   uniqueness_analysis)
+# 
+# # ocamlcommon mls
+# mls=$(
+#   { echo driver/{compenv,compmisc,main_args}.ml
+#     echo file_formats/{cmi,cms,cmt}_format.ml
+#     echo parsing/parser.ml
+#     echo {utils,parsing,lambda}/*.ml
+#     echo bytecomp/{meta,opcodes,bytesections,dll,symtable}.ml
+#     for f in "${typing_mls[@]}"; do
+#         echo "typing/${f}.ml"
+#     done
+#   } |
+#     tr ' ' '\n' |
+#     grep -v "utils/config.common.ml" |
+#     grep -v "utils/config.fixed.ml" |
+#     grep -v "utils/config.generated.ml" |
+#     cat;
+# )
+# echo "$mls"
+# dune_targets=$(
+#   for ml in $mls; do
+#     cmx=$(basename ${ml%.ml})
+#     echo _build/default/.ocamlcommon.objs/native/$cmx.cmx
+#   done
+# )
+# 
+# # ocamlbytecomp mls
+# mls=$(
+#   { echo driver/{errors,compile,maindriver}.ml
+#     echo bytecomp/{bytegen,bytelibrarian,bytelink,bytepackager}.ml
+#     echo bytecomp/{emitcode,printinstr,instruct}.ml
+#   } |
+#     tr ' ' '\n'
+# )
+# echo "$mls"
+# dune_targets=$(
+#   echo $dune_targets
+#   for ml in $mls; do
+#     cmx=$(basename ${ml%.ml})
+#     echo _build/default/.ocamlbytecomp.objs/native/$cmx.cmx
+#   done
+# )
+# 
+# # toplevel
+# dune_targets=$(
+#   echo "$dune_targets"
+#   for cmt in genprintval topcommon topdirs topeval toploop topmain topprinters trace; do
+#     echo _build/default/toplevel/byte/.ocamltoplevel.objs/byte/$cmt.cmt{,i}
+#     echo _build/default/toplevel/native/.ocamltoplevel_native.objs/byte/$cmt.cmt{,i}
+#   done
+#   echo _build/default/toplevel/native/.ocamltoplevel_native.objs/byte/tophooks.cmt{,i}
+#   for cmt in topstart; do
+#     echo _build/default/toplevel/native/.topstart.eobjs/byte/$cmt.cmt{,i}
+#     echo _build/default/toplevel/.topstart.eobjs/byte/$cmt.cmt{,i}
+#   done
+#   echo _build/default/toplevel/.expunge.eobjs/byte/expunge.cmt{,i}
+# )
+# 
+# # ocamloptcomp mls
+# mls=$(
+#   { echo middle_end/{,closure,flambda}/*.ml
+#     echo asmcomp/*.ml
+#     echo asmcomp/amd64/*.ml
+#     echo file_formats/linear_format.ml
+#   } |
+#     tr ' ' '\n' |
+#     sed "s/CSE/cSE/"
+# )
+# echo "$mls"
+# dune_targets=$(
+#   echo $dune_targets
+#   for ml in $mls; do
+#     cmx=$(basename ${ml%.ml})
+#     echo _build/default/.ocamloptcomp.objs/native/$cmx.cmx
+#   done
+# )
+# 
+# #ocamldoc
+# ocamldoc=_build/default/ocamldoc/.odoc_lib.objs/
+# mls=$(
+#   GLOBIGNORE="ocamldoc/odoc.ml"
+#   echo ocamldoc/*.ml |
+#     tr ' ' '\n'
+#   unset GLOBIGNORE
+# )
+# echo "$mls"
+# dune_targets=$(
+#   echo $dune_targets
+#   for ml in $mls; do
+#     cmx=$(basename ${ml%.ml})
+#     echo _build/default/ocamldoc/.odoc_lib.objs/native/$cmx.cmx
+#     echo _build/default/ocamldoc/.odoc_lib.objs/byte/$cmx.cmi
+#   done
+#   echo _build/default/ocamldoc/.odoc_native.eobjs/byte/odoc_native.cmi
+#   echo _build/default/ocamldoc/.odoc_byte.eobjs/byte/odoc_byte.cmi
+#   echo _build/default/ocamldoc/.odoc_native.eobjs/native/odoc_native.cmx
+#   echo _build/default/ocamldoc/.odoc_byte.eobjs/native/odoc_byte.cmx
+# )
+# 
+# mls=$(
+#   { echo debugger/*.ml
+#   } |
+#     tr ' ' '\n' |
+#     grep -v ocamldebug_entry
+# )
+# echo "$mls"
+# dune_targets=$(
+#   echo $dune_targets
+#   for ml in $mls; do
+#     basename=$(basename ${ml%.ml})
+#     cmx=ocamldebug__$(echo $basename | awk '{for (i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)} 1')
+#     echo _build/default/debugger/.ocamldebug.objs/native/$cmx.cmx
+#   done
+# )
+# 
+# # tools
+# dune_targets=$(
+#   echo "$dune_targets"
+#   cmxes_and_dirs="\
+#     objinfo .objinfo.eobjs
+#     make_opcodes .make_opcodes.eobjs
+#     cvt_emit .make_opcodes.eobjs
+#     ocamldep .ocamldep.eobjs
+#     cmpbyt .cmpbyt.eobjs
+#     ocamlmklib .ocamlmklib.eobjs
+#     ocamlmktop .ocamlmktop.eobjs
+#     debug_printers .debug_printers.objs
+#     opnames .opnames.objs"
+#   # omit dumpobj because it uses new opcodes, e.g. perform
+#   echo "$cmxes_and_dirs" | while read cmx dir; do
+#     echo _build/default/tools/$dir/native/$cmx.cmx
+#   done
+# )
+# 
+# dune_targets=$(
+#   echo "$dune_targets"
+#   mls="dynlink dynlink_common dynlink_platform_intf dynlink_types"
+#   for ml in $mls; do
+#     echo _build/default/otherlibs/dynlink/.dynlink_internal.objs/native/$ml.cmx;
+#     echo _build/default/otherlibs/dynlink/.dynlink_internal.objs/byte/$ml.cmi
+#   done
+# )
+# 
+# dune_targets="$dune_targets \
+# _build/default/otherlibs/str/.str.objs/native/str.cmx \
+# _build/default/otherlibs/str/.str.objs/byte/str.cmi \
+# _build/default/otherlibs/systhreads/byte/.threads.objs/native/thread.cmx \
+# _build/default/otherlibs/systhreads/byte/.threads.objs/byte/thread.cmi \
+# _build/default/otherlibs/systhreads/native/.threadsnat.objs/native/thread.cmx \
+# _build/default/otherlibs/systhreads/native/.threadsnat.objs/byte/thread.cmi
+# "
+# 
+# # ocamltest
+# ocamltest=_build/default/ocamltest/.ocamltest_core_and_plugin.objs/byte
+# dune_targets="$dune_targets \
+#   $ocamltest/actions.cmi \
+#   $ocamltest/actions_helpers.cmi \
+#   $ocamltest/builtin_actions.cmi \
+#   $ocamltest/builtin_variables.cmi \
+#   $ocamltest/empty.cmi \
+#   $ocamltest/environments.cmi \
+#   $ocamltest/filecompare.cmi \
+#   $ocamltest/modifier_parser.cmi \
+#   $ocamltest/ocaml_actions.cmi \
+#   $ocamltest/ocaml_backends.cmi \
+#   $ocamltest/ocaml_commands.cmi \
+#   $ocamltest/ocaml_compilers.cmi \
+#   $ocamltest/ocaml_directories.cmi \
+#   $ocamltest/ocaml_files.cmi \
+#   $ocamltest/ocaml_filetypes.cmi \
+#   $ocamltest/ocaml_flags.cmi \
+#   $ocamltest/ocaml_modifiers.cmi \
+#   $ocamltest/ocaml_tests.cmi \
+#   $ocamltest/ocaml_tools.cmi \
+#   $ocamltest/ocaml_toplevels.cmi \
+#   $ocamltest/ocaml_variables.cmi \
+#   $ocamltest/ocamltest_config.cmi \
+#   $ocamltest/ocamltest_stdlib.cmi \
+#   $ocamltest/ocamltest_unix.cmi \
+#   $ocamltest/result.cmi \
+#   $ocamltest/run_command.cmi \
+#   $ocamltest/strace.cmi \
+#   $ocamltest/tests.cmi \
+#   $ocamltest/tsl_ast.cmi \
+#   $ocamltest/tsl_semantics.cmi \
+#   $ocamltest/variables.cmi \
+#   $ocamltest/actions.cmo \
+#   $ocamltest/actions_helpers.cmo \
+#   $ocamltest/builtin_variables.cmo \
+#   $ocamltest/empty.cmo \
+#   $ocamltest/environments.cmo \
+#   $ocamltest/filecompare.cmo \
+#   $ocamltest/ocaml_actions.cmo \
+#   $ocamltest/ocaml_backends.cmo \
+#   $ocamltest/ocaml_commands.cmo \
+#   $ocamltest/ocaml_compilers.cmo \
+#   $ocamltest/ocaml_directories.cmo \
+#   $ocamltest/ocaml_files.cmo \
+#   $ocamltest/ocaml_filetypes.cmo \
+#   $ocamltest/ocaml_flags.cmo \
+#   $ocamltest/ocaml_modifiers.cmo \
+#   $ocamltest/ocaml_tests.cmo \
+#   $ocamltest/ocaml_tools.cmo \
+#   $ocamltest/ocaml_toplevels.cmo \
+#   $ocamltest/ocaml_variables.cmo \
+#   $ocamltest/ocamltest_config.cmo \
+#   $ocamltest/ocamltest_stdlib.cmo \
+#   $ocamltest/ocamltest_unix.cmo \
+#   $ocamltest/result.cmo \
+#   $ocamltest/run_command.cmo \
+#   $ocamltest/strace.cmo \
+#   $ocamltest/tests.cmo \
+#   $ocamltest/tsl_ast.cmo \
+#   $ocamltest/tsl_semantics.cmo \
+#   $ocamltest/variables.cmo \
+# "
 
 echo "Dune targets:"
 for target in $dune_targets; do echo $target; done

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -138,30 +138,9 @@ module Exp:
     val constant: ?loc:loc -> ?attrs:attrs -> constant -> expression
     val let_: ?loc:loc -> ?attrs:attrs -> rec_flag -> value_binding list
               -> expression -> expression
-<<<<<<< HEAD
-
-    (* We can delete these "prefer_jane_syntax" nudges once we merge
-       syntactic arity from upstream OCaml.
-    *)
-
-    val fun_: ?loc:loc -> ?attrs:attrs -> arg_label -> expression option
-              -> pattern -> expression -> expression
-    [@@alert
-      prefer_jane_syntax "Prefer Jane Syntax for constructing functions"]
-
-    val function_: ?loc:loc -> ?attrs:attrs -> case list -> expression
-    [@@alert
-      prefer_jane_syntax "Prefer Jane Syntax for constructing functions"]
-
-||||||| 121bedcfd2
-    val fun_: ?loc:loc -> ?attrs:attrs -> arg_label -> expression option
-              -> pattern -> expression -> expression
-    val function_: ?loc:loc -> ?attrs:attrs -> case list -> expression
-=======
     val function_ : ?loc:loc -> ?attrs:attrs -> function_param list
                    -> type_constraint option -> function_body
                    -> expression
->>>>>>> 5.2.0
     val apply: ?loc:loc -> ?attrs:attrs -> expression
                -> (arg_label * expression) list -> expression
     val match_: ?loc:loc -> ?attrs:attrs -> expression -> case list

--- a/parsing/ast_iterator.mli
+++ b/parsing/ast_iterator.mli
@@ -72,13 +72,9 @@ type iterator = {
   signature_item_jane_syntax: iterator -> Jane_syntax.Signature_item.t -> unit;
   structure: iterator -> structure -> unit;
   structure_item: iterator -> structure_item -> unit;
-<<<<<<< HEAD
   structure_item_jane_syntax: iterator -> Jane_syntax.Structure_item.t -> unit;
-||||||| 121bedcfd2
-=======
   toplevel_directive: iterator -> toplevel_directive -> unit;
   toplevel_phrase: iterator -> toplevel_phrase -> unit;
->>>>>>> 5.2.0
   typ: iterator -> core_type -> unit;
   typ_jane_syntax: iterator -> Jane_syntax.Core_type.t -> unit;
   typ_mode_syntax : iterator -> Jane_syntax.Mode_expr.t -> core_type -> unit;

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -19,24 +19,6 @@
     - ocaml.boxed
     - ocaml.deprecated
     - ocaml.deprecated_mutable
-<<<<<<< HEAD
-    - ocaml.boxed / ocaml.unboxed
-    - ocaml.nolabels
-    - ocaml.inline
-    - ocaml.afl_inst_ratio
-    - ocaml.flambda_o3
-    - ocaml.flambda_oclassic
-    - jkind attributes:
-      - ocaml.any
-      - ocaml.value
-      - ocaml.void
-      - ocaml.immediate
-      - ocaml.immediate64
-||||||| 121bedcfd2
-    - ocaml.immediate
-    - ocaml.immediate64
-    - ocaml.boxed / ocaml.unboxed
-=======
     - ocaml.explicit_arity
     - ocaml.immediate
     - ocaml.immediate64
@@ -55,68 +37,12 @@
     - ocaml.warnerror
     - ocaml.warning
     - ocaml.warn_on_literal_pattern
->>>>>>> 5.2.0
 
     {b Warning:} this module is unstable and part of
   {{!Compiler_libs}compiler-libs}.
 
 *)
 
-<<<<<<< HEAD
-
-(** [register_attr] must be called on the locations of all attributes that
-    should be tracked for the purpose of misplaced attribute warnings.  In
-    particular, it should be called on all attributes that are present in the
-    source program except those that are contained in the payload of another
-    attribute (because these may be left behind by a ppx and intentionally
-    ignored by the compiler).
-
-    The [attr_tracking_time] argument indicates when the attr is being added for
-    tracking - either when it is created in the parser or when we see it while
-    running the check in the [Ast_invariants] module.  This ensures that we
-    track only attributes from the final version of the parse tree: we skip
-    adding attributes at parse time if we can see that a ppx will be run later,
-    because the [Ast_invariants] check is always run on the result of a ppx.
-
-    Note that the [Ast_invariants] check is also run on parse trees created from
-    marshalled ast files if no ppx is being used, ensuring we don't miss
-    attributes in that case.
-*)
-type attr_tracking_time = Parser | Invariant_check
-val register_attr : attr_tracking_time -> string Location.loc -> unit
-
-(** Marks alert attributes used for the purposes of misplaced attribute
-    warnings.  Call this when moving things with alert attributes into the
-    environment. *)
-val mark_alert_used : Parsetree.attribute -> unit
-val mark_alerts_used : Parsetree.attributes -> unit
-
-(** Zero_alloc attributes are checked
-    in late stages of compilation in the backend.
-    Registering them helps detect code that is not checked,
-    because it is optimized away by the middle-end.  *)
-val register_zero_alloc_attribute : string Location.loc -> unit
-val mark_zero_alloc_attribute_checked : string -> Location.t -> unit
-
-(** Marks "warn_on_literal_pattern" attributes used for the purposes of
-    misplaced attribute warnings.  Call this when moving things with alert
-    attributes into the environment. *)
-val mark_warn_on_literal_pattern_used : Parsetree.attributes -> unit
-
-(** Marks the attributes hiding in the payload of another attribute used, for
-    the purposes of misplaced attribute warnings (see comment on
-    [attr_tracking_time] above).  In the parser, it's simplest to add these to
-    the table and remove them later, rather than threading through state
-    tracking whether we're in an attribute payload. *)
-val mark_payload_attrs_used : Parsetree.payload -> unit
-
-(** Issue misplaced attribute warnings for all attributes created with
-    [mk_internal] but not yet marked used. *)
-val warn_unused : unit -> unit
-val warn_unchecked_zero_alloc_attribute : unit -> unit
-
-||||||| 121bedcfd2
-=======
 (** {2 Attribute tracking for warning 53} *)
 
 (** [register_attr] must be called on the locations of all attributes that
@@ -182,9 +108,18 @@ val mark_warn_on_literal_pattern_used : Parsetree.attributes -> unit
     environment. *)
 val mark_deprecated_mutable_used : Parsetree.attributes -> unit
 
+(** {3 Warning 53 helpers for zero alloc}
+
+    Zero_alloc attributes are checked
+    in late stages of compilation in the backend.
+    Registering them helps detect code that is not checked,
+    because it is optimized away by the middle-end.  *)
+val register_zero_alloc_attribute : string Location.loc -> unit
+val mark_zero_alloc_attribute_checked : string -> Location.t -> unit
+val warn_unchecked_zero_alloc_attribute : unit -> unit
+
 (** {2 Helpers for alert and warning attributes} *)
 
->>>>>>> 5.2.0
 val check_alerts: Location.t -> Parsetree.attributes -> string -> unit
 val check_alerts_inclusion:
   def:Location.t -> use:Location.t -> Location.t -> Parsetree.attributes ->
@@ -225,44 +160,6 @@ val warning_scope:
       is executed.
   *)
 
-<<<<<<< HEAD
-(** [has_attribute names attrs] is true if an attribute named in [names] is
-    present in [attrs].  It marks that attribute used for the purposes of
-    misplaced attribute warnings. *)
-val has_attribute : string list -> Parsetree.attributes -> bool
-
-module Attributes_filter : sig
-  type t
-
-  val create : (string list * bool) list -> t
-end
-
-(** [filter_attributes (Attributes_filter.create nms_and_conds) attrs] finds
-    those attrs which appear in one of the sublists of nms_and_conds with
-    cond=true.
-
-    Each element [(nms, conds)] of the [nms_and_conds] list is a list of
-    attribute names along with a boolean indicating whether to include
-    attributes with those names in the output.  The boolean is used to
-    accomodate different compiler configurations (e.g., we may want to check for
-    "unrolled" only in the case where flambda or flambda2 is configured).  We
-    handle this by taking a bool, rather than simply passing fewer nms in those
-    cases, to support misplaced attribute warnings - the attribute should not
-    count as misplaced if the compiler could use it in some configuration.
-*)
-val filter_attributes :
-  ?mark:bool ->
-  Attributes_filter.t -> Parsetree.attributes -> Parsetree.attributes
-
-(** [find_attribute] behaves like [filter_attribute], except that it returns at
-    most one matching attribute and issues a "duplicated attribute" warning if
-    there are multiple matches. *)
-val find_attribute :
-  ?mark_used:bool -> Attributes_filter.t -> Parsetree.attributes ->
-  Parsetree.attribute option
-
-||||||| 121bedcfd2
-=======
 (** {2 Helpers for searching for particular attributes} *)
 
 (** [has_attribute name attrs] is true if an attribute with name [name] or
@@ -291,21 +188,9 @@ val select_attributes :
     or [select_attributes]. *)
 val attr_equals_builtin : Parsetree.attribute -> string -> bool
 
->>>>>>> 5.2.0
 val warn_on_literal_pattern: Parsetree.attributes -> bool
 val explicit_arity: Parsetree.attributes -> bool
 
-<<<<<<< HEAD
-||||||| 121bedcfd2
-
-val immediate: Parsetree.attributes -> bool
-val immediate64: Parsetree.attributes -> bool
-
-=======
-val immediate: Parsetree.attributes -> bool
-val immediate64: Parsetree.attributes -> bool
-
->>>>>>> 5.2.0
 val has_unboxed: Parsetree.attributes -> bool
 val has_boxed: Parsetree.attributes -> bool
 

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -15,11 +15,14 @@
 
 (** Support for the builtin attributes:
 
+    - ocaml.afl_inst_ratio
     - ocaml.alert
     - ocaml.boxed
     - ocaml.deprecated
     - ocaml.deprecated_mutable
     - ocaml.explicit_arity
+    - ocaml.flambda_o3
+    - ocaml.flambda_oclassic
     - ocaml.immediate
     - ocaml.immediate64
     - ocaml.inline

--- a/parsing/jane_syntax.ml
+++ b/parsing/jane_syntax.ml
@@ -941,7 +941,7 @@ module N_ary_functions = struct
       pparam_loc : Location.t
     }
 
-  type type_constraint =
+  type type_constraint = Parsetree.type_constraint =
     | Pconstraint of core_type
     | Pcoerce of core_type option * core_type
 

--- a/parsing/jane_syntax.mli
+++ b/parsing/jane_syntax.mli
@@ -278,7 +278,7 @@ module N_ary_functions : sig
       pparam_loc : Location.t
     }
 
-  type type_constraint =
+  type type_constraint = Parsetree.type_constraint =
     | Pconstraint of Parsetree.core_type
     | Pcoerce of Parsetree.core_type option * Parsetree.core_type
 

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -269,34 +269,19 @@ let rec mktailpat nilloc = let open Location in function
 let mkstrexp e attrs =
   { pstr_desc = Pstr_eval (e, attrs); pstr_loc = e.pexp_loc }
 
-<<<<<<< HEAD
-let mkexp_type_constraint ?(ghost=false) ~loc e t =
-  let desc =
-    match t with
-  | N_ary.Pconstraint t -> Pexp_constraint(e, t)
-  | N_ary.Pcoerce(t1, t2)  -> Pexp_coerce(e, t1, t2)
-  in
-  if ghost then ghexp ~loc desc
-  else mkexp ~loc desc
-||||||| 121bedcfd2
-let mkexp_constraint ~loc e (t1, t2) =
-  match t1, t2 with
-  | Some t, None -> mkexp ~loc (Pexp_constraint(e, t))
-  | _, Some t -> mkexp ~loc (Pexp_coerce(e, t1, t))
-  | None, None -> assert false
-=======
-let mkexp_desc_constraint e t =
+let mkexp_desc_type_constraint e t =
   match t with
   | Pconstraint t -> Pexp_constraint(e, t)
   | Pcoerce(t1, t2)  -> Pexp_coerce(e, t1, t2)
 
-let mkexp_constraint ~loc e t =
-  mkexp ~loc (mkexp_desc_constraint e t)
->>>>>>> 5.2.0
+let mkexp_type_constraint ?(ghost=false) ~loc e t =
+  let desc = mkexp_desc_type_constraint e t in
+  if ghost then ghexp ~loc desc
+  else mkexp ~loc desc
 
 let mkexp_opt_type_constraint ~loc e = function
   | None -> e
-  | Some c -> mkexp_type_constraint ~loc e c
+  | Some c -> mkexp_constraint ~loc e c
 
 let mkpat_opt_constraint ~loc p = function
   | None -> p
@@ -571,6 +556,11 @@ let pat_of_label lbl =
 
 let mk_newtypes ~loc newtypes exp =
   let mk_one (name, jkind) exp =
+    (* Mints a ghost location that approximates the newtype's "extent" as
+    being from the start of the newtype param until the end of the
+    function body.
+     *)
+    let loc = (newtype_loc.Location.loc_start, body.pexp_loc.loc_end) in
     match jkind with
     | None -> ghexp ~loc (Pexp_newtype (name, exp))
     | Some jkind ->
@@ -761,7 +751,6 @@ let class_of_let_bindings ~loc lbs body =
     assert (lbs.lbs_extension = None);
     mkclass ~loc (Pcl_let (lbs.lbs_rec, List.rev bindings, body))
 
-<<<<<<< HEAD
 (* If all the parameters are [Pparam_newtype x], then return [Some xs] where
    [xs] is the corresponding list of values [x]. This function is optimized for
    the common case, where a list of parameters contains at least one value
@@ -820,67 +809,6 @@ let mkfunction ~loc ~attrs params body_constraint body =
             attrs
     end
 
-||||||| 121bedcfd2
-=======
-(* If all the parameters are [Pparam_newtype x], then return [Some xs] where
-   [xs] is the corresponding list of values [x]. This function is optimized for
-   the common case, where a list of parameters contains at least one value
-   parameter.
-*)
-let all_params_as_newtypes =
-  let is_newtype { pparam_desc; _ } =
-    match pparam_desc with
-    | Pparam_newtype _ -> true
-    | Pparam_val _ -> false
-  in
-  let as_newtype { pparam_desc; pparam_loc } =
-    match pparam_desc with
-    | Pparam_newtype x -> Some (x, pparam_loc)
-    | Pparam_val _ -> None
-  in
-  fun params ->
-    if List.for_all is_newtype params
-    then Some (List.filter_map as_newtype params)
-    else None
-
-(* Given a construct [fun (type a b c) : t -> e], we construct
-   [Pexp_newtype(a, Pexp_newtype(b, Pexp_newtype(c, Pexp_constraint(e, t))))]
-   rather than a [Pexp_function].
-*)
-let mkghost_newtype_function_body newtypes body_constraint body =
-  let wrapped_body =
-    match body_constraint with
-    | None -> body
-    | Some body_constraint ->
-        let loc = { body.pexp_loc with loc_ghost = true } in
-        Exp.mk (mkexp_desc_constraint body body_constraint) ~loc
-  in
-  let expr =
-    List.fold_right
-      (fun (newtype, newtype_loc) e ->
-         (* Mints a ghost location that approximates the newtype's "extent" as
-            being from the start of the newtype param until the end of the
-            function body.
-         *)
-         let loc = (newtype_loc.Location.loc_start, body.pexp_loc.loc_end) in
-         ghexp (Pexp_newtype (newtype, e)) ~loc)
-      newtypes
-      wrapped_body
-  in
-  expr.pexp_desc
-
-let mkfunction params body_constraint body =
-  match body with
-  | Pfunction_cases _ -> Pexp_function (params, body_constraint, body)
-  | Pfunction_body body_exp ->
-    (* If all the params are newtypes, then we don't create a function node;
-       we create nested newtype nodes. *)
-      match all_params_as_newtypes params with
-      | None -> Pexp_function (params, body_constraint, body)
-      | Some newtypes ->
-          mkghost_newtype_function_body newtypes body_constraint body_exp
-
->>>>>>> 5.2.0
 (* Alternatively, we could keep the generic module type in the Parsetree
    and extract the package type during type-checking. In that case,
    the assertions below should be turned into explicit checks. *)
@@ -1381,29 +1309,6 @@ reversed_nonempty_llist(X):
   xs = rev(reversed_nonempty_llist(X))
     { xs }
 
-<<<<<<< HEAD
-(* [reversed_nonempty_concat(X)] recognizes a nonempty sequence of [X]s (each of
-    which is a list), and produces an OCaml list of their concatenation in
-    reverse order -- that is, the last element of the last list in the input text
-    appears first in the list.
-*)
-reversed_nonempty_concat(X):
-  x = X
-    { List.rev x }
-| xs = reversed_nonempty_concat(X) x = X
-    { List.rev_append x xs }
-
-(* [nonempty_concat(X)] recognizes a nonempty sequence of [X]s
-  (each of which is a list), and produces an OCaml list of their concatenation
-  in direct order -- that is, the first element of the first list in the input
-  text appears first in the list.
-*)
-%inline nonempty_concat(X):
-  xs = rev(reversed_nonempty_concat(X))
-    { xs }
-
-||||||| 121bedcfd2
-=======
 (* [reversed_nonempty_concat(X)] recognizes a nonempty sequence of [X]s (each of
    which is a list), and produces an OCaml list of their concatenation in
    reverse order -- that is, the last element of the last list in the input text
@@ -1425,7 +1330,6 @@ reversed_nonempty_concat(X):
   xs = rev(reversed_nonempty_concat(X))
     { xs }
 
->>>>>>> 5.2.0
 (* [reversed_separated_nonempty_llist(separator, X)] recognizes a nonempty list
    of [X]s, separated with [separator]s, and produces an OCaml list in reverse
    order -- that is, the last element in the input text appears first in this
@@ -2668,36 +2572,6 @@ class_type_declarations:
 
 /* Core expressions */
 
-<<<<<<< HEAD
-%inline or_function(EXPR):
-  | EXPR
-      { $1 }
-  | FUNCTION ext_attributes match_cases
-      { let loc = make_loc $sloc in
-        let cases = $3 in
-        mkfunction [] None (Pfunction_cases (cases, loc, []))
-          ~loc:$sloc ~attrs:$2
-      }
-;
-
-(* [fun_seq_expr] (and [fun_expr]) are legal expression bodies of a function.
-   [seq_expr] (and [expr]) are expressions that appear in other contexts
-   (e.g. subexpressions of the expression body of a function).
-   [fun_seq_expr] can't be a bare [function _ -> ...]. [seq_expr] can.
-   This distinction exists because [function _ -> ...] is parsed as a *function
-   cases* body of a function, not an expression body. This so functions can be
-   parsed with the intended arity.
-*)
-fun_seq_expr:
-  | fun_expr    %prec below_SEMI  { $1 }
-  | fun_expr SEMI                 { $1 }
-  | mkexp(fun_expr SEMI seq_expr
-||||||| 121bedcfd2
-seq_expr:
-  | expr        %prec below_SEMI  { $1 }
-  | expr SEMI                     { $1 }
-  | mkexp(expr SEMI seq_expr
-=======
 %inline or_function(EXPR):
   | EXPR
       { $1 }
@@ -2730,7 +2604,6 @@ fun_seq_expr:
   | fun_expr    %prec below_SEMI  { $1 }
   | fun_expr SEMI                 { $1 }
   | mkexp(fun_expr SEMI seq_expr
->>>>>>> 5.2.0
     { Pexp_sequence($1, $3) })
     { $1 }
   | fun_expr SEMI PERCENT attr_id seq_expr
@@ -2916,9 +2789,6 @@ fun_expr:
 %inline expr:
   | or_function(fun_expr) { $1 }
 ;
-%inline expr:
-  | or_function(fun_expr) { $1 }
-;
 %inline fun_expr_attrs:
   | LET MODULE ext_attributes mkrhs(module_name) module_binding_body IN seq_expr
       { Pexp_letmodule($4, $5, $7), $3 }
@@ -2928,23 +2798,6 @@ fun_expr:
       { let open_loc = make_loc ($startpos($2), $endpos($5)) in
         let od = Opn.mk $5 ~override:$3 ~loc:open_loc in
         Pexp_open(od, $7), $4 }
-<<<<<<< HEAD
-||||||| 121bedcfd2
-  | FUNCTION ext_attributes match_cases
-      { Pexp_function $3, $2 }
-  | FUN ext_attributes labeled_simple_pattern fun_def
-      { let (l,o,p) = $3 in
-        Pexp_fun(l, o, p, $4), $2 }
-  | FUN ext_attributes LPAREN TYPE lident_list RPAREN fun_def
-      { (mk_newtypes ~loc:$sloc $5 $7).pexp_desc, $2 }
-=======
-  /* Cf #5939: we used to accept (fun p when e0 -> e) */
-  | FUN ext_attributes fun_params preceded(COLON, atomic_type)?
-      MINUSGREATER fun_body
-      { let body_constraint = Option.map (fun x -> Pconstraint x) $4 in
-        mkfunction $3 body_constraint $6, $2
-      }
->>>>>>> 5.2.0
   | MATCH ext_attributes seq_expr WITH match_cases
       { Pexp_match($3, $5), $2 }
   | TRY ext_attributes seq_expr WITH match_cases
@@ -2985,27 +2838,9 @@ fun_expr:
   | mkrhs(constr_longident) simple_expr %prec below_HASH
       { mkexp ~loc:$sloc (Pexp_construct($1, Some $2)) }
   | name_tag simple_expr %prec below_HASH
-<<<<<<< HEAD
       { mkexp ~loc:$sloc (Pexp_variant($1, Some $2)) }
   | e1 = fun_expr op = op(infix_operator) e2 = expr
       { mkexp ~loc:$sloc (mkinfix e1 op e2) }
-||||||| 121bedcfd2
-      { Pexp_variant($1, Some $2) }
-  | e1 = expr op = op(infix_operator) e2 = expr
-      { mkinfix e1 op e2 }
-  | subtractive expr %prec prec_unary_minus
-      { mkuminus ~oploc:$loc($1) $1 $2 }
-  | additive expr %prec prec_unary_plus
-      { mkuplus ~oploc:$loc($1) $1 $2 }
-=======
-      { Pexp_variant($1, Some $2) }
-  | e1 = fun_expr op = op(infix_operator) e2 = expr
-      { mkinfix e1 op e2 }
-  | subtractive expr %prec prec_unary_minus
-      { mkuminus ~oploc:$loc($1) $1 $2 }
-  | additive expr %prec prec_unary_plus
-      { mkuplus ~oploc:$loc($1) $1 $2 }
->>>>>>> 5.2.0
 ;
 
 simple_expr:
@@ -3270,25 +3105,12 @@ let_binding_body_no_punning:
       { let v = $2 in (* PR#7344 *)
         let typ, modes1 = $3 in
         let t =
-<<<<<<< HEAD
           Option.map (function
           | N_ary.Pconstraint t ->
              Pvc_constraint { locally_abstract_univars = []; typ=t }
           | N_ary.Pcoerce (ground, coercion) -> Pvc_coercion { ground; coercion}
           ) typ
-||||||| 121bedcfd2
-          match $2 with
-            Some t, None -> t
-          | _, Some t -> t
-          | _ -> assert false
-=======
-          match $2 with
-            Pconstraint t ->
-             Pvc_constraint { locally_abstract_univars = []; typ=t }
-          | Pcoerce (ground, coercion) -> Pvc_coercion { ground; coercion}
->>>>>>> 5.2.0
         in
-<<<<<<< HEAD
         let modes = Mode.concat modes0 modes1 in
         let modes_ghost = Mode.ghostify modes in
         let exp = mkexp_with_modes ~ghost:true ~loc:$sloc modes_ghost $5 in
@@ -3332,32 +3154,7 @@ let_binding_body_no_punning:
         let exp = mkexp_with_modes ~ghost:true ~loc:$sloc modes_ghost exp in
         (ghpat ~loc (Ppat_constraint($1, poly)), exp, None, let_binding_mode_attrs modes)
        }
-||||||| 121bedcfd2
-        (v, $4, Some {locally_abstract_univars=[]; typ=t})
-        }
-  | let_ident COLON poly(core_type) EQUAL seq_expr
-    {
-      let t = ghtyp ~loc:($loc($3)) $3 in
-      ($1, $5, Some { locally_abstract_univars = []; typ = t})
-    }
-  | let_ident COLON TYPE lident_list DOT core_type EQUAL seq_expr
-      {  ($1, $8, Some { locally_abstract_univars = $4; typ = $6}) }
-=======
-        (v, $4, Some t)
-        }
-  | let_ident COLON poly(core_type) EQUAL seq_expr
-    {
-      let t = ghtyp ~loc:($loc($3)) $3 in
-      ($1, $5, Some (Pvc_constraint { locally_abstract_univars = []; typ=t }))
-    }
-  | let_ident COLON TYPE lident_list DOT core_type EQUAL seq_expr
-    { let constraint' =
-        Pvc_constraint { locally_abstract_univars=$4; typ = $6}
-      in
-      ($1, $8, Some constraint') }
->>>>>>> 5.2.0
   | pattern_no_exn EQUAL seq_expr
-<<<<<<< HEAD
       { ($1, $3, None, []) }
   | simple_pattern_not_ident pvc_modes EQUAL seq_expr
       {
@@ -3374,15 +3171,6 @@ let_binding_body_no_punning:
       { let modes_ghost = Mode.ghostify modes in
         ($2, mkexp_with_modes ~ghost:true ~loc:$sloc modes_ghost ($5 modes_ghost), None,
          let_binding_mode_attrs modes) }
-||||||| 121bedcfd2
-      { ($1, $3, None) }
-  | simple_pattern_not_ident COLON core_type EQUAL seq_expr
-      { ($1, $5, Some { locally_abstract_univars = []; typ=$3}) }
-=======
-      { ($1, $3, None) }
-  | simple_pattern_not_ident COLON core_type EQUAL seq_expr
-      { ($1, $5, Some(Pvc_constraint { locally_abstract_univars=[]; typ=$3 })) }
->>>>>>> 5.2.0
 ;
 let_binding_body:
   | let_binding_body_no_punning
@@ -3450,21 +3238,8 @@ letop_bindings:
         let and_ = {pbop_op; pbop_pat; pbop_exp; pbop_loc} in
         let_pat, let_exp, and_ :: rev_ands }
 ;
-<<<<<<< HEAD
 strict_binding_modes:
-||||||| 121bedcfd2
-fun_binding:
-    strict_binding
-      { $1 }
-  | type_constraint EQUAL seq_expr
-      { mkexp_constraint ~loc:$sloc $3 $1 }
-;
-strict_binding:
-=======
-strict_binding:
->>>>>>> 5.2.0
     EQUAL seq_expr
-<<<<<<< HEAD
       { fun _ -> $2 }
   | fun_params type_constraint? EQUAL fun_body
   (* CR zqian: The above [type_constraint] should be replaced by [constraint_]
@@ -3496,32 +3271,6 @@ fun_body:
       }
   | fun_seq_expr
       { N_ary.Pfunction_body $1 }
-||||||| 121bedcfd2
-      { $2 }
-  | labeled_simple_pattern fun_binding
-      { let (l, o, p) = $1 in ghexp ~loc:$sloc (Pexp_fun(l, o, p, $2)) }
-  | LPAREN TYPE lident_list RPAREN fun_binding
-      { mk_newtypes ~loc:$sloc $3 $5 }
-=======
-      { $2 }
-  | fun_params type_constraint? EQUAL fun_body
-      { ghexp ~loc:$sloc (mkfunction $1 $2 $4)
-      }
-;
-fun_body:
-  | FUNCTION ext_attributes match_cases
-      { let ext, attrs = $2 in
-        match ext with
-        | None -> Pfunction_cases ($3, make_loc $sloc, attrs)
-        | Some _ ->
-          (* function%foo extension nodes interrupt the arity *)
-            let cases = Pfunction_cases ($3, make_loc $sloc, []) in
-            Pfunction_body
-              (mkexp_attrs ~loc:$sloc (mkfunction [] None cases) $2)
-      }
-  | fun_seq_expr
-      { Pfunction_body $1 }
->>>>>>> 5.2.0
 ;
 %inline match_cases:
   xs = preceded_or_separated_nonempty_llist(BAR, match_case)
@@ -3535,7 +3284,6 @@ match_case:
   | pattern MINUSGREATER DOT
       { Exp.case $1 (Exp.unreachable ~loc:(make_loc $loc($3)) ()) }
 ;
-<<<<<<< HEAD
 fun_param_as_list:
   | LPAREN TYPE ty_params = newtypes RPAREN
       { (* We desugar (type a b c) to (type a) (type b) (type c).
@@ -3565,48 +3313,7 @@ fun_param_as_list:
             pparam_desc = Pparam_val (a, b, c)
           }
         ]
-||||||| 121bedcfd2
-fun_def:
-    MINUSGREATER seq_expr
-      { $2 }
-  | mkexp(COLON atomic_type MINUSGREATER seq_expr
-      { Pexp_constraint ($4, $2) })
-      { $1 }
-/* Cf #5939: we used to accept (fun p when e0 -> e) */
-  | labeled_simple_pattern fun_def
-      {
-       let (l,o,p) = $1 in
-       ghexp ~loc:$sloc (Pexp_fun(l, o, p, $2))
-=======
-fun_param_as_list:
-  | LPAREN TYPE ty_params = lident_list RPAREN
-      { (* We desugar (type a b c) to (type a) (type b) (type c).
-           If we do this desugaring, the loc for each parameter is a ghost.
-        *)
-        let loc =
-          match ty_params with
-          | [] -> assert false (* lident_list is non-empty *)
-          | [_] -> make_loc $sloc
-          | _ :: _ :: _ -> ghost_loc $sloc
-        in
-        List.map
-          (fun x -> { pparam_loc = loc; pparam_desc = Pparam_newtype x })
-          ty_params
->>>>>>> 5.2.0
       }
-<<<<<<< HEAD
-||||||| 121bedcfd2
-  | LPAREN TYPE lident_list RPAREN fun_def
-      { mk_newtypes ~loc:$sloc $3 $5 }
-=======
-  | labeled_simple_pattern
-      { let a, b, c = $1 in
-        [ { pparam_loc = make_loc $sloc; pparam_desc = Pparam_val (a, b, c) } ]
-      }
-;
-fun_params:
-  | nonempty_concat(fun_param_as_list) { $1 }
->>>>>>> 5.2.0
 ;
 fun_params:
   | nonempty_concat(fun_param_as_list) { $1 }
@@ -3732,19 +3439,9 @@ record_expr_content:
     { es }
 ;
 type_constraint:
-<<<<<<< HEAD
     COLON core_type                             { N_ary.Pconstraint $2 }
   | COLON core_type COLONGREATER core_type      { N_ary.Pcoerce (Some $2, $4) }
   | COLONGREATER core_type                      { N_ary.Pcoerce (None, $2) }
-||||||| 121bedcfd2
-    COLON core_type                             { (Some $2, None) }
-  | COLON core_type COLONGREATER core_type      { (Some $2, Some $4) }
-  | COLONGREATER core_type                      { (None, Some $2) }
-=======
-    COLON core_type                             { Pconstraint $2 }
-  | COLON core_type COLONGREATER core_type      { Pcoerce (Some $2, $4) }
-  | COLONGREATER core_type                      { Pcoerce (None, $2) }
->>>>>>> 5.2.0
   | COLON error                                 { syntax_error() }
   | COLONGREATER error                          { syntax_error() }
 ;
@@ -4504,21 +4201,11 @@ with_type_binder:
 
 /* Polymorphic types */
 
-<<<<<<< HEAD
 %inline typevar: (* : string with_loc * jkind_annotation option *)
     QUOTE mkrhs(ident)
       { ($2, None) }
     | LPAREN QUOTE tyvar=mkrhs(ident) COLON jkind=jkind_annotation RPAREN
       { (tyvar, Some jkind) }
-||||||| 121bedcfd2
-%inline typevar:
-  QUOTE mkrhs(ident)
-    { $2 }
-=======
-%inline typevar:
-  QUOTE ident
-    { mkrhs $2 $sloc }
->>>>>>> 5.2.0
 ;
 %inline typevar_list:
   (* : (string with_loc * jkind_annotation option) list *)
@@ -4814,42 +4501,6 @@ tuple_type:
    - applications of type constructors:   int, int list, int option list
    - variant types:                       [`A]
  *)
-<<<<<<< HEAD
-atomic_type:
-  | LPAREN core_type RPAREN
-      { $2 }
-  | LPAREN MODULE ext_attributes package_type RPAREN
-      { wrap_typ_attrs ~loc:$sloc (reloc_typ ~loc:$sloc $4) $3 }
-  | mktyp( /* begin mktyp group */
-      QUOTE ident
-        { Ptyp_var $2 }
-    | UNDERSCORE
-        { Ptyp_any }
-    | tys = actual_type_parameters
-      tid = mkrhs(type_unboxed_longident)
-        { unboxed_type $loc(tid) tid.txt tys }
-    | tys = actual_type_parameters
-      tid = mkrhs(type_longident)
-        { Ptyp_constr(tid, tys) }
-    | LESS meth_list GREATER
-        { let (f, c) = $2 in Ptyp_object (f, c) }
-||||||| 121bedcfd2
-atomic_type:
-  | LPAREN core_type RPAREN
-      { $2 }
-  | LPAREN MODULE ext_attributes package_type RPAREN
-      { wrap_typ_attrs ~loc:$sloc (reloc_typ ~loc:$sloc $4) $3 }
-  | mktyp( /* begin mktyp group */
-      QUOTE ident
-        { Ptyp_var $2 }
-    | UNDERSCORE
-        { Ptyp_any }
-    | tys = actual_type_parameters
-      tid = mkrhs(type_longident)
-        { Ptyp_constr(tid, tys) }
-    | LESS meth_list GREATER
-        { let (f, c) = $2 in Ptyp_object (f, c) }
-=======
 
 
 (*
@@ -4904,7 +4555,6 @@ object_type:
   | mktyp(
       LESS meth_list = meth_list GREATER
         { let (f, c) = meth_list in Ptyp_object (f, c) }
->>>>>>> 5.2.0
     | LESS GREATER
         { Ptyp_object ([], Closed) }
   )
@@ -4931,6 +4581,9 @@ atomic_type:
       { type_ }
   | mktyp( /* begin mktyp group */
       tys = actual_type_parameters
+      tid = mkrhs(type_unboxed_longident)
+        { unboxed_type $loc(tid) tid.txt tys }
+    | tys = actual_type_parameters
       tid = mkrhs(type_longident)
         { Ptyp_constr (tid, tys) }
     | tys = actual_type_parameters
@@ -4969,18 +4622,10 @@ atomic_type:
   | /* empty */
       { [] }
   | ty = atomic_type
-<<<<<<< HEAD
-      { [ty] }
+      { [ ty ] }
   | LPAREN
     tys = separated_nontrivial_llist(COMMA, one_type_parameter_of_several)
     RPAREN
-||||||| 121bedcfd2
-      { [ty] }
-  | LPAREN tys = separated_nontrivial_llist(COMMA, core_type) RPAREN
-=======
-      { [ ty ] }
-  | LPAREN tys = separated_nontrivial_llist(COMMA, core_type) RPAREN
->>>>>>> 5.2.0
       { tys }
 
 (* Layout annotations on type expressions typically require parens, as in [('a :

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -269,19 +269,34 @@ let rec mktailpat nilloc = let open Location in function
 let mkstrexp e attrs =
   { pstr_desc = Pstr_eval (e, attrs); pstr_loc = e.pexp_loc }
 
-let mkexp_desc_type_constraint e t =
+<<<<<<< HEAD
+let mkexp_type_constraint ?(ghost=false) ~loc e t =
+  let desc =
+    match t with
+  | N_ary.Pconstraint t -> Pexp_constraint(e, t)
+  | N_ary.Pcoerce(t1, t2)  -> Pexp_coerce(e, t1, t2)
+  in
+  if ghost then ghexp ~loc desc
+  else mkexp ~loc desc
+||||||| 121bedcfd2
+let mkexp_constraint ~loc e (t1, t2) =
+  match t1, t2 with
+  | Some t, None -> mkexp ~loc (Pexp_constraint(e, t))
+  | _, Some t -> mkexp ~loc (Pexp_coerce(e, t1, t))
+  | None, None -> assert false
+=======
+let mkexp_desc_constraint e t =
   match t with
   | Pconstraint t -> Pexp_constraint(e, t)
   | Pcoerce(t1, t2)  -> Pexp_coerce(e, t1, t2)
 
-let mkexp_type_constraint ?(ghost=false) ~loc e t =
-  let desc = mkexp_desc_type_constraint e t in
-  if ghost then ghexp ~loc desc
-  else mkexp ~loc desc
+let mkexp_constraint ~loc e t =
+  mkexp ~loc (mkexp_desc_constraint e t)
+>>>>>>> 5.2.0
 
 let mkexp_opt_type_constraint ~loc e = function
   | None -> e
-  | Some c -> mkexp_constraint ~loc e c
+  | Some c -> mkexp_type_constraint ~loc e c
 
 let mkpat_opt_constraint ~loc p = function
   | None -> p
@@ -556,11 +571,6 @@ let pat_of_label lbl =
 
 let mk_newtypes ~loc newtypes exp =
   let mk_one (name, jkind) exp =
-    (* Mints a ghost location that approximates the newtype's "extent" as
-    being from the start of the newtype param until the end of the
-    function body.
-     *)
-    let loc = (newtype_loc.Location.loc_start, body.pexp_loc.loc_end) in
     match jkind with
     | None -> ghexp ~loc (Pexp_newtype (name, exp))
     | Some jkind ->
@@ -751,6 +761,7 @@ let class_of_let_bindings ~loc lbs body =
     assert (lbs.lbs_extension = None);
     mkclass ~loc (Pcl_let (lbs.lbs_rec, List.rev bindings, body))
 
+<<<<<<< HEAD
 (* If all the parameters are [Pparam_newtype x], then return [Some xs] where
    [xs] is the corresponding list of values [x]. This function is optimized for
    the common case, where a list of parameters contains at least one value
@@ -809,6 +820,67 @@ let mkfunction ~loc ~attrs params body_constraint body =
             attrs
     end
 
+||||||| 121bedcfd2
+=======
+(* If all the parameters are [Pparam_newtype x], then return [Some xs] where
+   [xs] is the corresponding list of values [x]. This function is optimized for
+   the common case, where a list of parameters contains at least one value
+   parameter.
+*)
+let all_params_as_newtypes =
+  let is_newtype { pparam_desc; _ } =
+    match pparam_desc with
+    | Pparam_newtype _ -> true
+    | Pparam_val _ -> false
+  in
+  let as_newtype { pparam_desc; pparam_loc } =
+    match pparam_desc with
+    | Pparam_newtype x -> Some (x, pparam_loc)
+    | Pparam_val _ -> None
+  in
+  fun params ->
+    if List.for_all is_newtype params
+    then Some (List.filter_map as_newtype params)
+    else None
+
+(* Given a construct [fun (type a b c) : t -> e], we construct
+   [Pexp_newtype(a, Pexp_newtype(b, Pexp_newtype(c, Pexp_constraint(e, t))))]
+   rather than a [Pexp_function].
+*)
+let mkghost_newtype_function_body newtypes body_constraint body =
+  let wrapped_body =
+    match body_constraint with
+    | None -> body
+    | Some body_constraint ->
+        let loc = { body.pexp_loc with loc_ghost = true } in
+        Exp.mk (mkexp_desc_constraint body body_constraint) ~loc
+  in
+  let expr =
+    List.fold_right
+      (fun (newtype, newtype_loc) e ->
+         (* Mints a ghost location that approximates the newtype's "extent" as
+            being from the start of the newtype param until the end of the
+            function body.
+         *)
+         let loc = (newtype_loc.Location.loc_start, body.pexp_loc.loc_end) in
+         ghexp (Pexp_newtype (newtype, e)) ~loc)
+      newtypes
+      wrapped_body
+  in
+  expr.pexp_desc
+
+let mkfunction params body_constraint body =
+  match body with
+  | Pfunction_cases _ -> Pexp_function (params, body_constraint, body)
+  | Pfunction_body body_exp ->
+    (* If all the params are newtypes, then we don't create a function node;
+       we create nested newtype nodes. *)
+      match all_params_as_newtypes params with
+      | None -> Pexp_function (params, body_constraint, body)
+      | Some newtypes ->
+          mkghost_newtype_function_body newtypes body_constraint body_exp
+
+>>>>>>> 5.2.0
 (* Alternatively, we could keep the generic module type in the Parsetree
    and extract the package type during type-checking. In that case,
    the assertions below should be turned into explicit checks. *)
@@ -1309,6 +1381,29 @@ reversed_nonempty_llist(X):
   xs = rev(reversed_nonempty_llist(X))
     { xs }
 
+<<<<<<< HEAD
+(* [reversed_nonempty_concat(X)] recognizes a nonempty sequence of [X]s (each of
+    which is a list), and produces an OCaml list of their concatenation in
+    reverse order -- that is, the last element of the last list in the input text
+    appears first in the list.
+*)
+reversed_nonempty_concat(X):
+  x = X
+    { List.rev x }
+| xs = reversed_nonempty_concat(X) x = X
+    { List.rev_append x xs }
+
+(* [nonempty_concat(X)] recognizes a nonempty sequence of [X]s
+  (each of which is a list), and produces an OCaml list of their concatenation
+  in direct order -- that is, the first element of the first list in the input
+  text appears first in the list.
+*)
+%inline nonempty_concat(X):
+  xs = rev(reversed_nonempty_concat(X))
+    { xs }
+
+||||||| 121bedcfd2
+=======
 (* [reversed_nonempty_concat(X)] recognizes a nonempty sequence of [X]s (each of
    which is a list), and produces an OCaml list of their concatenation in
    reverse order -- that is, the last element of the last list in the input text
@@ -1330,6 +1425,7 @@ reversed_nonempty_concat(X):
   xs = rev(reversed_nonempty_concat(X))
     { xs }
 
+>>>>>>> 5.2.0
 (* [reversed_separated_nonempty_llist(separator, X)] recognizes a nonempty list
    of [X]s, separated with [separator]s, and produces an OCaml list in reverse
    order -- that is, the last element in the input text appears first in this
@@ -2572,6 +2668,36 @@ class_type_declarations:
 
 /* Core expressions */
 
+<<<<<<< HEAD
+%inline or_function(EXPR):
+  | EXPR
+      { $1 }
+  | FUNCTION ext_attributes match_cases
+      { let loc = make_loc $sloc in
+        let cases = $3 in
+        mkfunction [] None (Pfunction_cases (cases, loc, []))
+          ~loc:$sloc ~attrs:$2
+      }
+;
+
+(* [fun_seq_expr] (and [fun_expr]) are legal expression bodies of a function.
+   [seq_expr] (and [expr]) are expressions that appear in other contexts
+   (e.g. subexpressions of the expression body of a function).
+   [fun_seq_expr] can't be a bare [function _ -> ...]. [seq_expr] can.
+   This distinction exists because [function _ -> ...] is parsed as a *function
+   cases* body of a function, not an expression body. This so functions can be
+   parsed with the intended arity.
+*)
+fun_seq_expr:
+  | fun_expr    %prec below_SEMI  { $1 }
+  | fun_expr SEMI                 { $1 }
+  | mkexp(fun_expr SEMI seq_expr
+||||||| 121bedcfd2
+seq_expr:
+  | expr        %prec below_SEMI  { $1 }
+  | expr SEMI                     { $1 }
+  | mkexp(expr SEMI seq_expr
+=======
 %inline or_function(EXPR):
   | EXPR
       { $1 }
@@ -2604,6 +2730,7 @@ fun_seq_expr:
   | fun_expr    %prec below_SEMI  { $1 }
   | fun_expr SEMI                 { $1 }
   | mkexp(fun_expr SEMI seq_expr
+>>>>>>> 5.2.0
     { Pexp_sequence($1, $3) })
     { $1 }
   | fun_expr SEMI PERCENT attr_id seq_expr
@@ -2789,6 +2916,9 @@ fun_expr:
 %inline expr:
   | or_function(fun_expr) { $1 }
 ;
+%inline expr:
+  | or_function(fun_expr) { $1 }
+;
 %inline fun_expr_attrs:
   | LET MODULE ext_attributes mkrhs(module_name) module_binding_body IN seq_expr
       { Pexp_letmodule($4, $5, $7), $3 }
@@ -2798,6 +2928,23 @@ fun_expr:
       { let open_loc = make_loc ($startpos($2), $endpos($5)) in
         let od = Opn.mk $5 ~override:$3 ~loc:open_loc in
         Pexp_open(od, $7), $4 }
+<<<<<<< HEAD
+||||||| 121bedcfd2
+  | FUNCTION ext_attributes match_cases
+      { Pexp_function $3, $2 }
+  | FUN ext_attributes labeled_simple_pattern fun_def
+      { let (l,o,p) = $3 in
+        Pexp_fun(l, o, p, $4), $2 }
+  | FUN ext_attributes LPAREN TYPE lident_list RPAREN fun_def
+      { (mk_newtypes ~loc:$sloc $5 $7).pexp_desc, $2 }
+=======
+  /* Cf #5939: we used to accept (fun p when e0 -> e) */
+  | FUN ext_attributes fun_params preceded(COLON, atomic_type)?
+      MINUSGREATER fun_body
+      { let body_constraint = Option.map (fun x -> Pconstraint x) $4 in
+        mkfunction $3 body_constraint $6, $2
+      }
+>>>>>>> 5.2.0
   | MATCH ext_attributes seq_expr WITH match_cases
       { Pexp_match($3, $5), $2 }
   | TRY ext_attributes seq_expr WITH match_cases
@@ -2838,9 +2985,27 @@ fun_expr:
   | mkrhs(constr_longident) simple_expr %prec below_HASH
       { mkexp ~loc:$sloc (Pexp_construct($1, Some $2)) }
   | name_tag simple_expr %prec below_HASH
+<<<<<<< HEAD
       { mkexp ~loc:$sloc (Pexp_variant($1, Some $2)) }
   | e1 = fun_expr op = op(infix_operator) e2 = expr
       { mkexp ~loc:$sloc (mkinfix e1 op e2) }
+||||||| 121bedcfd2
+      { Pexp_variant($1, Some $2) }
+  | e1 = expr op = op(infix_operator) e2 = expr
+      { mkinfix e1 op e2 }
+  | subtractive expr %prec prec_unary_minus
+      { mkuminus ~oploc:$loc($1) $1 $2 }
+  | additive expr %prec prec_unary_plus
+      { mkuplus ~oploc:$loc($1) $1 $2 }
+=======
+      { Pexp_variant($1, Some $2) }
+  | e1 = fun_expr op = op(infix_operator) e2 = expr
+      { mkinfix e1 op e2 }
+  | subtractive expr %prec prec_unary_minus
+      { mkuminus ~oploc:$loc($1) $1 $2 }
+  | additive expr %prec prec_unary_plus
+      { mkuplus ~oploc:$loc($1) $1 $2 }
+>>>>>>> 5.2.0
 ;
 
 simple_expr:
@@ -3105,12 +3270,25 @@ let_binding_body_no_punning:
       { let v = $2 in (* PR#7344 *)
         let typ, modes1 = $3 in
         let t =
+<<<<<<< HEAD
           Option.map (function
           | N_ary.Pconstraint t ->
              Pvc_constraint { locally_abstract_univars = []; typ=t }
           | N_ary.Pcoerce (ground, coercion) -> Pvc_coercion { ground; coercion}
           ) typ
+||||||| 121bedcfd2
+          match $2 with
+            Some t, None -> t
+          | _, Some t -> t
+          | _ -> assert false
+=======
+          match $2 with
+            Pconstraint t ->
+             Pvc_constraint { locally_abstract_univars = []; typ=t }
+          | Pcoerce (ground, coercion) -> Pvc_coercion { ground; coercion}
+>>>>>>> 5.2.0
         in
+<<<<<<< HEAD
         let modes = Mode.concat modes0 modes1 in
         let modes_ghost = Mode.ghostify modes in
         let exp = mkexp_with_modes ~ghost:true ~loc:$sloc modes_ghost $5 in
@@ -3154,7 +3332,32 @@ let_binding_body_no_punning:
         let exp = mkexp_with_modes ~ghost:true ~loc:$sloc modes_ghost exp in
         (ghpat ~loc (Ppat_constraint($1, poly)), exp, None, let_binding_mode_attrs modes)
        }
+||||||| 121bedcfd2
+        (v, $4, Some {locally_abstract_univars=[]; typ=t})
+        }
+  | let_ident COLON poly(core_type) EQUAL seq_expr
+    {
+      let t = ghtyp ~loc:($loc($3)) $3 in
+      ($1, $5, Some { locally_abstract_univars = []; typ = t})
+    }
+  | let_ident COLON TYPE lident_list DOT core_type EQUAL seq_expr
+      {  ($1, $8, Some { locally_abstract_univars = $4; typ = $6}) }
+=======
+        (v, $4, Some t)
+        }
+  | let_ident COLON poly(core_type) EQUAL seq_expr
+    {
+      let t = ghtyp ~loc:($loc($3)) $3 in
+      ($1, $5, Some (Pvc_constraint { locally_abstract_univars = []; typ=t }))
+    }
+  | let_ident COLON TYPE lident_list DOT core_type EQUAL seq_expr
+    { let constraint' =
+        Pvc_constraint { locally_abstract_univars=$4; typ = $6}
+      in
+      ($1, $8, Some constraint') }
+>>>>>>> 5.2.0
   | pattern_no_exn EQUAL seq_expr
+<<<<<<< HEAD
       { ($1, $3, None, []) }
   | simple_pattern_not_ident pvc_modes EQUAL seq_expr
       {
@@ -3171,6 +3374,15 @@ let_binding_body_no_punning:
       { let modes_ghost = Mode.ghostify modes in
         ($2, mkexp_with_modes ~ghost:true ~loc:$sloc modes_ghost ($5 modes_ghost), None,
          let_binding_mode_attrs modes) }
+||||||| 121bedcfd2
+      { ($1, $3, None) }
+  | simple_pattern_not_ident COLON core_type EQUAL seq_expr
+      { ($1, $5, Some { locally_abstract_univars = []; typ=$3}) }
+=======
+      { ($1, $3, None) }
+  | simple_pattern_not_ident COLON core_type EQUAL seq_expr
+      { ($1, $5, Some(Pvc_constraint { locally_abstract_univars=[]; typ=$3 })) }
+>>>>>>> 5.2.0
 ;
 let_binding_body:
   | let_binding_body_no_punning
@@ -3238,8 +3450,21 @@ letop_bindings:
         let and_ = {pbop_op; pbop_pat; pbop_exp; pbop_loc} in
         let_pat, let_exp, and_ :: rev_ands }
 ;
+<<<<<<< HEAD
 strict_binding_modes:
+||||||| 121bedcfd2
+fun_binding:
+    strict_binding
+      { $1 }
+  | type_constraint EQUAL seq_expr
+      { mkexp_constraint ~loc:$sloc $3 $1 }
+;
+strict_binding:
+=======
+strict_binding:
+>>>>>>> 5.2.0
     EQUAL seq_expr
+<<<<<<< HEAD
       { fun _ -> $2 }
   | fun_params type_constraint? EQUAL fun_body
   (* CR zqian: The above [type_constraint] should be replaced by [constraint_]
@@ -3271,6 +3496,32 @@ fun_body:
       }
   | fun_seq_expr
       { N_ary.Pfunction_body $1 }
+||||||| 121bedcfd2
+      { $2 }
+  | labeled_simple_pattern fun_binding
+      { let (l, o, p) = $1 in ghexp ~loc:$sloc (Pexp_fun(l, o, p, $2)) }
+  | LPAREN TYPE lident_list RPAREN fun_binding
+      { mk_newtypes ~loc:$sloc $3 $5 }
+=======
+      { $2 }
+  | fun_params type_constraint? EQUAL fun_body
+      { ghexp ~loc:$sloc (mkfunction $1 $2 $4)
+      }
+;
+fun_body:
+  | FUNCTION ext_attributes match_cases
+      { let ext, attrs = $2 in
+        match ext with
+        | None -> Pfunction_cases ($3, make_loc $sloc, attrs)
+        | Some _ ->
+          (* function%foo extension nodes interrupt the arity *)
+            let cases = Pfunction_cases ($3, make_loc $sloc, []) in
+            Pfunction_body
+              (mkexp_attrs ~loc:$sloc (mkfunction [] None cases) $2)
+      }
+  | fun_seq_expr
+      { Pfunction_body $1 }
+>>>>>>> 5.2.0
 ;
 %inline match_cases:
   xs = preceded_or_separated_nonempty_llist(BAR, match_case)
@@ -3284,6 +3535,7 @@ match_case:
   | pattern MINUSGREATER DOT
       { Exp.case $1 (Exp.unreachable ~loc:(make_loc $loc($3)) ()) }
 ;
+<<<<<<< HEAD
 fun_param_as_list:
   | LPAREN TYPE ty_params = newtypes RPAREN
       { (* We desugar (type a b c) to (type a) (type b) (type c).
@@ -3313,7 +3565,48 @@ fun_param_as_list:
             pparam_desc = Pparam_val (a, b, c)
           }
         ]
+||||||| 121bedcfd2
+fun_def:
+    MINUSGREATER seq_expr
+      { $2 }
+  | mkexp(COLON atomic_type MINUSGREATER seq_expr
+      { Pexp_constraint ($4, $2) })
+      { $1 }
+/* Cf #5939: we used to accept (fun p when e0 -> e) */
+  | labeled_simple_pattern fun_def
+      {
+       let (l,o,p) = $1 in
+       ghexp ~loc:$sloc (Pexp_fun(l, o, p, $2))
+=======
+fun_param_as_list:
+  | LPAREN TYPE ty_params = lident_list RPAREN
+      { (* We desugar (type a b c) to (type a) (type b) (type c).
+           If we do this desugaring, the loc for each parameter is a ghost.
+        *)
+        let loc =
+          match ty_params with
+          | [] -> assert false (* lident_list is non-empty *)
+          | [_] -> make_loc $sloc
+          | _ :: _ :: _ -> ghost_loc $sloc
+        in
+        List.map
+          (fun x -> { pparam_loc = loc; pparam_desc = Pparam_newtype x })
+          ty_params
+>>>>>>> 5.2.0
       }
+<<<<<<< HEAD
+||||||| 121bedcfd2
+  | LPAREN TYPE lident_list RPAREN fun_def
+      { mk_newtypes ~loc:$sloc $3 $5 }
+=======
+  | labeled_simple_pattern
+      { let a, b, c = $1 in
+        [ { pparam_loc = make_loc $sloc; pparam_desc = Pparam_val (a, b, c) } ]
+      }
+;
+fun_params:
+  | nonempty_concat(fun_param_as_list) { $1 }
+>>>>>>> 5.2.0
 ;
 fun_params:
   | nonempty_concat(fun_param_as_list) { $1 }
@@ -3439,9 +3732,19 @@ record_expr_content:
     { es }
 ;
 type_constraint:
+<<<<<<< HEAD
     COLON core_type                             { N_ary.Pconstraint $2 }
   | COLON core_type COLONGREATER core_type      { N_ary.Pcoerce (Some $2, $4) }
   | COLONGREATER core_type                      { N_ary.Pcoerce (None, $2) }
+||||||| 121bedcfd2
+    COLON core_type                             { (Some $2, None) }
+  | COLON core_type COLONGREATER core_type      { (Some $2, Some $4) }
+  | COLONGREATER core_type                      { (None, Some $2) }
+=======
+    COLON core_type                             { Pconstraint $2 }
+  | COLON core_type COLONGREATER core_type      { Pcoerce (Some $2, $4) }
+  | COLONGREATER core_type                      { Pcoerce (None, $2) }
+>>>>>>> 5.2.0
   | COLON error                                 { syntax_error() }
   | COLONGREATER error                          { syntax_error() }
 ;
@@ -4201,11 +4504,21 @@ with_type_binder:
 
 /* Polymorphic types */
 
+<<<<<<< HEAD
 %inline typevar: (* : string with_loc * jkind_annotation option *)
     QUOTE mkrhs(ident)
       { ($2, None) }
     | LPAREN QUOTE tyvar=mkrhs(ident) COLON jkind=jkind_annotation RPAREN
       { (tyvar, Some jkind) }
+||||||| 121bedcfd2
+%inline typevar:
+  QUOTE mkrhs(ident)
+    { $2 }
+=======
+%inline typevar:
+  QUOTE ident
+    { mkrhs $2 $sloc }
+>>>>>>> 5.2.0
 ;
 %inline typevar_list:
   (* : (string with_loc * jkind_annotation option) list *)
@@ -4501,6 +4814,42 @@ tuple_type:
    - applications of type constructors:   int, int list, int option list
    - variant types:                       [`A]
  *)
+<<<<<<< HEAD
+atomic_type:
+  | LPAREN core_type RPAREN
+      { $2 }
+  | LPAREN MODULE ext_attributes package_type RPAREN
+      { wrap_typ_attrs ~loc:$sloc (reloc_typ ~loc:$sloc $4) $3 }
+  | mktyp( /* begin mktyp group */
+      QUOTE ident
+        { Ptyp_var $2 }
+    | UNDERSCORE
+        { Ptyp_any }
+    | tys = actual_type_parameters
+      tid = mkrhs(type_unboxed_longident)
+        { unboxed_type $loc(tid) tid.txt tys }
+    | tys = actual_type_parameters
+      tid = mkrhs(type_longident)
+        { Ptyp_constr(tid, tys) }
+    | LESS meth_list GREATER
+        { let (f, c) = $2 in Ptyp_object (f, c) }
+||||||| 121bedcfd2
+atomic_type:
+  | LPAREN core_type RPAREN
+      { $2 }
+  | LPAREN MODULE ext_attributes package_type RPAREN
+      { wrap_typ_attrs ~loc:$sloc (reloc_typ ~loc:$sloc $4) $3 }
+  | mktyp( /* begin mktyp group */
+      QUOTE ident
+        { Ptyp_var $2 }
+    | UNDERSCORE
+        { Ptyp_any }
+    | tys = actual_type_parameters
+      tid = mkrhs(type_longident)
+        { Ptyp_constr(tid, tys) }
+    | LESS meth_list GREATER
+        { let (f, c) = $2 in Ptyp_object (f, c) }
+=======
 
 
 (*
@@ -4555,6 +4904,7 @@ object_type:
   | mktyp(
       LESS meth_list = meth_list GREATER
         { let (f, c) = meth_list in Ptyp_object (f, c) }
+>>>>>>> 5.2.0
     | LESS GREATER
         { Ptyp_object ([], Closed) }
   )
@@ -4581,9 +4931,6 @@ atomic_type:
       { type_ }
   | mktyp( /* begin mktyp group */
       tys = actual_type_parameters
-      tid = mkrhs(type_unboxed_longident)
-        { unboxed_type $loc(tid) tid.txt tys }
-    | tys = actual_type_parameters
       tid = mkrhs(type_longident)
         { Ptyp_constr (tid, tys) }
     | tys = actual_type_parameters
@@ -4622,10 +4969,18 @@ atomic_type:
   | /* empty */
       { [] }
   | ty = atomic_type
-      { [ ty ] }
+<<<<<<< HEAD
+      { [ty] }
   | LPAREN
     tys = separated_nontrivial_llist(COMMA, one_type_parameter_of_several)
     RPAREN
+||||||| 121bedcfd2
+      { [ty] }
+  | LPAREN tys = separated_nontrivial_llist(COMMA, core_type) RPAREN
+=======
+      { [ ty ] }
+  | LPAREN tys = separated_nontrivial_llist(COMMA, core_type) RPAREN
+>>>>>>> 5.2.0
       { tys }
 
 (* Layout annotations on type expressions typically require parens, as in [('a :

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -318,39 +318,6 @@ and expression_desc =
             - [let rec P1 = E1 and ... and Pn = EN in E]
                when [flag] is {{!Asttypes.rec_flag.Recursive}[Recursive]}.
          *)
-<<<<<<< HEAD
-  | Pexp_function of case list  (** [function P1 -> E1 | ... | Pn -> En] *)
-  | Pexp_fun of arg_label * expression option * pattern * expression
-      (** [Pexp_fun(lbl, exp0, P, E1)] represents:
-            - [fun P -> E1]
-                      when [lbl] is {{!arg_label.Nolabel}[Nolabel]}
-                       and [exp0] is [None]
-            - [fun ~l:P -> E1]
-                      when [lbl] is {{!arg_label.Labelled}[Labelled l]}
-                       and [exp0] is [None]
-            - [fun ?l:P -> E1]
-                      when [lbl] is {{!arg_label.Optional}[Optional l]}
-                       and [exp0] is [None]
-            - [fun ?l:(P = E0) -> E1]
-                      when [lbl] is {{!arg_label.Optional}[Optional l]}
-                       and [exp0] is [Some E0]
-||||||| 121bedcfd2
-  | Pexp_function of case list  (** [function P1 -> E1 | ... | Pn -> En] *)
-  | Pexp_fun of arg_label * expression option * pattern * expression
-      (** [Pexp_fun(lbl, exp0, P, E1)] represents:
-            - [fun P -> E1]
-                      when [lbl] is {{!Asttypes.arg_label.Nolabel}[Nolabel]}
-                       and [exp0] is [None]
-            - [fun ~l:P -> E1]
-                      when [lbl] is {{!Asttypes.arg_label.Labelled}[Labelled l]}
-                       and [exp0] is [None]
-            - [fun ?l:P -> E1]
-                      when [lbl] is {{!Asttypes.arg_label.Optional}[Optional l]}
-                       and [exp0] is [None]
-            - [fun ?l:(P = E0) -> E1]
-                      when [lbl] is {{!Asttypes.arg_label.Optional}[Optional l]}
-                       and [exp0] is [Some E0]
-=======
   | Pexp_function of
       function_param list * type_constraint option * function_body
   (** [Pexp_function ([P1; ...; Pn], C, body)] represents any construct
@@ -359,37 +326,12 @@ and expression_desc =
         when [body = Pfunction_body E]
       - [fun P1 ... Pn -> function p1 -> e1 | ... | pm -> em]
         when [body = Pfunction_cases [ p1 -> e1; ...; pm -> em ]]
->>>>>>> 5.2.0
-
-<<<<<<< HEAD
-           Notes:
-           - If [E0] is provided, only
-             {{!arg_label.Optional}[Optional]} is allowed.
-           - [fun P1 P2 .. Pn -> E1] is represented as nested
-             {{!expression_desc.Pexp_fun}[Pexp_fun]}.
-           - [let f P = E] is represented using
-             {{!expression_desc.Pexp_fun}[Pexp_fun]}.
-           - While Position arguments ([lbl:[%call_pos] -> ...]) are parsed as
-             {{!Asttypes.arg_label.Labelled}[Labelled l]}, they are converted to
-             {{!Types.arg_label.Position}[Position l]} arguments for type-checking.
-         *)
-||||||| 121bedcfd2
-           Notes:
-           - If [E0] is provided, only
-             {{!Asttypes.arg_label.Optional}[Optional]} is allowed.
-           - [fun P1 P2 .. Pn -> E1] is represented as nested
-             {{!expression_desc.Pexp_fun}[Pexp_fun]}.
-           - [let f P = E] is represented using
-             {{!expression_desc.Pexp_fun}[Pexp_fun]}.
-         *)
-=======
       [C] represents a type constraint or coercion placed immediately before the
       arrow, e.g. [fun P1 ... Pn : ty -> ...] when [C = Some (Pconstraint ty)].
 
       A function must have parameters. [Pexp_function (params, _, body)] must
       have non-empty [params] or a [Pfunction_cases _] body.
   *)
->>>>>>> 5.2.0
   | Pexp_apply of expression * (arg_label * expression) list
       (** [Pexp_apply(E0, [(l1, E1) ; ... ; (ln, En)])]
             represents [E0 ~l1:E1 ... ~ln:En]
@@ -514,20 +456,20 @@ and function_param_desc =
   | Pparam_val of arg_label * expression option * pattern
   (** [Pparam_val (lbl, exp0, P)] represents the parameter:
       - [P]
-        when [lbl] is {{!Asttypes.arg_label.Nolabel}[Nolabel]}
+        when [lbl] is {{!arg_label.Nolabel}[Nolabel]}
         and [exp0] is [None]
       - [~l:P]
-        when [lbl] is {{!Asttypes.arg_label.Labelled}[Labelled l]}
+        when [lbl] is {{!arg_label.Labelled}[Labelled l]}
         and [exp0] is [None]
       - [?l:P]
-        when [lbl] is {{!Asttypes.arg_label.Optional}[Optional l]}
+        when [lbl] is {{!arg_label.Optional}[Optional l]}
         and [exp0] is [None]
       - [?l:(P = E0)]
-        when [lbl] is {{!Asttypes.arg_label.Optional}[Optional l]}
+        when [lbl] is {{!arg_label.Optional}[Optional l]}
         and [exp0] is [Some E0]
 
       Note: If [E0] is provided, only
-      {{!Asttypes.arg_label.Optional}[Optional]} is allowed.
+      {{!arg_label.Optional}[Optional]} is allowed.
   *)
   | Pparam_newtype of string loc
   (** [Pparam_newtype x] represents the parameter [(type x)].

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -67,7 +67,6 @@ val compile_only : bool ref
 val output_name : string option ref
 val include_dirs : string list ref
 val libloc : Libloc.t list ref
-val hidden_include_dirs : string list ref
 val no_std_include : bool ref
 val no_cwd : bool ref
 val print_types : bool ref


### PR DESCRIPTION
(Only the last 2 commits are to be read. The others are explained in / included in #270 .)

This PR fixes conflicts in parsing mlis and `parser.mly`, and builds them with CI.

Per-file description:
* `parsing/builtin_attributes.mli`: resolve with upstream version, except taking care to keep zero-alloc things. Reasoning: Chris made changes in response to review when posting upstream, and most of those changes apply to flambda-backend too.
* Misc: delete some changes that are duplicated in the merge.
* Misc: disable `flambda2_floats` library for now, as it's not present in ocaml-jst and is breaking the build.