### PR TITLE
Revert utils/load_path.ml{,i} to our side

### DIFF
--- a/utils/load_path.ml
+++ b/utils/load_path.ml
@@ -22,7 +22,6 @@ module Dir : sig
 
   type t
 
-<<<<<<< HEAD
   val path : t -> string
   val files : t -> entry list
   val basenames : t -> string list
@@ -38,39 +37,17 @@ end = struct
     basename : string;
     path : string
   }
-||||||| 121bedcfd2
-let files : registry ref = s_table STbl.create 42
-let files_uncap : registry ref = s_table STbl.create 42
-=======
-let visible_files : registry ref = s_table STbl.create 42
-let visible_files_uncap : registry ref = s_table STbl.create 42
-
-let hidden_files : registry ref = s_table STbl.create 42
-let hidden_files_uncap : registry ref = s_table STbl.create 42
->>>>>>> 5.2.0
 
   type t = {
     path : string;
-<<<<<<< HEAD
     files : entry list;
     hidden : bool
-||||||| 121bedcfd2
-    files : string list;
-=======
-    files : string list;
-    hidden : bool;
->>>>>>> 5.2.0
   }
 
   let path t = t.path
   let files t = t.files
-<<<<<<< HEAD
   let basenames t = List.map (fun { basename; _ } -> basename) t.files
   let hidden t = t.hidden
-||||||| 121bedcfd2
-=======
-  let hidden t = t.hidden
->>>>>>> 5.2.0
 
   let find t fn =
     List.find_map (fun { basename; path } ->
@@ -79,25 +56,11 @@ let hidden_files_uncap : registry ref = s_table STbl.create 42
       else
         None) t.files
 
-<<<<<<< HEAD
   let find_uncap t fn =
     let fn = String.uncapitalize_ascii fn in
     let search { basename; path } =
       if String.uncapitalize_ascii basename = fn then
         Some path
-||||||| 121bedcfd2
-  let find_uncap t fn =
-    let fn = String.uncapitalize_ascii fn in
-    let search base =
-      if String.uncapitalize_ascii base = fn then
-        Some (Filename.concat t.path base)
-=======
-  let find_normalized t fn =
-    let fn = Misc.normalized_unit_filename fn in
-    let search base =
-      if Misc.normalized_unit_filename base = fn then
-        Some (Filename.concat t.path base)
->>>>>>> 5.2.0
       else
         None
     in
@@ -112,7 +75,6 @@ let hidden_files_uncap : registry ref = s_table STbl.create 42
     with Sys_error _ ->
       [||]
 
-<<<<<<< HEAD
   let create ~hidden path =
     let files = Array.to_list (readdir_compat path)
       |> List.map (fun basename -> { basename; path = Filename.concat path basename }) in
@@ -217,13 +179,6 @@ end = struct
       find (String.uncapitalize_ascii fn) visible_files_uncap hidden_files_uncap
     else
       find fn visible_files hidden_files
-||||||| 121bedcfd2
-  let create path =
-    { path; files = Array.to_list (readdir_compat path) }
-=======
-  let create ~hidden path =
-    { path; files = Array.to_list (readdir_compat path); hidden }
->>>>>>> 5.2.0
 end
 
 type auto_include_callback =
@@ -236,30 +191,11 @@ let auto_include_callback = ref no_auto_include
 
 let reset () =
   assert (not Config.merlin || Local_store.is_bound ());
-<<<<<<< HEAD
   Path_cache.reset ();
   hidden_dirs := [];
   visible_dirs := [];
-||||||| 121bedcfd2
-  STbl.clear !files;
-  STbl.clear !files_uncap;
-  dirs := [];
-=======
-  STbl.clear !hidden_files;
-  STbl.clear !hidden_files_uncap;
-  STbl.clear !visible_files;
-  STbl.clear !visible_files_uncap;
-  hidden_dirs := [];
-  visible_dirs := [];
->>>>>>> 5.2.0
   auto_include_callback := no_auto_include
 
-<<<<<<< HEAD
-let get_visible () = List.rev !visible_dirs
-||||||| 121bedcfd2
-let get () = List.rev !dirs
-let get_paths () = List.rev_map Dir.path !dirs
-=======
 let get_visible () = List.rev !visible_dirs
 
 let get_path_list () =
