### PR TITLE
Revert "Get rid of the LongString module (#12360)" (allows building with 4.14.x)

### DIFF
--- a/.depend
+++ b/.depend
@@ -3021,6 +3021,7 @@ bytecomp/symtable.cmx : \
 >>>>>>> 5.2.0
     bytecomp/symtable.cmi
 bytecomp/symtable.cmi : \
+    utils/misc.cmi \
     lambda/lambda.cmi \
     utils/import_info.cmi \
     typing/ident.cmi \

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -289,14 +289,7 @@ let debug_info = ref ([] : (int * Instruct.debug_event list * string list) list)
 let link_compunit output_fun currpos_fun inchan file_name compunit =
   check_consistency file_name compunit;
   seek_in inchan compunit.cu_pos;
-  let code_block =
-    Bigarray.Array1.create Bigarray.Char Bigarray.c_layout compunit.cu_codesize
-  in
-  match
-    In_channel.really_input_bigarray inchan code_block 0 compunit.cu_codesize
-  with
-    | None -> raise End_of_file
-    | Some () -> ();
+  let code_block = LongString.input_bytes inchan compunit.cu_codesize in
   Symtable.patch_object code_block compunit.cu_reloc;
   if !Clflags.debug && compunit.cu_debug > 0 then begin
     seek_in inchan compunit.cu_debug;
@@ -311,7 +304,7 @@ let link_compunit output_fun currpos_fun inchan file_name compunit =
       else file_path :: debug_dirs in
     debug_info := (currpos_fun(), debug_event_list, debug_dirs) :: !debug_info
   end;
-  output_fun code_block;
+  Array.iter output_fun code_block;
   if !Clflags.link_everything then
     List.iter Symtable.require_primitive compunit.cu_primitives
 
@@ -585,8 +578,7 @@ let link_bytecode ?final_name tolink exec_name standalone =
          try Dll.open_dlls Dll.For_checking sharedobjs
          with Failure reason -> raise(Error(Cannot_open_dll reason))
        end;
-       let output_fun buf =
-         Out_channel.output_bigarray outchan buf 0 (Bigarray.Array1.dim buf)
+       let output_fun = output_bytes outchan
        and currpos_fun () = pos_out outchan - start_code in
        List.iter (link_file output_fun currpos_fun) tolink;
        if check_dlls then Dll.close_all_dlls();
@@ -632,12 +624,12 @@ let output_code_string_counter = ref 0
 
 let output_code_string outchan code =
   let pos = ref 0 in
-  let len = Bigarray.Array1.dim code in
+  let len = Bytes.length code in
   while !pos < len do
-    let c1 = Char.code(Bigarray.Array1.get code !pos) in
-    let c2 = Char.code(Bigarray.Array1.get code (!pos + 1)) in
-    let c3 = Char.code(Bigarray.Array1.get code (!pos + 2)) in
-    let c4 = Char.code(Bigarray.Array1.get code (!pos + 3)) in
+    let c1 = Char.code(Bytes.get code !pos) in
+    let c2 = Char.code(Bytes.get code (!pos + 1)) in
+    let c3 = Char.code(Bytes.get code (!pos + 2)) in
+    let c4 = Char.code(Bytes.get code (!pos + 3)) in
     pos := !pos + 4;
     Printf.fprintf outchan "0x%02x%02x%02x%02x, " c4 c3 c2 c1;
     incr output_code_string_counter;
@@ -720,7 +712,7 @@ let link_bytecode_as_c tolink outfile with_main =
        let currpos = ref 0 in
        let output_fun code =
          output_code_string outchan code;
-         currpos := !currpos + (Bigarray.Array1.dim code)
+         currpos := !currpos + Bytes.length code
        and currpos_fun () = !currpos in
        List.iter (link_file output_fun currpos_fun) tolink;
        (* The final STOP instruction *)

--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -49,30 +49,24 @@ let () =
     )
 
 (* Buffering of bytecode *)
