### PR TITLE
Resolve conflicts in file_formats/*.mli

### DIFF
--- a/file_formats/cmo_format.mli
+++ b/file_formats/cmo_format.mli
@@ -15,64 +15,32 @@
 
 (* Symbol table information for .cmo and .cma files *)
 
-<<<<<<< HEAD
-||||||| 121bedcfd2
-open Misc
-
-=======
-type modname = string
-type crcs = (modname * Digest.t option) list
-
-(* Names of compilation units as represented in CMO files *)
-type compunit = Compunit of string [@@unboxed]
-
 (* Predefined symbols as represented in CMO files *)
 
 type predef =
   | Predef_exn of string [@@unboxed]
 
->>>>>>> 5.2.0
 (* Relocation information *)
 
 type reloc_info =
   | Reloc_literal of Obj.t (* structured constant *)
-  | Reloc_getcompunit of compunit (* reference to a compunit *)
+  | Reloc_getcompunit of Compilation_unit.t (* reference to a compunit *)
   | Reloc_getpredef of predef (* reference to a predef *)
-  | Reloc_setcompunit of compunit (* definition of a compunit *)
+  | Reloc_setcompunit of Compilation_unit.t (* definition of a compunit *)
   | Reloc_primitive of string (* C primitive number *)
 
 (* Descriptor for compilation units *)
 
-<<<<<<< HEAD
 type compilation_unit_descr =
   { cu_name: Compilation_unit.t;        (* Name of compilation unit *)
-||||||| 121bedcfd2
-type compilation_unit =
-  { cu_name: modname;                   (* Name of compilation unit *)
-=======
-type compilation_unit =
-  { cu_name: compunit;                   (* Name of compilation unit *)
->>>>>>> 5.2.0
     mutable cu_pos: int;                (* Absolute position in file *)
     cu_codesize: int;                   (* Size of code block *)
     cu_reloc: (reloc_info * int) list;  (* Relocation information *)
-<<<<<<< HEAD
     cu_imports: Import_info.t array;    (* Names and CRC of intfs imported *)
     cu_required_globals: Compilation_unit.t list;
                                         (* Compilation units whose
                                            initialization side effects
                                            must occur before this one. *)
-||||||| 121bedcfd2
-    cu_imports: crcs;                   (* Names and CRC of intfs imported *)
-    cu_required_globals: Ident.t list;  (* Compilation units whose
-                                           initialization side effects
-                                           must occur before this one. *)
-=======
-    cu_imports: crcs;                     (* Names and CRC of intfs imported *)
-    cu_required_compunits: compunit list; (* Compilation units whose
-                                             initialization side effects
-                                             must occur before this one. *)
->>>>>>> 5.2.0
     cu_primitives: string list;         (* Primitives declared inside *)
     mutable cu_force_link: bool;        (* Must be linked even if unref'ed *)
     mutable cu_debug: int;              (* Position of debugging info, or 0 *)

--- a/file_formats/cmt_format.mli
+++ b/file_formats/cmt_format.mli
@@ -58,21 +58,17 @@ type cmt_infos = {
   cmt_sourcefile : string option;
   cmt_builddir : string;
   cmt_loadpath : Load_path.paths;
+  cmt_loadpath : Load_path.paths;
   cmt_source_digest : string option;
   cmt_initial_env : Env.t;
   cmt_imports : Import_info.t array;
   cmt_interface_digest : Digest.t option;
   cmt_use_summaries : bool;
   cmt_uid_to_decl : item_declaration Shape.Uid.Tbl.t;
+  cmt_uid_to_decl : item_declaration Shape.Uid.Tbl.t;
   cmt_impl_shape : Shape.t option; (* None for mli *)
-<<<<<<< HEAD
   cmt_ident_occurrences :
     (Longident.t Location.loc * Shape_reduce.result) array
-||||||| 121bedcfd2
-=======
-  cmt_ident_occurrences :
-    (Longident.t Location.loc * Shape_reduce.result) list
->>>>>>> 5.2.0
 }
 
 type error =
@@ -96,15 +92,8 @@ val read_cmi : string -> Cmi_format.cmi_infos_lazy
 (** [save_cmt filename modname binary_annots sourcefile initial_env cmi]
     writes a cmt(i) file.  *)
 val save_cmt :
-<<<<<<< HEAD
-  string ->  (* filename.cmt to generate *)
-  Compilation_unit.t ->  (* module name *)
-||||||| 121bedcfd2
-  string ->  (* filename.cmt to generate *)
-  string ->  (* module name *)
-=======
   Unit_info.Artifact.t ->
->>>>>>> 5.2.0
+  Compilation_unit.t ->  (* module name *)
   binary_annots ->
   Env.t -> (* initial env *)
   Cmi_format.cmi_infos_lazy option -> (* if a .cmi was generated *)
@@ -124,7 +113,6 @@ val set_saved_types : binary_part list -> unit
 val record_value_dependency:
   Types.value_description -> Types.value_description -> unit
 
-<<<<<<< HEAD
 val index_occurrences :
   binary_annots -> (Longident.t Location.loc * Shape_reduce.result) array
 
@@ -133,10 +121,6 @@ val iter_declarations
     -> f:(Shape.Uid.t -> Typedtree.item_declaration -> unit)
     -> unit
 
-||||||| 121bedcfd2
-
-=======
->>>>>>> 5.2.0
 (*
 
   val is_magic_number : string -> bool

--- a/file_formats/cmxs_format.mli
+++ b/file_formats/cmxs_format.mli
@@ -15,15 +15,6 @@
 
 (* Format of .cmxs files *)
 
-<<<<<<< HEAD
-||||||| 121bedcfd2
-open Misc
-
-=======
-type modname = string
-type crcs = (modname * Digest.t option) list
-
->>>>>>> 5.2.0
 (* Each .cmxs dynamically-loaded plugin contains a symbol
    "caml_plugin_header" containing the following info
    (as an externed record) *)

--- a/parsing/unit_info.mli
+++ b/parsing/unit_info.mli
@@ -21,6 +21,8 @@
 
 (** {1:modname_from_strings Module name convention and computation} *)
 
+(* CR mshinwell: Consider changing [modname] to be [Compilation_unit.t] *)
+
 type modname = string
 type filename = string
 type file_prefix = string


### PR DESCRIPTION
This is straightforward except for the design point about the new `Unit_info` module.  See https://github.com/ocaml-flambda/flambda-backend/wiki/Strategy-for-5.2.0-Unit_info-and-compunit for the current strategy.  We can come back and edit these files later if that changes.