### PR TITLE
Make ocamltest build

### DIFF
--- a/ocamltest/OCAMLTEST.org
+++ b/ocamltest/OCAMLTEST.org
@@ -581,19 +581,9 @@ namely:
 *)
 #+end_src
 
-<<<<<<< HEAD:ocamltest/ocamltest.org
-The braces make explicit the scope of variable assignments: an
-assignement modifies a variable for the rest of its block and for all
-sub-blocks (unless overridden at some point).
-||||||| 121bedcfd2:ocamltest/ocamltest.org
-The fact that the language is inspired by org-mode should also be
-helpful in understanding the scope of variable assignments. Roughly
-speaking:
-=======
 The braces make explicit the scope of variable assignments: an
 assignment modifies a variable for the rest of its block and for all
 sub-blocks (unless overridden at some point).
->>>>>>> 5.2.0:ocamltest/OCAMLTEST.org
 
 For instance, given the following blocks:
 #+begin_src

--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -218,23 +218,6 @@ let frame_pointers = make
      "frame-pointers available"
      "frame-pointers not available")
 
-<<<<<<< HEAD
-let probes = make
-  ~name:"probes"
-  ~description:"Pass if probes are available"
-  (Actions_helpers.pass_or_skip (Ocamltest_config.probes)
-     "Target supports probes"
-     "Target does not support probes")
-
-let naked_pointers = make
-  ~name:"naked_pointers"
-  ~description:"[BACKPORT] Pass if the runtime system supports naked pointers"
-  (Actions_helpers.pass_or_skip (Ocamltest_config.naked_pointers)
-     "Runtime system supports naked pointers"
-     "Runtime system does not support naked pointers")
-
-||||||| 121bedcfd2
-=======
 let tsan = make
   ~name:"tsan"
   ~description:"Pass if thread sanitizer is supported"
@@ -249,7 +232,20 @@ let no_tsan = make
      "tsan not available"
      "tsan available")
 
->>>>>>> 5.2.0
+let probes = make
+  ~name:"probes"
+  ~description:"Pass if probes are available"
+  (Actions_helpers.pass_or_skip (Ocamltest_config.probes)
+     "Target supports probes"
+     "Target does not support probes")
+
+let naked_pointers = make
+  ~name:"naked_pointers"
+  ~description:"[BACKPORT] Pass if the runtime system supports naked pointers"
+  (Actions_helpers.pass_or_skip (Ocamltest_config.naked_pointers)
+     "Runtime system supports naked pointers"
+     "Runtime system does not support naked pointers")
+
 let has_symlink = make
   ~name:"has_symlink"
   ~description:"Pass if symbolic links are available"
@@ -387,12 +383,8 @@ let _ =
     naked_pointers;
     file_exists;
     copy;
-<<<<<<< HEAD
-    probes;
-    naked_pointers
-||||||| 121bedcfd2
-=======
     tsan;
     no_tsan;
->>>>>>> 5.2.0
+    probes;
+    naked_pointers
   ]

--- a/ocamltest/dune
+++ b/ocamltest/dune
@@ -32,9 +32,7 @@
  (name ocamltest_core_and_plugin)
  (modes byte)
  (wrapped false)