-let create_bigarray = Bigarray.Array1.create Bigarray.Char Bigarray.c_layout
-
-let copy_bigarray src dst size =
-  Bigarray.Array1.(blit (sub src 0 size) (sub dst 0 size))
-
-let out_buffer = ref(create_bigarray 0)
+let out_buffer = ref(LongString.create 0)
 and out_position = ref 0
 
 let extend_buffer needed =
-  let size = Bigarray.Array1.dim !out_buffer in
+  let size = LongString.length !out_buffer in
   let new_size = ref(max size 16) (* we need new_size > 0 *) in
   while needed >= !new_size do new_size := 2 * !new_size done;
-  let new_buffer = create_bigarray !new_size in
-  copy_bigarray !out_buffer new_buffer size;
+  let new_buffer = LongString.create !new_size in
+  LongString.blit !out_buffer 0 new_buffer 0 (LongString.length !out_buffer);
   out_buffer := new_buffer
 
 let out_word b1 b2 b3 b4 =
   let p = !out_position in
-  let open Bigarray.Array1 in
-  if p+3 >= dim !out_buffer then extend_buffer (p+3);
-  set !out_buffer p (Char.unsafe_chr b1);
-  set !out_buffer (p+1) (Char.unsafe_chr b2);
-  set !out_buffer (p+2) (Char.unsafe_chr b3);
-  set !out_buffer (p+3) (Char.unsafe_chr b4);
+  if p+3 >= LongString.length !out_buffer then extend_buffer (p+3);
+  LongString.set !out_buffer p (Char.unsafe_chr b1);
+  LongString.set !out_buffer (p+1) (Char.unsafe_chr b2);
+  LongString.set !out_buffer (p+2) (Char.unsafe_chr b3);
+  LongString.set !out_buffer (p+3) (Char.unsafe_chr b4);
   out_position := p + 4
 
 let out opcode =
@@ -122,11 +116,10 @@ let extend_label_table needed =
 
 let backpatch (pos, orig) =
   let displ = (!out_position - orig) asr 2 in
-  let open Bigarray.Array1 in
-  set !out_buffer pos (Char.unsafe_chr displ);
-  set !out_buffer (pos+1) (Char.unsafe_chr (displ asr 8));
-  set !out_buffer (pos+2) (Char.unsafe_chr (displ asr 16));
-  set !out_buffer (pos+3) (Char.unsafe_chr (displ asr 24))
+  LongString.set !out_buffer pos (Char.unsafe_chr displ);
+  LongString.set !out_buffer (pos+1) (Char.unsafe_chr (displ asr 8));
+  LongString.set !out_buffer (pos+2) (Char.unsafe_chr (displ asr 16));
+  LongString.set !out_buffer (pos+3) (Char.unsafe_chr (displ asr 24))
 
 let define_label lbl =
   if lbl >= Array.length !label_table then extend_label_table lbl;
@@ -204,12 +197,12 @@ let clear() =
   reloc_info := [];
   debug_dirs := String.Set.empty;
   events := [];
-  out_buffer := create_bigarray 0
+  out_buffer := LongString.create 0
 
 let init () =
   clear ();
   label_table := Array.make 16 (Label_undefined []);
-  out_buffer := create_bigarray 1024
+  out_buffer := LongString.create 1024
 
 (* Emission of one instruction *)
 
@@ -435,7 +428,7 @@ let to_file outchan artifact_info ~required_globals code =
   output_binary_int outchan 0;
   let pos_code = pos_out outchan in
   emit code;
-  Out_channel.output_bigarray outchan !out_buffer 0 !out_position;
+  LongString.output outchan !out_buffer 0 !out_position;
   let (pos_debug, size_debug) =
     if !Clflags.debug then begin
       let filename = Unit_info.Artifact.filename artifact_info in
