### PR TITLE
Resolve conflicts in bytecomp/*.mli and remove Symtable.Compunit

### DIFF
--- a/bytecomp/bytelink.mli
+++ b/bytecomp/bytelink.mli
@@ -17,15 +17,8 @@ open Misc
 
 (* Link .cmo files and produce a bytecode executable. *)
 
-<<<<<<< HEAD
-(* CR mshinwell: seems like this should use [CU.Name.t] *)
-module Dep : Set.OrderedType with type t = string * string
-||||||| 121bedcfd2
-module Dep : Set.OrderedType with type t = modname * modname
-=======
 module Dep : Set.OrderedType with
-  type t = Cmo_format.compunit * Cmo_format.compunit
->>>>>>> 5.2.0
+  type t = Compilation_unit.t * Compilation_unit.t
 module DepSet : Set.S with type elt = Dep.t
 
 val link : filepath list -> filepath -> unit
@@ -44,23 +37,10 @@ type error =
   | Custom_runtime
   | File_exists of filepath
   | Cannot_open_dll of filepath
-<<<<<<< HEAD
-  | Required_module_unavailable of string * Compilation_unit.t
-||||||| 121bedcfd2
-  | Required_module_unavailable of modname * modname
-=======
-  | Required_compunit_unavailable of (Cmo_format.compunit * Cmo_format.compunit)
->>>>>>> 5.2.0
+  | Required_module_unavailable of Compilation_unit.t * Compilation_unit.t
   | Camlheader of string * filepath
   | Wrong_link_order of DepSet.t
-<<<<<<< HEAD
-  (* CR mshinwell: seems like [Multiple_definition] should use [CU.t] *)
-  | Multiple_definition of string * filepath * filepath
-||||||| 121bedcfd2
-  | Multiple_definition of modname * filepath * filepath
-=======
-  | Multiple_definition of Cmo_format.compunit * filepath * filepath
->>>>>>> 5.2.0
+  | Multiple_definition of Compilation_unit.t * filepath * filepath
 
 exception Error of error
 

--- a/bytecomp/bytepackager.mli
+++ b/bytecomp/bytepackager.mli
@@ -23,7 +23,7 @@ type error =
     Forward_reference of string * Compilation_unit.t
   | Multiple_definition of string * Compilation_unit.t
   | Not_an_object_file of string
-  | Illegal_renaming of Compilation_unit.Name.t * string * Compilation_unit.t
+  | Illegal_renaming of Compilation_unit.t * string * Compilation_unit.t
   | File_not_found of string
 
 exception Error of error

--- a/bytecomp/bytepackager.mli
+++ b/bytecomp/bytepackager.mli
@@ -20,16 +20,10 @@ val package_files:
   ppf_dump:Format.formatter -> Env.t -> string list -> string -> unit
 
 type error =
-    Forward_reference of string * Cmo_format.compunit
-  | Multiple_definition of string * Cmo_format.compunit
+    Forward_reference of string * Compilation_unit.t
+  | Multiple_definition of string * Compilation_unit.t
   | Not_an_object_file of string
-<<<<<<< HEAD
-  | Illegal_renaming of Compilation_unit.Name.t * string * string
-||||||| 121bedcfd2
-  | Illegal_renaming of string * string * string
-=======
-  | Illegal_renaming of Cmo_format.compunit * string * Cmo_format.compunit
->>>>>>> 5.2.0
+  | Illegal_renaming of Compilation_unit.Name.t * string * Compilation_unit.t
   | File_not_found of string
 
 exception Error of error

--- a/bytecomp/debug_event.mli
+++ b/bytecomp/debug_event.mli
@@ -15,21 +15,35 @@
 
 (* Structure of compilation environments *)
 
+type closure_entry =
+  | Free_variable of int
+  | Function of int
+
+type closure_env =
+  | Not_in_closure
+  | In_closure of {
+      entries: closure_entry Ident.tbl; (* Offsets of the free variables and
+                                           recursive functions from the start of
+                                           the block *)
+      env_pos: int;                     (* Offset of the current function from
+                                           the start of the block *)
+    }
+
 type compilation_env =
-  { ce_stack: int Ident.tbl; (* Positions of variables in the stack *)
-    ce_heap: int Ident.tbl;  (* Structure of the heap-allocated env *)
-    ce_rec: int Ident.tbl }  (* Functions bound by the same let rec *)
+  { ce_stack: int Ident.tbl;  (* Positions of variables in the stack *)
+    ce_closure: closure_env } (* Structure of the heap-allocated env *)
 
 (* The ce_stack component gives locations of variables residing
    in the stack. The locations are offsets w.r.t. the origin of the
    stack frame.
-   The ce_heap component gives the positions of variables residing in the
-   heap-allocated environment.
-   The ce_rec component associates offsets to identifiers for functions
-   bound by the same let rec as the current function.  The offsets
-   are used by the OFFSETCLOSURE instruction to recover the closure
-   pointer of the desired function from the env register (which
-   points to the closure for the current function). *)
+   The ce_closure component gives the positions of variables residing in the
+   heap-allocated environment. The env_pos component gives the position of
+   the current function from the start of the closure block, and the entries
+   component gives the positions of free variables and functions bound by the
+   same let rec as the current function, from the start of the closure block.
+   These are used by the ENVACC and OFFSETCLOSURE instructions to recover the
+   relevant value from the env register (which points to the current function).
+*)
 
 (* Debugging events *)
 

--- a/bytecomp/emitcode.mli
+++ b/bytecomp/emitcode.mli
@@ -18,16 +18,8 @@
 open Cmo_format
 open Instruct
 
-<<<<<<< HEAD
-val to_file: out_channel -> Compilation_unit.t -> string ->
+val to_file: out_channel -> Compilation_unit.t -> Unit_info.Artifact.t ->
   required_globals:Compilation_unit.Set.t -> instruction list -> unit
-||||||| 121bedcfd2
-val to_file: out_channel -> string -> string ->
-  required_globals:Ident.Set.t -> instruction list -> unit
-=======
-val to_file: out_channel -> Unit_info.Artifact.t ->
-  required_globals:Ident.Set.t -> instruction list -> unit
->>>>>>> 5.2.0
         (* Arguments:
              channel on output file
              name of compilation unit implemented

--- a/bytecomp/instruct.mli
+++ b/bytecomp/instruct.mli
@@ -19,28 +19,6 @@ open Lambda
 
 (* Structure of compilation environments *)
 
-<<<<<<< HEAD
-type compilation_env = Debug_event.compilation_env =
-  { ce_stack: int Ident.tbl;
-    ce_heap: int Ident.tbl;
-    ce_rec: int Ident.tbl }
-||||||| 121bedcfd2
-type compilation_env =
-  { ce_stack: int Ident.tbl; (* Positions of variables in the stack *)
-    ce_heap: int Ident.tbl;  (* Structure of the heap-allocated env *)
-    ce_rec: int Ident.tbl }  (* Functions bound by the same let rec *)
-
-(* The ce_stack component gives locations of variables residing
-   in the stack. The locations are offsets w.r.t. the origin of the
-   stack frame.
-   The ce_heap component gives the positions of variables residing in the
-   heap-allocated environment.
-   The ce_rec component associates offsets to identifiers for functions
-   bound by the same let rec as the current function.  The offsets
-   are used by the OFFSETCLOSURE instruction to recover the closure
-   pointer of the desired function from the env register (which
-   points to the closure for the current function). *)
-=======
 type closure_entry =
   | Free_variable of int
   | Function of int
@@ -55,7 +33,7 @@ type closure_env =
                                            the start of the block *)
     }
 
-type compilation_env =
+type compilation_env = Debug_event.compilation_env =
   { ce_stack: int Ident.tbl;  (* Positions of variables in the stack *)
     ce_closure: closure_env } (* Structure of the heap-allocated env *)
 
@@ -70,7 +48,6 @@ type compilation_env =
    These are used by the ENVACC and OFFSETCLOSURE instructions to recover the
    relevant value from the env register (which points to the current function).
 *)
->>>>>>> 5.2.0
 
 (* Debugging events *)
 

--- a/bytecomp/meta.mli
+++ b/bytecomp/meta.mli
@@ -20,14 +20,8 @@ external realloc_global_data : int -> unit = "caml_realloc_global"
 type closure = unit -> Obj.t
 type bytecode
 external reify_bytecode :
-<<<<<<< HEAD
-  bytes array -> Debug_event.debug_event list array -> string option ->
-||||||| 121bedcfd2
-  bytes array -> Instruct.debug_event list array -> string option ->
-=======
   (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
-  Instruct.debug_event list array -> string option ->
->>>>>>> 5.2.0
+  Debug_event.debug_event list array -> string option ->
     bytecode * closure
                            = "caml_reify_bytecode"
 external release_bytecode : bytecode -> unit

--- a/bytecomp/symtable.mli
+++ b/bytecomp/symtable.mli
@@ -17,15 +17,6 @@
 
 open Cmo_format
 
-module Compunit : sig
-  type t = compunit
-  val name : t -> string
-  val is_packed : compunit -> bool
-  val to_ident : compunit -> Ident.t
-  module Set : Set.S with type elt = t
-  module Map : Map.S with type key = t
-end
-
 module Predef : sig
   type t = predef
   module Set : Set.S with type elt = t
@@ -34,7 +25,7 @@ end
 
 module Global : sig
   type t =
-    | Glob_compunit of compunit
+    | Glob_compunit of Compilation_unit.t
     | Glob_predef of predef
   val name: t -> string
   val description: Format.formatter -> t -> unit
@@ -67,8 +58,8 @@ val is_global_defined: Global.t -> bool
 val assign_global_value: Global.t -> Obj.t -> unit
 val get_global_position: Global.t -> int
 val check_global_initialized: (reloc_info * int) list -> unit
-val initialized_compunits: (reloc_info * int) list -> compunit list
-val required_compunits: (reloc_info * int) list -> compunit list
+val initialized_compunits: (reloc_info * int) list -> Compilation_unit.t list
+val required_compunits: (reloc_info * int) list -> Compilation_unit.t list
 
 type global_map
 


### PR DESCRIPTION
A number of changes here are related to https://github.com/ocaml-flambda/flambda-backend/wiki/Strategy-for-5.2.0-Unit_info-and-compunit .  I've discussed with @lukemaurer .

We have the `Debug_event` interface split out, so I've updated that with changes from `Instruct`.