- (flags
-  (:standard -nostdlib))
- (libraries ocamlcommon stdlib unix)
+ (libraries ocamlcommon unix)
  (modules
   (:standard \ options main ocamltest_unix_dummy ocamltest_unix_real))
  (foreign_stubs

--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -20,35 +20,9 @@ open Tsl_ast
 open Tsl_semantics
 
 type behavior =
-<<<<<<< HEAD
-  | Skip_all_tests
-  | Run of Environments.t
-
-||||||| 121bedcfd2
-  | Skip_all_tests
-  | Run of Environments.t
-
-(*
-let first_token filename =
-  let input_channel = open_in filename in
-  let lexbuf = Lexing.from_channel input_channel in
-  Location.init lexbuf filename;
-  let token =
-    try Tsl_lexer.token lexbuf with e -> close_in input_channel; raise e
-  in close_in input_channel; token
-
-let is_test filename =
-  match first_token filename with
-    | exception _ -> false
-    | Tsl_parser.TSL_BEGIN_C_STYLE | TSL_BEGIN_OCAML_STYLE -> true
-    | _ -> false
-*)
-
-=======
   | Skip_all
   | Run
 
->>>>>>> 5.2.0
 (* this primitive announce should be used for tests
    that were aborted on system error before ocamltest
    could parse them *)
@@ -56,13 +30,6 @@ let announce_test_error test_filename error =
   Printf.printf " ... testing '%s' => unexpected error (%s)\n%!"
     (Filename.basename test_filename) error
 
-<<<<<<< HEAD
-exception Syntax_error of Lexing.position
-
-let tsl_parse_file test_filename =
-||||||| 121bedcfd2
-let tsl_block_of_file test_filename =
-=======
 let print_exn loc e =
   let open Printf in
   let locstring =
@@ -92,7 +59,6 @@ let print_exn loc e =
 exception Syntax_error of Lexing.position
 
 let tsl_parse_file test_filename =
->>>>>>> 5.2.0
   let input_channel = open_in test_filename in
   let lexbuf = Lexing.from_channel input_channel in
   Location.init lexbuf test_filename;
@@ -206,22 +172,10 @@ let extract_rootenv (Ast (stmts, subs)) =
 let test_file test_filename =
   let start = if Options.show_timings then Unix.gettimeofday () else 0.0 in
   let skip_test = List.mem test_filename !tests_to_skip in
-<<<<<<< HEAD
-  let tsl_ast = tsl_parse_file_safe test_filename in
-  let (rootenv_statements, test_trees) = test_trees_of_tsl_ast tsl_ast in
-  let test_trees = match test_trees with
-    | [] ->
-||||||| 121bedcfd2
-  let tsl_block = tsl_block_of_file_safe test_filename in
-  let (rootenv_statements, test_trees) = test_trees_of_tsl_block tsl_block in
-  let test_trees = match test_trees with
-    | [] ->
-=======
   let tsl_ast = tsl_parse_file_safe test_filename in
   let (rootenv_statements, tsl_ast) = extract_rootenv tsl_ast in
   let tsl_ast = match tsl_ast with
     | Ast ([], []) ->
->>>>>>> 5.2.0
       let default_tests = Tests.default_tests() in
       let make_tree test =
         let id = make_identifier test.Tests.test_name in

--- a/ocamltest/ocamltest_config.ml.in
+++ b/ocamltest/ocamltest_config.ml.in
@@ -86,13 +86,7 @@ let exe = {@QS@|@exeext@|@QS@}
 let mkdll = {@QS@|@mkdll_exp@|@QS@}
 let mkexe = {@QS@|@mkexe_exp@|@QS@}
 
-<<<<<<< HEAD
-let bytecc_libs = {@QS@|@cclibs@|@QS@}
-||||||| 121bedcfd2
-let bytecc_libs = {@QS@|@bytecclibs@|@QS@}
-=======
 let bytecc_libs = {@QS@|@zstd_libs@ @cclibs@|@QS@}
->>>>>>> 5.2.0
 
 let nativecc_libs = {@QS@|@cclibs@|@QS@}
 
@@ -103,7 +97,6 @@ let function_sections = @function_sections@
 let instrumented_runtime = @instrumented_runtime@
 
 let frame_pointers = @frame_pointers@
-<<<<<<< HEAD
 
 let probes = @probes@
 
@@ -112,8 +105,5 @@ let stack_allocation = @stack_allocation@
 let poll_insertion = @poll_insertion@
 
 let naked_pointers = @naked_pointers@
-||||||| 121bedcfd2
-=======
 
 let tsan = @tsan@
->>>>>>> 5.2.0

--- a/ocamltest/ocamltest_config.mli
+++ b/ocamltest/ocamltest_config.mli
@@ -145,13 +145,9 @@ val poll_insertion : bool
 
 val frame_pointers : bool
 (** Whether frame-pointers have been enabled at configure time *)
-<<<<<<< HEAD
-
-val naked_pointers : bool
-(** Whether the runtime system supports naked pointers outside the heap *)
-||||||| 121bedcfd2
-=======
 
 val tsan : bool
 (** Whether ThreadSanitizer support has been enabled at configure time *)
->>>>>>> 5.2.0
+
+val naked_pointers : bool
+(** Whether the runtime system supports naked pointers outside the heap *)

--- a/ocamltest/tsl_ast.ml
+++ b/ocamltest/tsl_ast.ml
@@ -35,20 +35,8 @@ type tsl_item =
 
 type tsl_block = tsl_item list
 
-<<<<<<< HEAD
 type t = Ast of tsl_item list * t list
 
-||||||| 121bedcfd2
-=======
-type t = Ast of tsl_item list * t list
-
-let rec split_env l =
-  match l with
-  | Environment_statement env :: tl ->
-    let (env2, rest) = split_env tl in (env :: env2, rest)
-  | _ -> ([], l)
-
->>>>>>> 5.2.0
 let make ?(loc = Location.none) foo = { node = foo; loc = loc }
 
 let make_identifier = make

--- a/ocamltest/tsl_ast.mli
+++ b/ocamltest/tsl_ast.mli
@@ -36,18 +36,9 @@ type tsl_item =
 
 type tsl_block = tsl_item list
 
-<<<<<<< HEAD
 (* New syntax *)
 type t = Ast of tsl_item list * t list
 
-||||||| 121bedcfd2
-=======
-(* New syntax *)
-type t = Ast of tsl_item list * t list
-val split_env :
-  tsl_item list -> environment_statement located list * tsl_item list
-
->>>>>>> 5.2.0
 val make_identifier : ?loc:Location.t -> string -> string located
 val make_string : ?loc:Location.t -> string -> string located
 val make_environment_statement :

--- a/ocamltest/tsl_semantics.ml
+++ b/ocamltest/tsl_semantics.ml
@@ -97,17 +97,6 @@ let lookup_test located_name =
     end
   | Some test -> test
 
-let lookup_test located_name =
-  let name = located_name.node in
-  match Tests.lookup name with
-  | None ->
-    begin match Actions.lookup name with
-    | None -> no_such_test_or_action located_name
-    | Some action ->
-      Tests.test_of_action action
-    end
-  | Some test -> test
-
 let test_trees_of_tsl_block tsl_block =
   let rec env_of_lines = function
     | [] -> ([], [])
@@ -174,31 +163,6 @@ let actions_in_tests tests =
   let f test action_set =
     Actions.ActionSet.union (actions_in_test test) action_set in
   Tests.TestSet.fold f tests Actions.ActionSet.empty
-<<<<<<< HEAD
-
-let rec split_env l =
-  match l with
-  | Environment_statement env :: tl ->
-    let (env2, rest) = split_env tl in (env :: env2, rest)
-  | _ -> ([], l)
-
-let rec test_trees_of_tsl_ast (Ast (seq, subs)) =
-  let (env, rest) = split_env seq in
-  let trees =
-    match rest with
-    | [] -> List.map test_tree_of_tsl_ast subs
-    | [ Test (_, name, mods) ] ->
-      [Node ([], lookup_test name, mods, List.map test_tree_of_tsl_ast subs)]
-    | Test (_, name, mods) :: seq1 ->
-      let sub = test_tree_of_tsl_ast (Ast (seq1, subs)) in
-      [Node ([], lookup_test name, mods, [sub])]
-    | Environment_statement _ :: _ -> assert false
-  in (env, trees)
-
-and test_tree_of_tsl_ast ast =
-  match test_trees_of_tsl_ast ast with
-  | (env, [Node (env1, t, m, s)]) -> Node (env @ env1, t, m, s)
-  | (env, trees) -> Node (env, Tests.null, [], trees)
 
 let rec ast_of_tree (Node (env, test, mods, subs)) =
   let tst = [Test (0, Tsl_ast.make_identifier test.Tests.test_name, mods)] in
@@ -265,72 +229,3 @@ let print_tsl_ast ~compact oc ast =
       pr "%sunset %s;\n" indent ls.node;
   in
   print_ast " " ast;
-||||||| 121bedcfd2
-=======
-
-let rec ast_of_tree (Node (env, test, mods, subs)) =
-  let tst = [Test (0, Tsl_ast.make_identifier test.Tests.test_name, mods)] in
-  ast_of_tree_aux env tst subs
-
-and ast_of_tree_aux env tst subs =
-  let env = List.map (fun x -> Environment_statement x) env in
-  match List.map ast_of_tree subs with
-  | [ Ast (stmts, subs) ] -> Ast (env @ tst @ stmts, subs)
-  | asts -> Ast (env @ tst, asts)
-
-let tsl_ast_of_test_trees (env, trees) = ast_of_tree_aux env [] trees
-
-open Printf
-
-let print_tsl_ast ~compact oc ast =
-  let pr fmt (*args*) = fprintf oc fmt (*args*) in
-
-  let rec print_ast indent (Ast (stmts, subs)) =
-    print_statements indent stmts;
-    print_forest indent subs;
-
-  and print_sub indent ast =
-    pr "{\n";
-    print_ast (indent ^ "  ") ast;
-    pr "%s}" indent;
-
-  and print_statements indent stmts =
-    match stmts with
-    | Test (_, name, mods) :: tl ->
-      pr "%s%s" indent name.node;
-      begin match mods with
-      | m :: tl ->
-        pr " with %s" m.node;
-        List.iter (fun m -> pr ", %s" m.node) tl;
-      | [] -> ()
-      end;
-      pr ";\n";
-      if tl <> [] && not compact then pr "\n";
-      print_statements indent tl;
-    | Environment_statement env :: tl->
-      print_env indent env;
-      print_statements indent tl;
-    | [] -> ()
-
-  and print_forest indent subs =
-    if subs <> [] then begin
-      pr "%s" indent;
-      List.iter (print_sub indent) subs;
-      pr "\n";
-    end
-
-  and print_env indent e =
-    match e.node with
-    | Assignment (set, variable, value) ->
-      pr "%s" indent;
-      if set then pr "set ";
-      pr "%s = \"%s\";\n" variable.node value.node;
-    | Append (variable, value) ->
-      pr "%s%s += \"%s\";\n" indent variable.node value.node;
-    | Include ls ->
-      pr "%sinclude %s;\n" indent ls.node;
-    | Unset ls ->
-      pr "%sunset %s;\n" indent ls.node;
-  in
-  print_ast " " ast;
->>>>>>> 5.2.0

--- a/ocamltest/tsl_semantics.mli
+++ b/ocamltest/tsl_semantics.mli
@@ -37,35 +37,14 @@ val test_trees_of_tsl_block :
   Tsl_ast.tsl_item list ->
   Tsl_ast.environment_statement located list * test_tree list
 
-<<<<<<< HEAD
-val test_trees_of_tsl_ast :
-  Tsl_ast.t ->
-  Tsl_ast.environment_statement located list * test_tree list
-
 val tsl_ast_of_test_trees :
   Tsl_ast.environment_statement located list * test_tree list ->
   Tsl_ast.t
-
-val tests_in_tree : test_tree -> Tests.TestSet.t
-||||||| 121bedcfd2
-val tests_in_tree : test_tree -> Tests.TestSet.t
-=======
-val tsl_ast_of_test_trees :
-  Tsl_ast.environment_statement located list * test_tree list ->
-  Tsl_ast.t
->>>>>>> 5.2.0
 
 val tests_in_tree : Tsl_ast.t -> Tests.TestSet.t
 
 val actions_in_test : Tests.t -> Actions.ActionSet.t
 
 val actions_in_tests : Tests.TestSet.t -> Actions.ActionSet.t
-<<<<<<< HEAD
-
 
 val print_tsl_ast : compact:bool -> out_channel -> Tsl_ast.t -> unit
-||||||| 121bedcfd2
-=======
-
-val print_tsl_ast : compact:bool -> out_channel -> Tsl_ast.t -> unit
->>>>>>> 5.2.0


### PR DESCRIPTION
The only notable thing here is that upstream ocamltest now seems to have an explicit stdlib dependency.  I've removed that in this PR so that it can be built using the boot compiler and its stdlib.  (We don't currently require that in flambda-backend I don't think, but it would be useful for this to be possible in future, so tests could be run on the first stage compiler in the event of a suspected miscompilation of the compiler.)