### PR TITLE
Resolve conflicts in typing/*.mli

### DIFF
--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -82,13 +82,7 @@ val is_Tconstr: type_expr -> bool
 val is_Tpoly: type_expr -> bool
 
 val dummy_method: label
-<<<<<<< HEAD
 val type_kind_is_abstract: type_declaration -> bool
-||||||| 121bedcfd2
-=======
-val type_kind_is_abstract: type_declaration -> bool
-val type_origin : type_declaration -> type_origin
->>>>>>> 5.2.0
 
 (**** polymorphic variants ****)
 

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -176,18 +176,9 @@ val generic_instance: type_expr -> type_expr
 val instance_list: type_expr list -> type_expr list
         (* Take an instance of a list of type schemes *)
 val new_local_type:
-<<<<<<< HEAD
         ?loc:Location.t -> ?manifest_and_scope:(type_expr * int) ->
         Jkind.t -> jkind_annot:Jkind.annotation option -> type_declaration
 val existential_name: constructor_description -> type_expr -> string
-||||||| 121bedcfd2
-        ?loc:Location.t ->
-        ?manifest_and_scope:(type_expr * int) -> unit -> type_declaration
-val existential_name: constructor_description -> type_expr -> string
-=======
-        ?loc:Location.t ->
-        ?manifest_and_scope:(type_expr * int) ->
-        type_origin -> type_declaration
 
 module Pattern_env : sig
   type t = private
@@ -201,7 +192,6 @@ module Pattern_env : sig
   val copy: ?equations_scope:int -> t -> t
   val set_env: t -> Env.t -> unit
 end
->>>>>>> 5.2.0
 
 type existential_treatment =
   | Keep_existentials_flexible

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -354,19 +354,10 @@ val add_value_lazy:
     ?check:(string -> Warnings.t) -> mode:(Mode.allowed * 'r) Mode.Value.t ->
     Ident.t -> Subst.Lazy.value_description -> t -> t
 val add_value:
-<<<<<<< HEAD
     ?check:(string -> Warnings.t) -> mode:(Mode.allowed * 'r) Mode.Value.t ->
     Ident.t -> Types.value_description -> t -> t
 val add_type:
     check:bool -> ?shape:Shape.t -> Ident.t -> type_declaration -> t -> t
-||||||| 121bedcfd2
-    ?check:(string -> Warnings.t) -> Ident.t -> value_description -> t -> t
-val add_type: check:bool -> Ident.t -> type_declaration -> t -> t
-=======
-    ?check:(string -> Warnings.t) -> Ident.t -> value_description -> t -> t
-val add_type:
-  check:bool -> ?shape:Shape.t -> Ident.t -> type_declaration -> t -> t
->>>>>>> 5.2.0
 val add_extension:
   check:bool -> ?shape:Shape.t -> rebind:bool -> Ident.t ->
   extension_constructor -> t -> t
@@ -483,53 +474,24 @@ val set_unit_name: Compilation_unit.t option -> unit
 val get_unit_name: unit -> Compilation_unit.t option
 
 (* Read, save a signature to/from a file *)
-<<<<<<< HEAD
 val read_signature:
-  Compilation_unit.Name.t -> filepath -> add_binding:bool -> signature
+  Compilation_unit.Name.t -> Unit_info.Artifact.t -> add_binding:bool
+  -> signature
         (* Arguments: module name, file name, [add_binding] flag.
            Results: signature. If [add_binding] is true, creates an entry for
            the module in the environment. *)
-||||||| 121bedcfd2
-val read_signature: modname -> filepath -> signature
-        (* Arguments: module name, file name. Results: signature. *)
-=======
-val read_signature: Unit_info.Artifact.t -> signature
-        (* Arguments: module name, file name. Results: signature. *)
->>>>>>> 5.2.0
 val save_signature:
-<<<<<<< HEAD
-  alerts:alerts -> signature -> Compilation_unit.Name.t -> Cmi_format.kind
-  -> filepath -> Cmi_format.cmi_infos_lazy
+  alerts:alerts -> Types.signature -> Compilation_unit.Name.t -> Cmi_format.kind
+  -> Unit_info.Artifact.t -> Cmi_format.cmi_infos_lazy
         (* Arguments: signature, module name, module kind, file name. *)
-||||||| 121bedcfd2
-  alerts:alerts -> signature -> modname -> filepath
-  -> Cmi_format.cmi_infos
-        (* Arguments: signature, module name, file name. *)
-=======
-  alerts:alerts -> Types.signature -> Unit_info.Artifact.t
-  -> Cmi_format.cmi_infos
-        (* Arguments: signature, module name, file name. *)
->>>>>>> 5.2.0
 val save_signature_with_imports:
-<<<<<<< HEAD
   alerts:alerts -> signature -> Compilation_unit.Name.t -> Cmi_format.kind
-  -> filepath -> Import_info.t array -> Cmi_format.cmi_infos_lazy
+  -> Unit_info.Artifact.t -> Import_info.t array -> Cmi_format.cmi_infos_lazy
         (* Arguments: signature, module name, module kind,
            file name, imported units with their CRCs. *)
 
 (* Register a module as a parameter to this unit. *)
 val register_parameter_import: Compilation_unit.Name.t -> unit
-||||||| 121bedcfd2
-  alerts:alerts -> signature -> modname -> filepath -> crcs
-  -> Cmi_format.cmi_infos
-        (* Arguments: signature, module name, file name,
-           imported units with their CRCs. *)
-=======
-  alerts:alerts -> signature -> Unit_info.Artifact.t -> crcs
-  -> Cmi_format.cmi_infos
-        (* Arguments: signature, module name, file name,
-           imported units with their CRCs. *)
->>>>>>> 5.2.0
 
 (* Return the CRC of the interface of the given compilation unit *)
 val crc_of_unit: Compilation_unit.Name.t -> Digest.t

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -58,17 +58,6 @@ type out_value =
   | Oval_variant of string * out_value option
   | Oval_lazy of out_value
 
-<<<<<<< HEAD
-||||||| 121bedcfd2
-type out_type_param = string * (Asttypes.variance * Asttypes.injectivity)
-=======
-type out_type_param = {
-    ot_non_gen: bool;
-    ot_name: string;
-    ot_variance: Asttypes.variance * Asttypes.injectivity
-}
->>>>>>> 5.2.0
-
 type out_modality_legacy = Ogf_global
 
 type out_modality_new = string
@@ -129,6 +118,7 @@ and out_jkind =
 
 and out_type_param =
   { oparam_name : string;
+    oparam_non_gen : bool;
     oparam_variance : Asttypes.variance;
     oparam_injectivity : Asttypes.injectivity;
     oparam_jkind : out_jkind option }
@@ -140,15 +130,9 @@ and out_type =
   | Otyp_abstract
   | Otyp_open
   | Otyp_alias of {non_gen:bool; aliased:out_type; alias:string}
-<<<<<<< HEAD
   | Otyp_arrow of arg_label * out_arg_mode * out_type * out_ret_mode * out_type
   (* INVARIANT: the [out_ret_mode] is [Orm_not_arrow] unless the RHS [out_type]
     is [Otyp_arrow] *)
-||||||| 121bedcfd2
-  | Otyp_arrow of string * out_type * out_type
-=======
-  | Otyp_arrow of Asttypes.arg_label * out_type * out_type
->>>>>>> 5.2.0
   | Otyp_class of out_ident * out_type list
   | Otyp_constr of out_ident * out_type list
   | Otyp_manifest of out_type * out_type
@@ -178,13 +162,7 @@ and out_variant =
 
 type out_class_type =
   | Octy_constr of out_ident * out_type list
-<<<<<<< HEAD
   | Octy_arrow of arg_label * out_type * out_class_type
-||||||| 121bedcfd2
-  | Octy_arrow of string * out_type * out_class_type
-=======
-  | Octy_arrow of Asttypes.arg_label * out_type * out_class_type
->>>>>>> 5.2.0
   | Octy_signature of out_type option * out_class_sig_item list
 and out_class_sig_item =
   | Ocsg_constraint of out_type * out_type

--- a/typing/patterns.mli
+++ b/typing/patterns.mli
@@ -65,16 +65,8 @@ end
 module General : sig
   type view = [
     | Half_simple.view
-<<<<<<< HEAD
     | `Var of Ident.t * string loc * Uid.t * Mode.Value.l
     | `Alias of pattern * Ident.t * string loc * Uid.t * Mode.Value.l
-||||||| 121bedcfd2
-    | `Var of Ident.t * string loc
-    | `Alias of pattern * Ident.t * string loc
-=======
-    | `Var of Ident.t * string loc * Uid.t
-    | `Alias of pattern * Ident.t * string loc * Uid.t
->>>>>>> 5.2.0
   ]
   type pattern = view pattern_data
 

--- a/typing/persistent_env.mli
+++ b/typing/persistent_env.mli
@@ -43,29 +43,15 @@ val report_error: Format.formatter -> error -> unit
 module Persistent_signature : sig
   type t =
     { filename : string; (** Name of the file containing the signature. *)
-<<<<<<< HEAD
       cmi : Cmi_format.cmi_infos_lazy;
       visibility : Load_path.visibility
     }
-||||||| 121bedcfd2
-      cmi : Cmi_format.cmi_infos }
-=======
-      cmi : Cmi_format.cmi_infos;
-      visibility : Load_path.visibility
-    }
->>>>>>> 5.2.0
 
   (** Function used to load a persistent signature. The default is to look for
       the .cmi file in the load path. This function can be overridden to load
       it from memory, for instance to build a self-contained toplevel. *)
-<<<<<<< HEAD
   val load :
     (allow_hidden:bool -> unit_name:Compilation_unit.Name.t -> t option) ref
-||||||| 121bedcfd2
-  val load : (unit_name:string -> t option) ref
-=======
-  val load : (allow_hidden:bool -> unit_name:string -> t option) ref
->>>>>>> 5.2.0
 end
 
 type can_load_cmis =
@@ -81,21 +67,10 @@ val clear_missing : 'a t -> unit
 
 val fold : 'a t -> (Compilation_unit.Name.t -> 'a -> 'b -> 'b) -> 'b -> 'b
 
-<<<<<<< HEAD
 type address =
   | Aunit of Compilation_unit.t
   | Alocal of Ident.t
   | Adot of address * int
-||||||| 121bedcfd2
-val read : 'a t -> (Persistent_signature.t -> 'a)
-  -> modname -> filepath -> 'a
-val find : 'a t -> (Persistent_signature.t -> 'a)
-  -> modname -> 'a
-=======
-val read : 'a t -> (Persistent_signature.t -> 'a) -> Unit_info.Artifact.t -> 'a
-val find : allow_hidden:bool -> 'a t -> (Persistent_signature.t -> 'a)
-  -> modname -> 'a
->>>>>>> 5.2.0
 
 type 'a sig_reader =
   Subst.Lazy.signature
@@ -106,13 +81,13 @@ type 'a sig_reader =
   -> flags:Cmi_format.pers_flags list
   -> 'a
 
-<<<<<<< HEAD
 (* If [add_binding] is false, reads the signature from the .cmi but does not
    bind the module name in the environment. *)
 (* CR-someday lmaurer: [add_binding] is apparently always false, including in the
    [-instantiate] branch. We should remove this parameter. *)
 val read : 'a t -> 'a sig_reader
-  -> Compilation_unit.Name.t -> filepath -> add_binding:bool -> Subst.Lazy.signature
+  -> Compilation_unit.Name.t -> Unit_info.Artifact.t -> add_binding:bool
+  -> Subst.Lazy.signature
 val find : allow_hidden:bool -> 'a t -> 'a sig_reader
   -> Compilation_unit.Name.t -> 'a
 
@@ -129,13 +104,6 @@ val register_parameter_import : 'a t -> Compilation_unit.Name.t -> unit
 (* [is_parameter_import penv md] checks if [md] is a parameter. Raises a fatal
    error if the module has not been imported. *)
 val is_parameter_import : 'a t -> Compilation_unit.Name.t -> bool
-||||||| 121bedcfd2
-val check : 'a t -> (Persistent_signature.t -> 'a)
-  -> loc:Location.t -> modname -> unit
-=======
-val check : allow_hidden:bool -> 'a t -> (Persistent_signature.t -> 'a)
-  -> loc:Location.t -> modname -> unit
->>>>>>> 5.2.0
 
 (* [looked_up penv md] checks if one has already tried
    to read the signature for [md] in the environment

--- a/typing/printpat.mli
+++ b/typing/printpat.mli
@@ -16,19 +16,9 @@
 
 
 val pretty_const
-<<<<<<< HEAD
-    : Typedtree.constant -> string
-val top_pretty
-    : Format.formatter -> 'k Typedtree.general_pattern -> unit
-||||||| 121bedcfd2
-    : Asttypes.constant -> string
-val top_pretty
-    : Format.formatter -> 'k Typedtree.general_pattern -> unit
-=======
-  : Asttypes.constant -> string
+  : Typedtree.constant -> string
 val pretty_val : Format.formatter -> 'k Typedtree.general_pattern -> unit
 
->>>>>>> 5.2.0
 val pretty_pat
     : Format.formatter -> 'k Typedtree.general_pattern -> unit
 val pretty_line

--- a/typing/shape_reduce.mli
+++ b/typing/shape_reduce.mli
@@ -1,68 +1,3 @@
-<<<<<<< HEAD
-(**************************************************************************)
-(*                                                                        *)
-(*                                 OCaml                                  *)
-(*                                                                        *)
-(*                 Ulysse Gérard, Thomas Refis, Tarides                   *)
-(*                    Nathanaëlle Courant, OCamlPro                       *)
-(*              Gabriel Scherer, projet Picube, INRIA Paris               *)
-(*                                                                        *)
-(*   Copyright 2021 Institut National de Recherche en Informatique et     *)
-(*     en Automatique.                                                    *)
-(*                                                                        *)
-(*   All rights reserved.  This file is distributed under the terms of    *)
-(*   the GNU Lesser General Public License version 2.1, with the          *)
-(*   special exception on linking described in the file LICENSE.          *)
-(*                                                                        *)
-(**************************************************************************)
-
-(** The result of reducing a shape and looking for its uid *)
-type result =
-  | Resolved of Shape.Uid.t (** Shape reduction succeeded and a uid was found *)
-  | Resolved_alias of Shape.Uid.t list (** Reduction led to an alias chain *)
-  | Unresolved of Shape.t (** Result still contains [Comp_unit] terms *)
-  | Approximated of Shape.Uid.t option
-    (** Reduction failed: it can arrive with first-clsss modules for example *)
-  | Internal_error_missing_uid
-    (** Reduction succeeded but no uid was found, this should never happen *)
-
-val print_result : Format.formatter -> result -> unit
-
-(** The [Make] functor is used to generate a reduction function for
-    shapes.
-
-    It is parametrized by:
-    - a function to load the shape of an external compilation unit
-    - some fuel, which is used to bound recursion when dealing with recursive
-      shapes introduced by recursive modules. (FTR: merlin currently uses a
-      fuel of 10, which seems to be enough for most practical examples)
-
-    Usage warning: To ensure good performances, every reduction made with the
-    same instance of that functor share the same ident-based memoization tables.
-    Such an instance should only be used to perform reduction inside a unique
-    compilation unit to prevent conflicting entries in these memoization tables.
-*)
-module Make(_ : sig
-    val fuel : int
-
-    val read_unit_shape : unit_name:string -> Shape.t option
-  end) : sig
-  val reduce : Env.t -> Shape.t -> Shape.t
-
-  (** Perform weak reduction and return the head's uid if any. If reduction was
-    incomplete the partially reduced shape is returned. *)
-  val reduce_for_uid : Env.t -> Shape.t -> result
-end
-
-(** [local_reduce] will not reduce shapes that require loading external
-  compilation units. *)
-val local_reduce : Env.t -> Shape.t -> Shape.t
-
-(** [local_reduce_for_uid] will not reduce shapes that require loading external
-  compilation units. *)
-val local_reduce_for_uid : Env.t -> Shape.t -> result
-||||||| 121bedcfd2
-=======
 (**************************************************************************)
 (*                                                                        *)
 (*                                 OCaml                                  *)
@@ -125,4 +60,3 @@ val local_reduce : Env.t -> Shape.t -> Shape.t
 (** [local_reduce_for_uid] will not reduce shapes that require loading external
   compilation units. *)
 val local_reduce_for_uid : Env.t -> Shape.t -> result
->>>>>>> 5.2.0

--- a/typing/subst.mli
+++ b/typing/subst.mli
@@ -106,19 +106,6 @@ val module_declaration: scoping -> t -> module_declaration -> module_declaration
      apply (compose s1 s2) x = apply s2 (apply s1 x) *)
 val compose: t -> t -> t
 
-<<<<<<< HEAD
-(* A forward reference to be filled in ctype.ml. *)
-val ctype_apply_env_empty:
-  (type_expr list -> type_expr -> type_expr list -> type_expr) ref
-
-||||||| 121bedcfd2
-(* A forward reference to be filled in ctype.ml. *)
-val ctype_apply_env_empty:
-  (type_expr list -> type_expr -> type_expr list -> type_expr) ref
-
-
-=======
->>>>>>> 5.2.0
 module Lazy : sig
   include Types.Wrapped
 

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -69,7 +69,6 @@ type pattern_variable =
     pv_loc: Location.t;
     pv_as_var: bool;
     pv_attributes: Typedtree.attributes;
-    pv_uid : Uid.t;
   }
 
 val mk_expected:
@@ -112,19 +111,11 @@ type existential_restriction =
   | In_class_def (** or in [class c = let ... in ...] *)
   | In_self_pattern (** or in self pattern *)
 
-<<<<<<< HEAD
 type module_patterns_restriction =
   | Modules_allowed of { scope: int }
   | Modules_rejected
   | Modules_ignored
 
-||||||| 121bedcfd2
-type module_patterns_restriction =
-  | Modules_allowed of { scope : int }
-  | Modules_rejected
-
-=======
->>>>>>> 5.2.0
 val type_binding:
         Env.t -> rec_flag ->
           ?force_toplevel:bool ->

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -46,7 +46,6 @@ val transl_with_constraint:
     outer_env:Env.t -> Parsetree.type_declaration ->
     Typedtree.type_declaration
 
-<<<<<<< HEAD
 val transl_package_constraint:
   loc:Location.t -> type_expr -> Types.type_declaration
 
@@ -59,14 +58,6 @@ val abstract_type_decl:
   params:Jkind.t list ->
   type_declaration
 
-||||||| 121bedcfd2
-val abstract_type_decl: injective:bool -> int -> type_declaration
-=======
-val transl_package_constraint:
-  loc:Location.t -> Env.t -> type_expr -> Types.type_declaration
-
-val abstract_type_decl: injective:bool -> int -> type_declaration
->>>>>>> 5.2.0
 val approx_type_decl:
     Parsetree.type_declaration list -> (Ident.t * type_declaration) list
 val check_recmod_typedecl:

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -22,7 +22,6 @@
 *)
 
 open Asttypes
-module Uid = Shape.Uid
 
 (* We define a new constant type that can represent unboxed values.
    This is currently used only in [Typedtree], but the long term goal
@@ -119,23 +118,11 @@ and 'k pattern_desc =
   (* value patterns *)
   | Tpat_any : value pattern_desc
         (** _ *)
-<<<<<<< HEAD
   | Tpat_var : Ident.t * string loc * Uid.t * Mode.Value.l -> value pattern_desc
-||||||| 121bedcfd2
-  | Tpat_var : Ident.t * string loc -> value pattern_desc
-=======
-  | Tpat_var : Ident.t * string loc * Uid.t -> value pattern_desc
->>>>>>> 5.2.0
         (** x *)
   | Tpat_alias :
-<<<<<<< HEAD
       value general_pattern * Ident.t * string loc * Uid.t * Mode.Value.l
         -> value pattern_desc
-||||||| 121bedcfd2
-      value general_pattern * Ident.t * string loc -> value pattern_desc
-=======
-      value general_pattern * Ident.t * string loc * Uid.t -> value pattern_desc
->>>>>>> 5.2.0
         (** P as a *)
   | Tpat_constant : constant -> value pattern_desc
         (** 1, 'a', "true", 1.0, 1l, 1L, 1n *)
@@ -269,7 +256,6 @@ and expression_desc =
         (** let P1 = E1 and ... and Pn = EN in E       (flag = Nonrecursive)
             let rec P1 = E1 and ... and Pn = EN in E   (flag = Recursive)
          *)
-<<<<<<< HEAD
   | Texp_function of
       { params : function_param list;
         body : function_body;
@@ -295,34 +281,6 @@ and expression_desc =
   | Texp_apply of
       expression * (arg_label * apply_arg) list * apply_position *
         Mode.Locality.l * Zero_alloc_utils.Assume_info.t
-||||||| 121bedcfd2
-  | Texp_function of { arg_label : arg_label; param : Ident.t;
-      cases : value case list; partial : partial; }
-        (** [Pexp_fun] and [Pexp_function] both translate to [Texp_function].
-            See {!Parsetree} for more details.
-
-            [param] is the identifier that is to be used to name the
-            parameter of the function.
-
-            partial =
-              [Partial] if the pattern match is partial
-              [Total] otherwise.
-         *)
-  | Texp_apply of expression * (arg_label * expression option) list
-=======
-  | Texp_function of function_param list * function_body
-    (** fun P0 P1 -> function p1 -> e1 | p2 -> e2  (body = Tfunction_cases _)
-        fun P0 P1 -> E                             (body = Tfunction_body _)
-
-        This construct has the same arity as the originating
-        {{!Parsetree.expression_desc.Pexp_function}[Pexp_function]}.
-        Arity determines when side-effects for effectful parameters are run
-        (e.g. optional argument defaults, matching against lazy patterns).
-        Parameters' effects are run left-to-right when an n-ary function is
-        saturated with n arguments.
-    *)
-  | Texp_apply of expression * (arg_label * expression option) list
->>>>>>> 5.2.0
         (** E0 ~l1:E1 ... ~ln:En
 
             The expression can be Omitted if the expression is abstracted over
@@ -573,54 +531,6 @@ and 'k case =
      c_rhs: expression;
     }
 
-and function_param =
-  {
-    fp_arg_label: arg_label;
-    fp_param: Ident.t;
-    (** [fp_param] is the identifier that is to be used to name the
-        parameter of the function.
-    *)
-    fp_partial: partial;
-    (**
-       [fp_partial] =
-       [Partial] if the pattern match is partial
-       [Total] otherwise.
-    *)
-    fp_kind: function_param_kind;
-    fp_newtypes: string loc list;
-      (** [fp_newtypes] are the new type declarations that come *after* that
-          parameter. The newtypes that come before the first parameter are
-          placed as exp_extras on the Texp_function node. This is just used in
-          {!Untypeast}. *)
-    fp_loc: Location.t;
-      (** [fp_loc] is the location of the entire value parameter, not including
-          the [fp_newtypes].
-      *)
-  }
-
-and function_param_kind =
-  | Tparam_pat of pattern
-  (** [Tparam_pat p] is a non-optional argument with pattern [p]. *)
-  | Tparam_optional_default of pattern * expression
-  (** [Tparam_optional_default (p, e)] is an optional argument [p] with default
-      value [e], i.e. [?x:(p = e)]. If the parameter is of type [a option], the
-      pattern and expression are of type [a]. *)
-
-and function_body =
-  | Tfunction_body of expression
-  | Tfunction_cases of
-      { cases: value case list;
-        partial: partial;
-        param: Ident.t;
-        loc: Location.t;
-        exp_extra: exp_extra option;
-        attributes: attributes;
-        (** [attributes] is just used in untypeast. *)
-      }
-(** The function body binds a final argument in [Tfunction_cases],
-    and this argument is pattern-matched against the cases.
-*)
-
 and record_label_definition =
   | Kept of Types.type_expr * Types.mutability * unique_use
   | Overridden of Longident.t loc * expression
@@ -789,13 +699,8 @@ and value_binding =
   {
     vb_pat: pattern;
     vb_expr: expression;
-<<<<<<< HEAD
     vb_rec_kind: Value_rec_types.recursive_binding_kind;
     vb_sort: Jkind.sort;
-||||||| 121bedcfd2
-=======
-    vb_rec_kind: Value_rec_types.recursive_binding_kind;
->>>>>>> 5.2.0
     vb_attributes: attributes;
     vb_loc: Location.t;
   }
@@ -966,24 +871,14 @@ and core_type_desc =
   | Ttyp_constr of Path.t * Longident.t loc * core_type list
   | Ttyp_object of object_field list * closed_flag
   | Ttyp_class of Path.t * Longident.t loc * core_type list
-<<<<<<< HEAD
-  | Ttyp_alias of core_type * string option * Jkind.annotation option
-||||||| 121bedcfd2
-  | Ttyp_alias of core_type * string
-=======
-  | Ttyp_alias of core_type * string loc
->>>>>>> 5.2.0
+  | Ttyp_alias of core_type * string loc option * Jkind.annotation option
   | Ttyp_variant of row_field list * closed_flag * label list option
   | Ttyp_poly of (string * Jkind.annotation option) list * core_type
   | Ttyp_package of package_type
-<<<<<<< HEAD
+  | Ttyp_open of Path.t * Longident.t loc * core_type
   | Ttyp_call_pos
       (** [Ttyp_call_pos] represents the type of the value of a Position
           argument ([lbl:[%call_pos] -> ...]). *)
-||||||| 121bedcfd2
-=======
-  | Ttyp_open of Path.t * Longident.t loc * core_type
->>>>>>> 5.2.0
 
 and package_type = {
   pack_path : Path.t;
@@ -1047,16 +942,9 @@ and label_declaration =
     {
      ld_id: Ident.t;
      ld_name: string loc;
-<<<<<<< HEAD
      ld_uid: Uid.t;
      ld_mutable: Types.mutability;
      ld_modalities: Mode.Modality.Value.Const.t;
-||||||| 121bedcfd2
-     ld_mutable: mutable_flag;
-=======
-     ld_uid: Uid.t;
-     ld_mutable: mutable_flag;
->>>>>>> 5.2.0
      ld_type: core_type;
      ld_loc: Location.t;
      ld_attributes: attributes;
@@ -1066,15 +954,8 @@ and constructor_declaration =
     {
      cd_id: Ident.t;
      cd_name: string loc;
-<<<<<<< HEAD
      cd_uid: Uid.t;
      cd_vars: (string * Jkind.annotation option) list;
-||||||| 121bedcfd2
-     cd_vars: string loc list;
-=======
-     cd_uid: Uid.t;
-     cd_vars: string loc list;
->>>>>>> 5.2.0
      cd_args: constructor_arguments;
      cd_res: core_type option;
      cd_loc: Location.t;
@@ -1260,7 +1141,6 @@ val exists_pattern: (pattern -> bool) -> pattern -> bool
 
 val let_bound_idents: value_binding list -> Ident.t list
 val let_bound_idents_full:
-<<<<<<< HEAD
     value_binding list -> (Ident.t * string loc * Types.type_expr * Uid.t) list
 
 (* [let_bound_idents_with_modes_sorts_and_checks] finds all the idents in the
@@ -1279,12 +1159,6 @@ val let_bound_idents_with_modes_sorts_and_checks:
   value_binding list
   -> (Ident.t * (Location.t * Mode.Value.l * Jkind.sort) list
               * Builtin_attributes.zero_alloc_attribute) list
-||||||| 121bedcfd2
-    value_binding list -> (Ident.t * string loc * Types.type_expr) list
-=======
-    value_binding list ->
-    (Ident.t * string loc * Types.type_expr * Types.Uid.t) list
->>>>>>> 5.2.0
 
 (** Alpha conversion of patterns *)
 val alpha_pat:
@@ -1297,15 +1171,8 @@ val pat_bound_idents: 'k general_pattern -> Ident.t list
 val pat_bound_idents_with_types:
   'k general_pattern -> (Ident.t * Types.type_expr) list
 val pat_bound_idents_full:
-<<<<<<< HEAD
   Jkind.sort -> 'k general_pattern
   -> (Ident.t * string loc * Types.type_expr * Types.Uid.t * Jkind.sort) list
-||||||| 121bedcfd2
-  'k general_pattern -> (Ident.t * string loc * Types.type_expr) list
-=======
-  'k general_pattern ->
-  (Ident.t * string loc * Types.type_expr * Types.Uid.t) list
->>>>>>> 5.2.0
 
 (** Splits an or pattern into its value (left) and exception (right) parts. *)
 val split_pattern:

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -39,16 +39,8 @@ val type_toplevel_phrase:
   Typedtree.structure * Types.signature * Signature_names.t * Shape.t *
   Env.t
 val type_implementation:
-<<<<<<< HEAD
-  sourcefile:string -> string -> Compilation_unit.t -> Env.t ->
+  Unit_info.t -> Compilation_unit.t -> Env.t ->
   Parsetree.structure -> Typedtree.implementation
-||||||| 121bedcfd2
-  string -> string -> string -> Env.t ->
-  Parsetree.structure -> Typedtree.implementation
-=======
-  Unit_info.t -> Env.t -> Parsetree.structure ->
-  Typedtree.implementation
->>>>>>> 5.2.0
 val type_interface:
   sourcefile:string -> Compilation_unit.t -> Env.t ->
   Parsetree.signature -> Typedtree.signature
@@ -69,25 +61,12 @@ val modtype_of_package:
 val path_of_module : Typedtree.module_expr -> Path.t option
 
 val save_signature:
-<<<<<<< HEAD
-  Compilation_unit.t -> Typedtree.signature -> string -> string ->
+  Unit_info.t -> Compilation_unit.t -> Typedtree.signature ->
   Env.t -> Cmi_format.cmi_infos_lazy -> unit
-||||||| 121bedcfd2
-  string -> Typedtree.signature -> string -> string ->
-  Env.t -> Cmi_format.cmi_infos -> unit
-=======
-  Unit_info.t -> Typedtree.signature -> Env.t ->
-  Cmi_format.cmi_infos -> unit
->>>>>>> 5.2.0
 
 val package_units:
-<<<<<<< HEAD
-  Env.t -> string list -> string -> Compilation_unit.t -> Typedtree.module_coercion
-||||||| 121bedcfd2
-  Env.t -> string list -> string -> string -> Typedtree.module_coercion
-=======
-  Env.t -> string list -> Unit_info.Artifact.t -> Typedtree.module_coercion
->>>>>>> 5.2.0
+  Env.t -> string list -> Unit_info.Artifact.t -> Compilation_unit.t
+  -> Typedtree.module_coercion
 
 (* Should be in Envaux, but it breaks the build of the debugger *)
 val initial_env:

--- a/typing/typeopt.mli
+++ b/typing/typeopt.mli
@@ -34,7 +34,6 @@ val array_pattern_kind :
   Typedtree.pattern -> Jkind.Sort.t -> Lambda.array_kind
 val bigarray_type_kind_and_layout :
       Env.t -> Types.type_expr -> Lambda.bigarray_kind * Lambda.bigarray_layout
-<<<<<<< HEAD
 
 (* CR layouts v7: [layout], [function_return_layout], [function2_return_layout],
    and [layout_of_sort] have had location arguments added just to support the
@@ -67,12 +66,7 @@ val function2_return_layout :
 val function_arg_layout :
   Env.t -> Location.t -> Jkind.sort -> Types.type_expr -> Lambda.layout
 
-||||||| 121bedcfd2
 val value_kind : Env.t -> Types.type_expr -> Lambda.value_kind
-val function_return_value_kind : Env.t -> Types.type_expr -> Lambda.value_kind
-=======
-val value_kind : Env.t -> Types.type_expr -> Lambda.value_kind
->>>>>>> 5.2.0
 
 val classify_lazy_argument : Typedtree.expression ->
                              [ `Constant_or_function

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -537,18 +537,11 @@ type type_declaration =
 and type_decl_kind = (label_declaration, constructor_declaration) type_kind
 
 and ('lbl, 'cstr) type_kind =
-<<<<<<< HEAD
     Type_abstract of abstract_reason
-||||||| 121bedcfd2
-    Type_abstract
-=======
-    Type_abstract of type_origin
->>>>>>> 5.2.0
   | Type_record of 'lbl list  * record_representation
   | Type_variant of 'cstr list * variant_representation
   | Type_open
 
-<<<<<<< HEAD
 (* CR layouts: after removing the void translation from lambda, we could get rid of
    this src_index / runtime_tag distinction.  But I am leaving it in because it
    may not be long before we need it again.
@@ -567,6 +560,7 @@ and tag = Ordinary of {src_index: int;  (* Unique name (per type) *)
 and abstract_reason =
     Abstract_def
   | Abstract_rec_check_regularity       (* See Typedecl.transl_type_decl *)
+  | Abstract_existential
 
 (* A mixed product contains a possibly-empty prefix of values followed by a
    non-empty suffix of "flat" elements. Intuitively, a flat element is one that
@@ -588,14 +582,6 @@ and mixed_product_shape =
     flat_suffix : flat_element array;
   }
 
-||||||| 121bedcfd2
-=======
-and type_origin =
-    Definition
-  | Rec_check_regularity       (* See Typedecl.transl_type_decl *)
-  | Existential of string
-
->>>>>>> 5.2.0
 and record_representation =
   | Record_unboxed
   | Record_inlined of tag * variant_representation


### PR DESCRIPTION
For @ncik-roberts 

I'm reasonably confident about the `Unit_info` changes here.  (See note on https://github.com/ocaml-flambda/flambda-backend/wiki/Strategy-for-5.2.0-Unit_info-and-compunit regarding functions with juxtaposed `Unit_info` and `Compilation_unit` parameters.)

I need to do a bit more work on `typedtree.mli`.