@@ -275,61 +211,9 @@ let get_paths () =
 
 let get_visible_path_list () = List.rev_map Dir.path !visible_dirs
 let get_hidden_path_list () = List.rev_map Dir.path !hidden_dirs
->>>>>>> 5.2.0
-
-<<<<<<< HEAD
-let get_path_list () =
-  Misc.rev_map_end Dir.path !visible_dirs (List.rev_map Dir.path !hidden_dirs)
-||||||| 121bedcfd2
-(* Optimized version of [add] below, for use in [init] and [remove_dir]: since
-   we are starting from an empty cache, we can avoid checking whether a unit
-   name already exists in the cache simply by adding entries in reverse
-   order. *)
-let prepend_add dir =
-  List.iter (fun base ->
-      let fn = Filename.concat dir.Dir.path base in
-      STbl.replace !files base fn;
-      STbl.replace !files_uncap (String.uncapitalize_ascii base) fn
-    ) dir.Dir.files
-=======
-(* Optimized version of [add] below, for use in [init] and [remove_dir]: since
-   we are starting from an empty cache, we can avoid checking whether a unit
-   name already exists in the cache simply by adding entries in reverse
-   order. *)
-let prepend_add dir =
-  List.iter (fun base ->
-      let fn = Filename.concat dir.Dir.path base in
-      let filename = Misc.normalized_unit_filename base in
-      if dir.Dir.hidden then begin
-        STbl.replace !hidden_files base fn;
-        STbl.replace !hidden_files_uncap filename fn
-      end else begin
-        STbl.replace !visible_files base fn;
-        STbl.replace !visible_files_uncap filename fn
-      end
-    ) dir.Dir.files
->>>>>>> 5.2.0
-
-<<<<<<< HEAD
-type paths =
-  { visible : string list;
-    hidden : string list }
-
-let get_paths () =
-  { visible = List.rev_map Dir.path !visible_dirs;
-    hidden = List.rev_map Dir.path !hidden_dirs }
-
-let get_visible_path_list () = List.rev_map Dir.path !visible_dirs
-let get_hidden_path_list () = List.rev_map Dir.path !hidden_dirs
 
 let init ~auto_include ~visible ~hidden =
-||||||| 121bedcfd2
-let init ~auto_include l =
-=======
-let init ~auto_include ~visible ~hidden =
->>>>>>> 5.2.0
   reset ();
-<<<<<<< HEAD
   visible_dirs := List.rev_map (Dir.create ~hidden:false) visible;
   hidden_dirs := List.rev_map (Dir.create ~hidden:true) hidden;
   List.iter (fun (libloc : Clflags.Libloc.t) ->
@@ -338,15 +222,6 @@ let init ~auto_include ~visible ~hidden =
   ) !Clflags.libloc;
   List.iter Path_cache.prepend_add !hidden_dirs;
   List.iter Path_cache.prepend_add !visible_dirs;
-||||||| 121bedcfd2
-  dirs := List.rev_map Dir.create l;
-  List.iter prepend_add !dirs;
-=======
-  visible_dirs := List.rev_map (Dir.create ~hidden:false) visible;
-  hidden_dirs := List.rev_map (Dir.create ~hidden:true) hidden;
-  List.iter prepend_add !hidden_dirs;
-  List.iter prepend_add !visible_dirs;
->>>>>>> 5.2.0
   auto_include_callback := auto_include
 
 let remove_dir dir =
@@ -356,20 +231,10 @@ let remove_dir dir =
   if    List.compare_lengths visible !visible_dirs <> 0
      || List.compare_lengths hidden !hidden_dirs <> 0 then begin
     reset ();
-<<<<<<< HEAD
     visible_dirs := visible;
     hidden_dirs := hidden;
     List.iter Path_cache.prepend_add hidden;
     List.iter Path_cache.prepend_add visible