@@ -504,8 +497,8 @@ let to_memory instrs =
   init();
   Fun.protect ~finally:clear (fun () ->
   emit instrs;
-  let code = create_bigarray !out_position in
-  copy_bigarray !out_buffer code !out_position;
+  let code = LongString.create !out_position in
+  LongString.blit !out_buffer 0 code 0 !out_position;
   let reloc = List.rev !reloc_info in
   let events = !events in
   (code, reloc, events))
@@ -516,7 +509,7 @@ let to_packed_file outchan code =
   init ();
   Fun.protect ~finally:clear (fun () ->
   emit code;
-  Out_channel.output_bigarray outchan !out_buffer 0 !out_position;
+  LongString.output outchan !out_buffer 0 !out_position;
   let reloc = List.rev !reloc_info in
   let events = !events in
   let debug_dirs = !debug_dirs in

--- a/bytecomp/emitcode.mli
+++ b/bytecomp/emitcode.mli
@@ -29,8 +29,7 @@ val to_file: out_channel -> Compilation_unit.t -> Unit_info.Artifact.t ->
              list of instructions to emit *)
 val to_memory:
   instruction list ->
-    (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t *
-    (reloc_info * int) list * debug_event list
+    Misc.LongString.t * (reloc_info * int) list * debug_event list
         (* Arguments:
              initialization code (terminated by STOP)
              function code

--- a/bytecomp/meta.ml
+++ b/bytecomp/meta.ml
@@ -18,14 +18,8 @@ external realloc_global_data : int -> unit = "caml_realloc_global"
 type closure = unit -> Obj.t
 type bytecode
 external reify_bytecode :
-<<<<<<< HEAD
-  bytes array -> Debug_event.debug_event list array -> string option ->
-||||||| 121bedcfd2
-  bytes array -> Instruct.debug_event list array -> string option ->
-=======
-  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
+  bytes array ->
   Instruct.debug_event list array -> string option ->
->>>>>>> 5.2.0
     bytecode * closure
                            = "caml_reify_bytecode"
 external release_bytecode : bytecode -> unit

--- a/bytecomp/meta.mli
+++ b/bytecomp/meta.mli
@@ -20,7 +20,7 @@ external realloc_global_data : int -> unit = "caml_realloc_global"
 type closure = unit -> Obj.t
 type bytecode
 external reify_bytecode :
-  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
+  bytes array ->
   Debug_event.debug_event list array -> string option ->
     bytecode * closure
                            = "caml_reify_bytecode"

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -300,11 +300,10 @@ let init () =
 (* Relocate a block of object bytecode *)
 
 let patch_int buff pos n =
-  let open Bigarray.Array1 in
-  set buff pos (Char.unsafe_chr n);
-  set buff (pos + 1) (Char.unsafe_chr (n asr 8));
-  set buff (pos + 2) (Char.unsafe_chr (n asr 16));
-  set buff (pos + 3) (Char.unsafe_chr (n asr 24))
+  LongString.set buff pos (Char.unsafe_chr n);
+  LongString.set buff (pos + 1) (Char.unsafe_chr (n asr 8));
+  LongString.set buff (pos + 2) (Char.unsafe_chr (n asr 16));
+  LongString.set buff (pos + 3) (Char.unsafe_chr (n asr 24))
 
 let patch_object buff patchlist =
   List.iter

--- a/bytecomp/symtable.mli
+++ b/bytecomp/symtable.mli
@@ -37,9 +37,7 @@ end
 (* Functions for batch linking *)
 
 val init: unit -> unit
-val patch_object:
-  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
-  (reloc_info * int) list -> unit
+val patch_object: Misc.LongString.t -> (reloc_info * int) list -> unit
 val require_primitive: string -> unit
 val initial_global_table: unit -> Obj.t array
 val output_global_map: out_channel -> unit

--- a/otherlibs/dynlink/byte/dynlink.ml
+++ b/otherlibs/dynlink/byte/dynlink.ml
@@ -171,21 +171,13 @@ module Bytecode = struct
       Fun.protect f
         ~finally:(fun () -> Mutex.unlock lock)
 
-  let really_input_bigarray ic ar st n =
-    match In_channel.really_input_bigarray ic ar st n with
-      | None -> raise End_of_file
-      | Some () -> ()
-
   let run lock (ic, file_name, file_digest) ~unit_header ~priv =
+    let open Misc in
     let clos = with_lock lock (fun () ->
         let old_state = Symtable.current_state () in
         let compunit : Cmo_format.compilation_unit_descr = unit_header in
         seek_in ic compunit.cu_pos;
-        let code =
-          Bigarray.Array1.create Bigarray.Char Bigarray.c_layout
-            compunit.cu_codesize
-        in
-        really_input_bigarray ic code 0 compunit.cu_codesize;
+        let code = LongString.input_bytes ic compunit.cu_codesize in
         begin try
           Symtable.patch_object code compunit.cu_reloc;
           Symtable.check_global_initialized compunit.cu_reloc;

--- a/runtime/meta.c
+++ b/runtime/meta.c
@@ -20,7 +20,6 @@
 #include <string.h>
 #include "caml/alloc.h"
 #include "caml/backtrace_prim.h"
-#include "caml/bigarray.h"
 #include "caml/codefrag.h"
 #include "caml/config.h"
 #include "caml/debugger.h"
@@ -121,16 +120,28 @@ CAMLprim value caml_reify_bytecode(value ls_prog,
   CAMLparam3(ls_prog, debuginfo, digest_opt);
   CAMLlocal3(clos, bytecode, retval);
   code_t prog;
-  asize_t len; /* in bytes */
+  asize_t len, off; /* in bytes */
   enum digest_status digest_kind;
   unsigned char * digest;
-  int fragnum;
+  int fragnum, i;
 
-  len = caml_ba_byte_size(Caml_ba_array_val(ls_prog));
-
+  /* ls_prog is a bytes array (= LongString.t) */
+  len = 0;
+  for (i = 0; i < Wosize_val(ls_prog); i++) {
+    value s = Field(ls_prog, i);
+    len += caml_string_length(s);
+  }
   prog = caml_stat_alloc(len + sizeof(opcode_t) * 2 /* for 'RETURN 1' */);
 
-  memcpy(prog, Caml_ba_data_val(ls_prog), len);
+  off = 0;
+  for (i = 0; i < Wosize_val(ls_prog); i++) {
+    size_t s_len;
+    value s = Field(ls_prog, i);
+    s_len = caml_string_length(s);
+    memcpy((char*)prog + off, Bytes_val(s), s_len);
+    off += s_len;
+  }
+
 #ifdef ARCH_BIG_ENDIAN
   caml_fixup_endianness(prog, len);
 #endif

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
@@ -5,9 +5,19 @@ Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from Test10_plugin.g in file "test10_plugin.ml", line 3, characters 2-21
 Called from Test10_plugin.f in file "test10_plugin.ml", line 6, characters 2-6
 Called from Test10_plugin in file "test10_plugin.ml", line 10, characters 2-6
+<<<<<<< HEAD
 Called from Dynlink.Bytecode.run in file "otherlibs/dynlink/dynlink.ml", line 148, characters 16-25
 Re-raised at Dynlink.Bytecode.run in file "otherlibs/dynlink/dynlink.ml", line 150, characters 6-137
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 363, characters 13-56
+||||||| 4c3016f1a1 (Get rid of the LongString module (#12360))
+Called from Dynlink.Bytecode.run in file "byte/dynlink.ml", line 154, characters 16-25
+Re-raised at Dynlink.Bytecode.run in file "byte/dynlink.ml", line 156, characters 6-137
+Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 360, characters 11-54
+=======
+Called from Dynlink.Bytecode.run in file "byte/dynlink.ml", line 146, characters 16-25
+Re-raised at Dynlink.Bytecode.run in file "byte/dynlink.ml", line 148, characters 6-137
+Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 360, characters 11-54
+>>>>>>> parent of 4c3016f1a1 (Get rid of the LongString module (#12360))
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 359, characters 8-392
 Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 372, characters 8-17

--- a/toplevel/byte/topeval.ml
+++ b/toplevel/byte/topeval.ml
@@ -251,12 +251,7 @@ let check_consistency ppf filename cu =
 let load_compunit ic filename ppf compunit =
   check_consistency ppf filename compunit;
   seek_in ic compunit.cu_pos;
-  let code =
-    Bigarray.Array1.create Bigarray.Char Bigarray.c_layout compunit.cu_codesize
-  in
-  match In_channel.really_input_bigarray ic code 0 compunit.cu_codesize with
-    | None -> raise End_of_file
-    | Some () -> ();
+  let code = LongString.input_bytes ic compunit.cu_codesize in
   let initial_symtable = Symtable.current_state() in
   Symtable.patch_object code compunit.cu_reloc;
   Symtable.update_global_table();

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -712,6 +712,53 @@ let thd4 (_,_,x,_) = x
 let for4 (_,_,_,x) = x
 
 
+module LongString = struct
+  type t = bytes array
+
+  let create str_size =
+    let tbl_size = str_size / Sys.max_string_length + 1 in
+    let tbl = Array.make tbl_size Bytes.empty in
+    for i = 0 to tbl_size - 2 do
+      tbl.(i) <- Bytes.create Sys.max_string_length;
+    done;
+    tbl.(tbl_size - 1) <- Bytes.create (str_size mod Sys.max_string_length);
+    tbl
+
+  let length tbl =
+    let tbl_size = Array.length tbl in
+    Sys.max_string_length * (tbl_size - 1) + Bytes.length tbl.(tbl_size - 1)
+
+  let get tbl ind =
+    Bytes.get tbl.(ind / Sys.max_string_length) (ind mod Sys.max_string_length)
+
+  let set tbl ind c =
+    Bytes.set tbl.(ind / Sys.max_string_length) (ind mod Sys.max_string_length)
+              c
+
+  let blit src srcoff dst dstoff len =
+    for i = 0 to len - 1 do
+      set dst (dstoff + i) (get src (srcoff + i))
+    done
+
+  let output oc tbl pos len =
+    for i = pos to pos + len - 1 do
+      output_char oc (get tbl i)
+    done
+
+  let input_bytes_into tbl ic len =
+    let count = ref len in
+    Array.iter (fun str ->
+      let chunk = Int.min !count (Bytes.length str) in
+      really_input ic str 0 chunk;
+      count := !count - chunk) tbl
+
+  let input_bytes ic len =
+    let tbl = create len in
+    input_bytes_into tbl ic len;
+    tbl
+end
+
+
 let cut_at s c =
   let pos = String.index s c in
   String.sub s 0 pos, String.sub s (pos+1) (String.length s - pos - 1)

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -494,6 +494,23 @@ val snd4: 'a * 'b * 'c * 'd -> 'b
 val thd4: 'a * 'b * 'c * 'd -> 'c
 val for4: 'a * 'b * 'c * 'd -> 'd
 
+(** {1 Long strings} *)
+
+(** ``Long strings'' are mutable arrays of characters that are not limited
+    in length to {!Sys.max_string_length}. *)
+
+module LongString :
+  sig
+    type t = bytes array
+    val create : int -> t
+    val length : t -> int
+    val get : t -> int -> char
+    val set : t -> int -> char -> unit
+    val blit : t -> int -> t -> int -> int -> unit
+    val output : out_channel -> t -> int -> int -> unit
+    val input_bytes : in_channel -> int -> t
+  end
+
 (** {1 Spell checking and ``did you mean'' suggestions} *)
 
 val edit_distance : string -> string -> int -> int option


### PR DESCRIPTION
This reverts commit 4c3016f1a1c697b1b883fc35f7819f6cfbaec2bf.

(cherry picked from commit c5f4ccfc84542247b4be012e7359778b6731164f)

I'm going to self-approve this; apart from a minor conflict resolution in `Meta` this is a verbatim revert from upstream.