-||||||| 121bedcfd2
-    List.iter prepend_add new_dirs;
-    dirs := new_dirs
-=======
-    visible_dirs := visible;
-    hidden_dirs := hidden;
-    List.iter prepend_add hidden;
-    List.iter prepend_add visible
->>>>>>> 5.2.0
   end
 
 (* General purpose version of function to add a new entry to load path: We only
@@ -377,42 +242,11 @@ let remove_dir dir =
    left-to-right precedence. *)
 let add (dir : Dir.t) =
   assert (not Config.merlin || Local_store.is_bound ());
-<<<<<<< HEAD
   Path_cache.add dir;
   if (Dir.hidden dir) then
     hidden_dirs := dir :: !hidden_dirs
   else
     visible_dirs := dir :: !visible_dirs
-||||||| 121bedcfd2
-  List.iter
-    (fun base ->
-       let fn = Filename.concat dir.Dir.path base in
-       if not (STbl.mem !files base) then
-         STbl.replace !files base fn;
-       let ubase = String.uncapitalize_ascii base in
-       if not (STbl.mem !files_uncap ubase) then
-         STbl.replace !files_uncap ubase fn)
-    dir.Dir.files;
-  dirs := dir :: !dirs
-=======
-  let update base fn visible_files hidden_files =
-    if dir.hidden && not (STbl.mem !hidden_files base) then
-      STbl.replace !hidden_files base fn
-    else if not (STbl.mem !visible_files base) then
-      STbl.replace !visible_files base fn
-  in
-  List.iter
-    (fun base ->
-       let fn = Filename.concat dir.Dir.path base in
-       update base fn visible_files hidden_files;
-       let ubase = Misc.normalized_unit_filename base in
-       update ubase fn visible_files_uncap hidden_files_uncap)
-    dir.files;
-  if dir.hidden then
-    hidden_dirs := dir :: !hidden_dirs
-  else
-    visible_dirs := dir :: !visible_dirs
->>>>>>> 5.2.0
 
 let append_dir = add
 
@@ -422,22 +256,11 @@ let add_dir ~hidden dir = add (Dir.create ~hidden dir)
    unconditionally added. *)
 let prepend_dir (dir : Dir.t) =
   assert (not Config.merlin || Local_store.is_bound ());
-<<<<<<< HEAD
   Path_cache.prepend_add dir;
   if (Dir.hidden dir) then
     hidden_dirs := !hidden_dirs @ [dir]
   else
     visible_dirs := !visible_dirs @ [dir]
-||||||| 121bedcfd2
-  prepend_add dir;
-  dirs := !dirs @ [dir]
-=======
-  prepend_add dir;
-  if dir.hidden then
-    hidden_dirs := !hidden_dirs @ [dir]
-  else
-    visible_dirs := !visible_dirs @ [dir]
->>>>>>> 5.2.0
 
 let is_basename fn = Filename.basename fn = fn
 
@@ -463,74 +286,29 @@ let auto_include_otherlibs =
     List.map (fun lib -> (lib, read_lib lib)) ["dynlink"; "str"; "unix"] in
   auto_include_libs otherlibs
 
-type visibility = Visible | Hidden
-
-let find_file_in_cache fn visible_files hidden_files =
-  try (STbl.find !visible_files fn, Visible) with
-  | Not_found -> (STbl.find !hidden_files fn, Hidden)
-
 let find fn =
   assert (not Config.merlin || Local_store.is_bound ());
   try
     if is_basename fn && not !Sys.interactive then
-<<<<<<< HEAD
       fst (Path_cache.find ~uncap:false fn)
-||||||| 121bedcfd2
-      STbl.find !files fn
-=======
-      fst (find_file_in_cache fn visible_files hidden_files)
->>>>>>> 5.2.0
     else
       Misc.find_in_path (get_path_list ()) fn
   with Not_found ->
     !auto_include_callback Dir.find fn
 
-<<<<<<< HEAD
 let find_uncap_with_visibility fn =
-||||||| 121bedcfd2
-let find_uncap fn =
-=======
-let find_normalized_with_visibility fn =
->>>>>>> 5.2.0
   assert (not Config.merlin || Local_store.is_bound ());
   try
     if is_basename fn && not !Sys.interactive then
-<<<<<<< HEAD
       Path_cache.find ~uncap:true fn
-||||||| 121bedcfd2
-      STbl.find !files_uncap (String.uncapitalize_ascii fn)
-=======
-      find_file_in_cache (Misc.normalized_unit_filename fn)
-        visible_files_uncap hidden_files_uncap
->>>>>>> 5.2.0
     else
-<<<<<<< HEAD
       try
         (Misc.find_in_path_uncap (get_visible_path_list ()) fn, Visible)
       with
       | Not_found ->
         (Misc.find_in_path_uncap (get_hidden_path_list ()) fn, Hidden)
-||||||| 121bedcfd2
-      Misc.find_in_path_uncap (get_paths ()) fn
-=======
-      try
-        (Misc.find_in_path_normalized (get_visible_path_list ()) fn, Visible)
-      with
-      | Not_found ->
-        (Misc.find_in_path_normalized (get_hidden_path_list ()) fn, Hidden)
->>>>>>> 5.2.0
   with Not_found ->
-<<<<<<< HEAD
     let fn_uncap = String.uncapitalize_ascii fn in
     (!auto_include_callback Dir.find_uncap fn_uncap, Visible)
 
 let find_uncap fn = fst (find_uncap_with_visibility fn)
-||||||| 121bedcfd2
-    let fn_uncap = String.uncapitalize_ascii fn in
-    !auto_include_callback Dir.find_uncap fn_uncap
-=======
-    let fn_uncap = Misc.normalized_unit_filename fn in
-    (!auto_include_callback Dir.find_normalized fn_uncap, Visible)
-
-let find_normalized fn = fst (find_normalized_with_visibility fn)
->>>>>>> 5.2.0

--- a/utils/load_path.mli
+++ b/utils/load_path.mli
@@ -22,6 +22,9 @@
     doesn't change during the execution of the compiler.
 *)
 
+(* CR aodintsov/mshinwell: merge the remaining flambda-backend changes
+   upstream *)
+
 val add_dir : hidden:bool -> string -> unit
 (** Add a directory to the end of the load path (i.e. at lowest priority.) *)
 

--- a/utils/load_path.mli
+++ b/utils/load_path.mli
@@ -40,28 +40,6 @@ module Dir : sig
   val basenames : t -> string list
   (** All the files in that directory. This doesn't include files in
       sub-directories of this directory. *)
-<<<<<<< HEAD
-||||||| 121bedcfd2
-
-  val find : t -> string -> string option
-  (** [find dir fn] returns the full path to [fn] in [dir]. *)
-
-  val find_uncap : t -> string -> string option
-  (** As {!find}, but search also for uncapitalized name, i.e. if name is
-      Foo.ml, either /path/Foo.ml or /path/foo.ml may be returned. *)
-=======
-
-  val hidden : t -> bool
-  (** If the modules in this directory should not be bound in the initial
-      scope *)
-
-  val find : t -> string -> string option
-  (** [find dir fn] returns the full path to [fn] in [dir]. *)
-
-  val find_normalized : t -> string -> string option
-  (** As {!find}, but search also for uncapitalized name, i.e. if name is
-      Foo.ml, either /path/Foo.ml or /path/foo.ml may be returned. *)
->>>>>>> 5.2.0
 end
 
 type auto_include_callback =
@@ -102,16 +80,9 @@ val find : string -> string
     filename is a basename, i.e. doesn't contain a directory
     separator. *)
 
-val find_normalized : string -> string
-(** Same as [find], but search also for normalized unit name (see
-    {!Misc.normalized_unit_filename}), i.e. if name is [Foo.ml], allow
-    [/path/Foo.ml] and [/path/foo.ml] to match. *)
-
-type visibility = Visible | Hidden
-
-val find_normalized_with_visibility : string -> string * visibility
-(** Same as [find_normalized], but also reports whether the cmi was found in a
-    -I directory (Visible) or a -H directory (Hidden) *)
+val find_uncap : string -> string
+(** Same as [find], but search also for uncapitalized name, i.e.  if
+    name is Foo.ml, allow /path/Foo.ml and /path/foo.ml to match. *)
 
 type visibility = Visible | Hidden
 


### PR DESCRIPTION
This reverts `utils/load_path.ml{,i}` to our existing flambda-backend versions.  @Forestryks please review to see if we want to take any of the incoming changes from `5.2.0` upstream.